### PR TITLE
[CRM-128] feat : 내 박람회 상세 조회 로직 구현

### DIFF
--- a/src/main/java/com/myce/common/exception/CustomErrorCode.java
+++ b/src/main/java/com/myce/common/exception/CustomErrorCode.java
@@ -13,15 +13,16 @@ public enum CustomErrorCode {
     // 엑스포 E
     EXPO_NOT_EXIST(HttpStatus.NOT_FOUND, "E001", "운영중인 박람회가 존재하지 않습니다."),
     CATEGORY_NOT_EXIST(HttpStatus.NOT_FOUND, "E002", "카테고리가 존재하지 않습니다."),
+    EXPO_ACCESS_DENIED(HttpStatus.UNAUTHORIZED, "E003", "해당 박람회의 관리자가 아닙니다."),
 
     // 티켓 T
     TICKET_NOT_EXIST(HttpStatus.NOT_FOUND, "T001", "티켓이 존재하지 않습니다."),
     TICKET_NOT_BELONG_TO_EXPO(HttpStatus.FORBIDDEN, "T002", "해당 티켓은 현재 박람회에 속하지 않습니다."),
     TICKET_TYPE_INVALID(HttpStatus.BAD_REQUEST, "T003", "유효하지 않은 티켓 타입입니다."),
-    
-  
+
+
     // 관계자 정보 I
-    BUSINESS_NOT_EXIST(HttpStatus.NOT_FOUND,"I001", "관계자 정보를 찾지 못했습니다");
+    BUSINESS_NOT_EXIST(HttpStatus.NOT_FOUND, "I001", "관계자 정보를 찾지 못했습니다");
 
     // 결제 P
 

--- a/src/main/java/com/myce/expo/controller/MyExpoController.java
+++ b/src/main/java/com/myce/expo/controller/MyExpoController.java
@@ -1,0 +1,29 @@
+package com.myce.expo.controller;
+
+import com.myce.auth.dto.CustomUserDetails;
+import com.myce.auth.security.filter.JwtUtil;
+import com.myce.expo.dto.MyExpoDetailResponse;
+import com.myce.expo.service.MyExpoService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/expos/my")
+public class MyExpoController {
+
+    private final MyExpoService expoService;
+    private final JwtUtil jwtUtil;
+
+    // 나의 박람회 상세 정보 조회
+    @GetMapping("/{expoId}")
+    public ResponseEntity<MyExpoDetailResponse> getMyExpoDetail(
+            @PathVariable Long expoId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        Long memberId = customUserDetails.getMemberId();
+        MyExpoDetailResponse response = expoService.getMyExpoDetail(expoId, memberId);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/myce/expo/dto/MyExpoDetailResponse.java
+++ b/src/main/java/com/myce/expo/dto/MyExpoDetailResponse.java
@@ -1,0 +1,58 @@
+package com.myce.expo.dto;
+
+import com.myce.expo.entity.type.ExpoStatus;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime; // LocalTime import 추가
+import java.util.List;
+
+// 나의 박람회 상세 조회 응답 DTO
+@Getter
+@NoArgsConstructor
+public class MyExpoDetailResponse {
+
+    private Long id;
+    // 박람회에 연결된 카테고리 ID 리스트
+    private List<Long> categoryIds;
+    private String title;
+    private String thumbnailUrl;
+    private String description;
+    private String location;
+    private String locationDetail;
+    private Integer maxReserverCount;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private ExpoStatus status;
+    private LocalDateTime displayStartDate;
+    private LocalDateTime displayEndDate;
+    private LocalTime startTime;
+    private LocalTime endTime;
+    private Boolean isPremium;
+
+    @Builder
+    public MyExpoDetailResponse(Long id, List<Long> categoryIds, String title, String thumbnailUrl, String description,
+                                String location, String locationDetail, Integer maxReserverCount, LocalDate startDate,
+                                LocalDate endDate, ExpoStatus status, LocalDateTime displayStartDate,
+                                LocalDateTime displayEndDate, LocalTime startTime, LocalTime endTime, Boolean isPremium) {
+        this.id = id;
+        this.categoryIds = categoryIds;
+        this.title = title;
+        this.thumbnailUrl = thumbnailUrl;
+        this.description = description;
+        this.location = location;
+        this.locationDetail = locationDetail;
+        this.maxReserverCount = maxReserverCount;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.status = status;
+        this.displayStartDate = displayStartDate;
+        this.displayEndDate = displayEndDate;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.isPremium = isPremium;
+    }
+}

--- a/src/main/java/com/myce/expo/repository/ExpoCategoryRepository.java
+++ b/src/main/java/com/myce/expo/repository/ExpoCategoryRepository.java
@@ -1,8 +1,14 @@
 package com.myce.expo.repository;
 
+import com.myce.expo.entity.Expo;
 import com.myce.expo.entity.ExpoCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ExpoCategoryRepository extends JpaRepository<ExpoCategory, Long> {
+
+    // 특정 Expo에 연결된 모든 ExpoCategory 엔티티를 찾습니다.
+    List<ExpoCategory> findByExpoId(Long expoId);
 
 }

--- a/src/main/java/com/myce/expo/service/MyExpoService.java
+++ b/src/main/java/com/myce/expo/service/MyExpoService.java
@@ -1,0 +1,7 @@
+package com.myce.expo.service;
+
+import com.myce.expo.dto.MyExpoDetailResponse;
+
+public interface MyExpoService {
+    MyExpoDetailResponse getMyExpoDetail(Long expoId, Long memberId);
+}

--- a/src/main/java/com/myce/expo/service/impl/MyExpoServiceImpl.java
+++ b/src/main/java/com/myce/expo/service/impl/MyExpoServiceImpl.java
@@ -1,0 +1,47 @@
+package com.myce.expo.service.impl;
+
+import com.myce.common.exception.CustomErrorCode;
+import com.myce.common.exception.CustomException;
+import com.myce.expo.dto.MyExpoDetailResponse;
+import com.myce.expo.entity.Expo;
+import com.myce.expo.entity.ExpoCategory;
+import com.myce.expo.repository.ExpoRepository;
+import com.myce.expo.repository.ExpoCategoryRepository;
+import com.myce.expo.service.MyExpoService;
+import com.myce.expo.service.mapper.MyExpoMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MyExpoServiceImpl implements MyExpoService {
+
+    private final ExpoRepository expoRepository;
+    private final ExpoCategoryRepository expoCategoryRepository;
+    private final MyExpoMapper expoMapper;
+
+    @Override
+    @Transactional(readOnly = true)
+    public MyExpoDetailResponse getMyExpoDetail(Long expoId, Long memberId) {
+        Expo expo = findAndValidateExpo(expoId, memberId);
+        List<ExpoCategory> expoCategories = expoCategoryRepository.findByExpoId(expo.getId());
+        return expoMapper.toMyExpoDetailResponse(expo, expoCategories);
+    }
+
+    /// 유틸 메소드
+    // 박람회 조회 및 박람회 관리자 검증 로직
+    private Expo findAndValidateExpo(Long expoId, Long memberId) {
+        // 박람회 조회
+        Expo expo = expoRepository.findById(expoId).orElseThrow(() -> new CustomException(CustomErrorCode.EXPO_NOT_EXIST));
+        // 로그인한 회원과 박람회 신청한 회원이 일치하는지 검증
+        if (!expo.getMember().getId().equals(memberId)) {
+            throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
+        }
+        //엔티티 반환
+        return expo;
+    }
+
+}

--- a/src/main/java/com/myce/expo/service/mapper/MyExpoMapper.java
+++ b/src/main/java/com/myce/expo/service/mapper/MyExpoMapper.java
@@ -1,0 +1,38 @@
+package com.myce.expo.service.mapper;
+
+import com.myce.expo.dto.MyExpoDetailResponse;
+import com.myce.expo.entity.Expo;
+import com.myce.expo.entity.ExpoCategory;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+// Entity와 DTO 간의 변환을 담당하는 매퍼 클래스
+@Component
+public class MyExpoMapper {
+
+    // Expo 엔티티와 ExpoCategory 리스트를 MyExpoDetailResponse DTO로 변환
+    public MyExpoDetailResponse toMyExpoDetailResponse(Expo expo, List<ExpoCategory> expoCategories) {
+        return MyExpoDetailResponse.builder()
+                .id(expo.getId())
+                .categoryIds(expoCategories.stream()
+                        .map(expoCategory -> expoCategory.getCategory().getId())
+                        .collect(Collectors.toList()))
+                .title(expo.getTitle())
+                .thumbnailUrl(expo.getThumbnailUrl())
+                .description(expo.getDescription())
+                .location(expo.getLocation())
+                .locationDetail(expo.getLocationDetail())
+                .maxReserverCount(expo.getMaxReserverCount())
+                .startDate(expo.getStartDate())
+                .endDate(expo.getEndDate())
+                .status(expo.getStatus())
+                .displayStartDate(expo.getDisplayStartDate())
+                .displayEndDate(expo.getDisplayEndDate())
+                .startTime(expo.getStartTime())
+                .endTime(expo.getEndTime())
+                .isPremium(expo.getIsPremium())
+                .build();
+    }
+}


### PR DESCRIPTION
### 💡 주요 변경 사항
**1. Expo 엔티티 변경 반영**
Expo 엔티티에 locationDetail, startTime, endTime, isPremium 필드가 추가됨에 따라, 이 새로운 정보들을 상세 조회 응답에 포함

**2. MyExpoDetailResponse DTO 업데이트**
박람회 상세 조회 응답 DTO인 MyExpoDetailResponse에 Expo 엔티티에 추가된 locationDetail (세부 장소), startTime (운영 시작 시간), endTime (운영 종료 시간), isPremium (프리미엄 여부) 필드를 추가했습니다. 

**3. ExpoMapper 수정**
ExpoMapper 클래스의 toMyExpoDetailResponse 메서드를 수정하여, 변경된 Expo 엔티티의 새로운 필드들을 MyExpoDetailResponse DTO로 정확히 매핑하도록 로직을 추가했습니다. 이는 엔티티의 데이터를 DTO 형식에 맞춰 변환하는 역할을 수행합니다.

**4. ExpoService (인터페이스 및 구현체)**
ExpoServiceImpl 구현체: getMyExpoDetail 메서드 내에서 Expo 엔티티와 ExpoCategory 리스트를 조회한 후, 업데이트된 ExpoMapper를 사용하여 MyExpoDetailResponse를 생성하고 반환하도록 로직을 유지했습니다. 이 변경으로 인해 서비스 계층은 새로운 엔티티 구조를 기반으로 상세 정보를 제공하게 됩니다.