### PR TITLE
[CRM-226] feat : 내 박람회 상세 수정 로직 구현

### DIFF
--- a/src/main/java/com/myce/common/exception/CustomErrorCode.java
+++ b/src/main/java/com/myce/common/exception/CustomErrorCode.java
@@ -7,12 +7,13 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum CustomErrorCode {
-  
+
     // 회원 M
     MEMBER_NOT_EXIST(HttpStatus.NOT_FOUND, "M001", "회원정보가 존재하지 않습니다."),
+    AUTHORIZATION_NOT_EXIST(HttpStatus.UNAUTHORIZED, "M002", "인증정보가 존재하지 않습니다."),
 
     // 관계자 정보 I
-    BUSINESS_NOT_EXIST(HttpStatus.NOT_FOUND,"I001", "관계자 정보를 찾지 못했습니다"),
+    BUSINESS_NOT_EXIST(HttpStatus.NOT_FOUND, "I001", "관계자 정보를 찾지 못했습니다"),
 
     // QR 코드 Q
     QR_NOT_FOUND(HttpStatus.NOT_FOUND, "Q001", "QR 코드를 찾을 수 없습니다."),
@@ -31,7 +32,8 @@ public enum CustomErrorCode {
     // 엑스포 E
     EXPO_NOT_EXIST(HttpStatus.NOT_FOUND, "E001", "운영중인 박람회가 존재하지 않습니다."),
     CATEGORY_NOT_EXIST(HttpStatus.NOT_FOUND, "E002", "카테고리가 존재하지 않습니다."),
-    EXPO_ACCESS_DENIED(HttpStatus.UNAUTHORIZED, "E003", "해당 박람회의 관리자가 아닙니다."),
+    EXPO_ACCESS_DENIED(HttpStatus.FORBIDDEN, "E003", "해당 박람회에 대한 접근 권한이 없습니다."),
+    EXPO_UPDATE_DENIED(HttpStatus.FORBIDDEN, "E004", "해당 박람회에 대한 수정 권한이 없습니다."),
 
     // 티켓 T
     TICKET_NOT_EXIST(HttpStatus.NOT_FOUND, "T001", "티켓이 존재하지 않습니다."),

--- a/src/main/java/com/myce/common/exception/CustomErrorCode.java
+++ b/src/main/java/com/myce/common/exception/CustomErrorCode.java
@@ -10,7 +10,6 @@ public enum CustomErrorCode {
 
     // 회원 M
     MEMBER_NOT_EXIST(HttpStatus.NOT_FOUND, "M001", "회원정보가 존재하지 않습니다."),
-    AUTHORIZATION_NOT_EXIST(HttpStatus.UNAUTHORIZED, "M002", "인증정보가 존재하지 않습니다."),
 
     // 관계자 정보 I
     BUSINESS_NOT_EXIST(HttpStatus.NOT_FOUND, "I001", "관계자 정보를 찾지 못했습니다"),

--- a/src/main/java/com/myce/expo/controller/MyExpoController.java
+++ b/src/main/java/com/myce/expo/controller/MyExpoController.java
@@ -1,9 +1,12 @@
 package com.myce.expo.controller;
 
 import com.myce.auth.dto.CustomUserDetails;
-import com.myce.auth.security.filter.JwtUtil;
+import com.myce.common.exception.CustomErrorCode;
+import com.myce.common.exception.CustomException;
 import com.myce.expo.dto.MyExpoDetailResponse;
+import com.myce.expo.dto.MyExpoUpdateRequest;
 import com.myce.expo.service.MyExpoService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -15,7 +18,6 @@ import org.springframework.web.bind.annotation.*;
 public class MyExpoController {
 
     private final MyExpoService expoService;
-    private final JwtUtil jwtUtil;
 
     // 나의 박람회 상세 정보 조회
     @GetMapping("/{expoId}")
@@ -25,5 +27,19 @@ public class MyExpoController {
         Long memberId = customUserDetails.getMemberId();
         MyExpoDetailResponse response = expoService.getMyExpoDetail(expoId, memberId);
         return ResponseEntity.ok(response);
+    }
+
+    // 나의 박람회 상세 정보 수정
+    @PutMapping("/{expoId}")
+    public ResponseEntity<MyExpoDetailResponse> updateMyExpoDetail(
+            @PathVariable Long expoId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @Valid @RequestBody MyExpoUpdateRequest updateRequest) {
+        if (customUserDetails == null) {
+            throw new CustomException(CustomErrorCode.AUTHORIZATION_NOT_EXIST);
+        }
+        Long memberId = customUserDetails.getMemberId();
+        MyExpoDetailResponse updatedExpo = expoService.updateMyExpoDetail(expoId, memberId, updateRequest); // 서비스에서 DTO 반환
+        return ResponseEntity.ok(updatedExpo); // 업데이트된 DTO 반환
     }
 }

--- a/src/main/java/com/myce/expo/controller/MyExpoController.java
+++ b/src/main/java/com/myce/expo/controller/MyExpoController.java
@@ -35,9 +35,6 @@ public class MyExpoController {
             @PathVariable Long expoId,
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @Valid @RequestBody MyExpoUpdateRequest updateRequest) {
-        if (customUserDetails == null) {
-            throw new CustomException(CustomErrorCode.AUTHORIZATION_NOT_EXIST);
-        }
         Long memberId = customUserDetails.getMemberId();
         MyExpoDetailResponse updatedExpo = expoService.updateMyExpoDetail(expoId, memberId, updateRequest); // 서비스에서 DTO 반환
         return ResponseEntity.ok(updatedExpo); // 업데이트된 DTO 반환

--- a/src/main/java/com/myce/expo/dto/MyExpoDetailResponse.java
+++ b/src/main/java/com/myce/expo/dto/MyExpoDetailResponse.java
@@ -1,6 +1,7 @@
 package com.myce.expo.dto;
 
 import com.myce.expo.entity.type.ExpoStatus;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,6 +14,8 @@ import java.util.List;
 // 나의 박람회 상세 조회 응답 DTO
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class MyExpoDetailResponse {
 
     private Long id;
@@ -33,26 +36,4 @@ public class MyExpoDetailResponse {
     private LocalTime endTime;
     private Boolean isPremium;
 
-    @Builder
-    public MyExpoDetailResponse(Long id, List<Long> categoryIds, String title, String thumbnailUrl, String description,
-                                String location, String locationDetail, Integer maxReserverCount, LocalDate startDate,
-                                LocalDate endDate, ExpoStatus status, LocalDate displayStartDate,
-                                LocalDate displayEndDate, LocalTime startTime, LocalTime endTime, Boolean isPremium) {
-        this.id = id;
-        this.categoryIds = categoryIds;
-        this.title = title;
-        this.thumbnailUrl = thumbnailUrl;
-        this.description = description;
-        this.location = location;
-        this.locationDetail = locationDetail;
-        this.maxReserverCount = maxReserverCount;
-        this.startDate = startDate;
-        this.endDate = endDate;
-        this.status = status;
-        this.displayStartDate = displayStartDate;
-        this.displayEndDate = displayEndDate;
-        this.startTime = startTime;
-        this.endTime = endTime;
-        this.isPremium = isPremium;
-    }
 }

--- a/src/main/java/com/myce/expo/dto/MyExpoUpdateRequest.java
+++ b/src/main/java/com/myce/expo/dto/MyExpoUpdateRequest.java
@@ -1,9 +1,7 @@
 package com.myce.expo.dto;
 
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.PositiveOrZero;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,9 +13,14 @@ import java.util.List;
 // 나의 박람회 수정 요청 DTO
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class MyExpoUpdateRequest {
 
-    // 박람회에 연결할 카테고리 ID 리스트 TODO: NotBlank 추후 추가
+    // 박람회에 연결할 카테고리 ID 리스트
+    // TODO: NotBlank 및 제약 조건 설정
+    //@NotEmpty(message = "최소 하나의 카테고리를 선택해야 합니다.")
+    //@Size(max = 10, message = "카테고리는 최대 10개까지 선택 가능합니다.")
     private List<Long> categoryIds;
 
     @NotBlank(message = "제목은 필수 입력 값입니다.")
@@ -25,6 +28,7 @@ public class MyExpoUpdateRequest {
     private String title;
 
     @Size(max = 500, message = "썸네일 URL은 500자 이하로 입력해주세요.")
+    @Pattern(regexp = "^https?://.*", message = "올바른 URL 형식이 아닙니다.")
     private String thumbnailUrl;
 
     @NotBlank(message = "상세 설명은 필수 입력 값입니다.")
@@ -63,25 +67,4 @@ public class MyExpoUpdateRequest {
     @NotNull(message = "부스 프리미엄 여부는 필수 입력 값입니다.")
     private Boolean isPremium;
 
-    @Builder
-    public MyExpoUpdateRequest(List<Long> categoryIds, String title, String thumbnailUrl, String description,
-                               String location, String locationDetail, Integer maxReserverCount,
-                               LocalDate startDate, LocalDate endDate,
-                               LocalDate displayStartDate, LocalDate displayEndDate,
-                               LocalTime startTime, LocalTime endTime, Boolean isPremium) {
-        this.categoryIds = categoryIds;
-        this.title = title;
-        this.thumbnailUrl = thumbnailUrl;
-        this.description = description;
-        this.location = location;
-        this.locationDetail = locationDetail;
-        this.maxReserverCount = maxReserverCount;
-        this.startDate = startDate;
-        this.endDate = endDate;
-        this.displayStartDate = displayStartDate;
-        this.displayEndDate = displayEndDate;
-        this.startTime = startTime;
-        this.endTime = endTime;
-        this.isPremium = isPremium;
-    }
 }

--- a/src/main/java/com/myce/expo/dto/MyExpoUpdateRequest.java
+++ b/src/main/java/com/myce/expo/dto/MyExpoUpdateRequest.java
@@ -1,0 +1,87 @@
+package com.myce.expo.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+// 나의 박람회 수정 요청 DTO
+@Getter
+@NoArgsConstructor
+public class MyExpoUpdateRequest {
+
+    // 박람회에 연결할 카테고리 ID 리스트 TODO: NotBlank 추후 추가
+    private List<Long> categoryIds;
+
+    @NotBlank(message = "제목은 필수 입력 값입니다.")
+    @Size(max = 100, message = "제목은 100자 이하로 입력해주세요.")
+    private String title;
+
+    @Size(max = 500, message = "썸네일 URL은 500자 이하로 입력해주세요.")
+    private String thumbnailUrl;
+
+    @NotBlank(message = "상세 설명은 필수 입력 값입니다.")
+    private String description;
+
+    @NotBlank(message = "위치는 필수 입력 값입니다.")
+    @Size(max = 100, message = "위치는 100자 이하로 입력해주세요.")
+    private String location;
+
+    @NotBlank(message = "세부 위치는 필수 입력 값입니다.")
+    @Size(max = 100, message = "세부 위치는 100자 이하로 입력해주세요.")
+    private String locationDetail;
+
+    @NotNull(message = "최대 수용 인원수는 필수 입력 값입니다.")
+    @PositiveOrZero(message = "최대 수용 인원수는 0 이상이어야 합니다.")
+    private Integer maxReserverCount;
+
+    @NotNull(message = "개최 시작일은 필수 입력 값입니다.")
+    private LocalDate startDate;
+
+    @NotNull(message = "개최 종료일은 필수 입력 값입니다.")
+    private LocalDate endDate;
+
+    @NotNull(message = "게시 시작일은 필수 입력 값입니다.")
+    private LocalDate displayStartDate;
+
+    @NotNull(message = "게시 종료일은 필수 입력 값입니다.")
+    private LocalDate displayEndDate;
+
+    @NotNull(message = "운영 시작 시간은 필수 입력 값입니다.")
+    private LocalTime startTime;
+
+    @NotNull(message = "운영 종료 시간은 필수 입력 값입니다.")
+    private LocalTime endTime;
+
+    @NotNull(message = "부스 프리미엄 여부는 필수 입력 값입니다.")
+    private Boolean isPremium;
+
+    @Builder
+    public MyExpoUpdateRequest(List<Long> categoryIds, String title, String thumbnailUrl, String description,
+                               String location, String locationDetail, Integer maxReserverCount,
+                               LocalDate startDate, LocalDate endDate,
+                               LocalDate displayStartDate, LocalDate displayEndDate,
+                               LocalTime startTime, LocalTime endTime, Boolean isPremium) {
+        this.categoryIds = categoryIds;
+        this.title = title;
+        this.thumbnailUrl = thumbnailUrl;
+        this.description = description;
+        this.location = location;
+        this.locationDetail = locationDetail;
+        this.maxReserverCount = maxReserverCount;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.displayStartDate = displayStartDate;
+        this.displayEndDate = displayEndDate;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.isPremium = isPremium;
+    }
+}

--- a/src/main/java/com/myce/expo/entity/Expo.java
+++ b/src/main/java/com/myce/expo/entity/Expo.java
@@ -1,11 +1,14 @@
 package com.myce.expo.entity;
 
+import com.myce.expo.dto.MyExpoUpdateRequest;
 import com.myce.expo.entity.type.ExpoStatus;
 import com.myce.member.entity.Member;
 import jakarta.persistence.*;
+
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
+
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
@@ -15,7 +18,8 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
-@Getter @Entity
+@Getter
+@Entity
 @NoArgsConstructor
 @Table(name = "expo")
 @EntityListeners(AuditingEntityListener.class)
@@ -113,5 +117,22 @@ public class Expo {
         this.startTime = startTime;
         this.endTime = endTime;
         this.isPremium = isPremium;
+    }
+
+    // DTO를 사용하여 엔티티의 필드를 업데이트하는 메서드 (더티 체킹 활용)
+    public void updateFromDto(MyExpoUpdateRequest dto) {
+        this.title = dto.getTitle();
+        this.thumbnailUrl = dto.getThumbnailUrl();
+        this.description = dto.getDescription();
+        this.location = dto.getLocation();
+        this.locationDetail = dto.getLocationDetail();
+        this.maxReserverCount = dto.getMaxReserverCount();
+        this.startDate = dto.getStartDate();
+        this.endDate = dto.getEndDate();
+        this.displayStartDate = dto.getDisplayStartDate();
+        this.displayEndDate = dto.getDisplayEndDate();
+        this.startTime = dto.getStartTime();
+        this.endTime = dto.getEndTime();
+        this.isPremium = dto.getIsPremium();
     }
 }

--- a/src/main/java/com/myce/expo/repository/ExpoCategoryRepository.java
+++ b/src/main/java/com/myce/expo/repository/ExpoCategoryRepository.java
@@ -7,8 +7,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface ExpoCategoryRepository extends JpaRepository<ExpoCategory, Long> {
-
     // 특정 Expo에 연결된 모든 ExpoCategory 엔티티를 찾습니다.
     List<ExpoCategory> findByExpoId(Long expoId);
 
+    // 특정 Expo에 연결된 모든 ExpoCategory 엔티티를 삭제합니다.
+    void deleteAllByExpo(Expo expo);
 }

--- a/src/main/java/com/myce/expo/service/MyExpoService.java
+++ b/src/main/java/com/myce/expo/service/MyExpoService.java
@@ -1,7 +1,10 @@
 package com.myce.expo.service;
 
 import com.myce.expo.dto.MyExpoDetailResponse;
+import com.myce.expo.dto.MyExpoUpdateRequest;
 
 public interface MyExpoService {
     MyExpoDetailResponse getMyExpoDetail(Long expoId, Long memberId);
+
+    MyExpoDetailResponse updateMyExpoDetail(Long expoId, Long memberId, MyExpoUpdateRequest updateRequest);
 }

--- a/src/main/java/com/myce/expo/service/impl/MyExpoServiceImpl.java
+++ b/src/main/java/com/myce/expo/service/impl/MyExpoServiceImpl.java
@@ -3,17 +3,24 @@ package com.myce.expo.service.impl;
 import com.myce.common.exception.CustomErrorCode;
 import com.myce.common.exception.CustomException;
 import com.myce.expo.dto.MyExpoDetailResponse;
+import com.myce.expo.dto.MyExpoUpdateRequest;
+import com.myce.expo.entity.Category;
 import com.myce.expo.entity.Expo;
 import com.myce.expo.entity.ExpoCategory;
+import com.myce.expo.repository.CategoryRepository;
 import com.myce.expo.repository.ExpoRepository;
 import com.myce.expo.repository.ExpoCategoryRepository;
 import com.myce.expo.service.MyExpoService;
 import com.myce.expo.service.mapper.MyExpoMapper;
+import com.myce.member.entity.Member;
+import com.myce.member.entity.type.Role;
+import com.myce.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -21,7 +28,9 @@ public class MyExpoServiceImpl implements MyExpoService {
 
     private final ExpoRepository expoRepository;
     private final ExpoCategoryRepository expoCategoryRepository;
+    private final CategoryRepository categoryRepository;
     private final MyExpoMapper expoMapper;
+    private final MemberRepository memberRepository;
 
     @Override
     @Transactional(readOnly = true)
@@ -31,17 +40,79 @@ public class MyExpoServiceImpl implements MyExpoService {
         return expoMapper.toMyExpoDetailResponse(expo, expoCategories);
     }
 
+    @Override
+    @Transactional
+    public MyExpoDetailResponse updateMyExpoDetail(Long expoId, Long memberId, MyExpoUpdateRequest updateRequest) {
+        // 박람회 조회 및 회원이 박람회 관리자인지 검증
+        Expo expo = findAndValidateExpo(expoId, memberId);
+
+        // TODO: 박람회 관리자 수정 권한 검증
+
+        // 엔티티 업데이트 (더티체킹)
+        expo.updateFromDto(updateRequest);
+
+        // 카테고리 업데이트 로직
+        updateExpoCategories(expo, updateRequest.getCategoryIds());
+
+        // 업데이트된 엔티티를 DTO로 변환하여 반환
+        List<ExpoCategory> expoCategories = expoCategoryRepository.findByExpoId(expo.getId());
+        return expoMapper.toMyExpoDetailResponse(expo, expoCategories);
+    }
+
+
     /// 유틸 메소드
     // 박람회 조회 및 박람회 관리자 검증 로직
     private Expo findAndValidateExpo(Long expoId, Long memberId) {
         // 박람회 조회
         Expo expo = expoRepository.findById(expoId).orElseThrow(() -> new CustomException(CustomErrorCode.EXPO_NOT_EXIST));
+
+        // 회원 조회
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.MEMBER_NOT_EXIST));
+
         // 로그인한 회원과 박람회 신청한 회원이 일치하는지 검증
         if (!expo.getMember().getId().equals(memberId)) {
             throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
         }
-        //엔티티 반환
+
+        // 회원의 롤(Role)이 EXPO_ADMIN인지 확인합니다.
+        if (member.getRole() != Role.EXPO_ADMIN) {
+            throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
+        }
+
         return expo;
+    }
+
+    // 박람회 카테고리를 업데이트하는 로직
+    private void updateExpoCategories(Expo expo, List<Long> categoryIds) {
+        // 엑스포 관련 카테고리 초기화
+        expoCategoryRepository.deleteAllByExpo(expo);
+
+        // 카테고리 ID로 카테고리 목록 가져오기
+        List<Category> categories = categoryRepository.findAllById(categoryIds);
+        if (categories.size() != categoryIds.size()) {
+            throw new CustomException(CustomErrorCode.CATEGORY_NOT_EXIST);
+        }
+
+        // 업데이트
+        List<ExpoCategory> newExpoCategories = categories.stream()
+                .map(category -> ExpoCategory.builder()
+                        .expo(expo)
+                        .category(category)
+                        .build())
+                .collect(Collectors.toList());
+
+        expoCategoryRepository.saveAll(newExpoCategories);
+    }
+
+    // TODO: 박람회 하위 관리자 수정 권한 검증
+    private void validateUpdatePermission(Long memberId, Long expoId) {
+        // TODO: AdminCode 무엇으로 조회?
+
+        // AdminCode를 통해 AdminPermission 엔티티를 조회
+
+        // isExpoDetailUpdate 권한이 true인지 확인
+
     }
 
 }


### PR DESCRIPTION
### 💡 주요 변경 사항
**1. MyExpoUpdateRequest DTO 재정의**
Expo 엔티티의 displayStartDate 및 displayEndDate 필드와 일관성을 유지하기 위해 DTO의 해당 필드 타입을 LocalDate로 변경
@NotBlank 유효성 검사, @Size 유효성 검사 추가

**2. Expo 엔티티 updateFromDto 메서드 수정**
엔티티가 자신의 상태 변경 책임을 가지도록 하여 도메인 주도 설계 원칙을 준수했습니다.

**3. ExpoServiceImpl 수정**
updateMyExpoDetail 메서드에서 MyExpoUpdateRequest DTO를 받아 Expo 엔티티의 updateFromDto 메서드를 호출하도록 변경했습니다.
JPA의 더티 체킹을 활용하여 트랜잭션 커밋 시점에 변경된 엔티티 필드가 자동으로 데이터베이스에 반영되도록 했습니다.
수정 완료 후, 업데이트된 박람회 상세 정보를 MyExpoDetailResponse DTO로 변환하여 반환하도록 하여, 프론트엔드에서 최신 데이터를 즉시 확인할 수 있게 했습니다.

> 포스트맨 api 테스트 완료했습니다