### PR TITLE
[CRM-208] feat: 부스 등록 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,8 @@ gradle/
 !gradle/wrapper/gradle-wrapper.properties
 gradle.lockfile
 *.gradle.local
+
+# Gemini files
+GEMINI.md
+.prompt
+.prMessage

--- a/src/main/java/com/myce/common/exception/CustomErrorCode.java
+++ b/src/main/java/com/myce/common/exception/CustomErrorCode.java
@@ -57,6 +57,12 @@ public enum CustomErrorCode {
     BANNER_NOT_EXIST(HttpStatus.NOT_FOUND, "A001", "배너가 존재하지 않습니다."),
     BANNER_MAX_CAPACITY_REACHED(HttpStatus.CONFLICT, "A002", "신청할 수 없는 기간이 포함되어 있습니다."),
 
+    // 부스 B
+    BOOTH_PREMIUM_RANK_REQUIRED(HttpStatus.BAD_REQUEST, "B001", "프리미엄 부스는 노출 순위가 필수입니다."),
+    BOOTH_PREMIUM_RANK_INVALID(HttpStatus.BAD_REQUEST, "B002", "프리미엄 부스 노출 순위는 1에서 3 사이여야 합니다."),
+    BOOTH_PREMIUM_MAX_CAPACITY_REACHED(HttpStatus.CONFLICT, "B003", "프리미엄 부스는 최대 3개까지만 등록할 수 있습니다."),
+    BOOTH_PREMIUM_RANK_DUPLICATED(HttpStatus.CONFLICT, "B004", "이미 사용중인 프리미엄 부스 노출 순위입니다."),
+
     // 광고 위치 AP
     BANNER_POSITION_NOT_EXIST(HttpStatus.NOT_FOUND, "AP001", "배너 위치 정보가 존재하지 않습니다.");
     // 결제 P

--- a/src/main/java/com/myce/expo/controller/BoothController.java
+++ b/src/main/java/com/myce/expo/controller/BoothController.java
@@ -1,0 +1,31 @@
+package com.myce.expo.controller;
+
+import com.myce.auth.dto.CustomUserDetails;
+import com.myce.expo.dto.BoothRegistrationRequest;
+import com.myce.expo.dto.BoothRegistrationResponse;
+import com.myce.expo.service.BoothService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/expos/{expoId}/booths")
+@RequiredArgsConstructor
+public class BoothController {
+
+    private final BoothService boothService;
+
+    // 부스 등록
+    @PostMapping
+    public ResponseEntity<BoothRegistrationResponse> saveBooth(
+            @PathVariable Long expoId,
+            @Valid @RequestBody BoothRegistrationRequest request,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        Long memberId = customUserDetails.getMemberId();
+        BoothRegistrationResponse response = boothService.saveBooth(expoId, request, memberId);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}

--- a/src/main/java/com/myce/expo/dto/BoothRegistrationRequest.java
+++ b/src/main/java/com/myce/expo/dto/BoothRegistrationRequest.java
@@ -1,0 +1,50 @@
+package com.myce.expo.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BoothRegistrationRequest {
+
+    @NotBlank(message = "부스 번호는 필수입니다.")
+    @Size(max = 30, message = "부스 번호는 30자 이하여야 합니다.")
+    private String boothNumber;
+
+    @NotBlank(message = "부스 이름은 필수입니다.")
+    @Size(max = 100, message = "부스 이름은 100자 이하여야 합니다.")
+    private String name;
+
+    @NotBlank(message = "부스 설명은 필수입니다.")
+    private String description;
+
+    @NotBlank(message = "메인 이미지 URL은 필수입니다.")
+    @Size(max = 500, message = "메인 이미지 URL은 500자 이하여야 합니다.")
+    private String mainImageUrl;
+
+    @NotBlank(message = "담당자 이름은 필수입니다.")
+    @Size(max = 30, message = "담당자 이름은 30자 이하여야 합니다.")
+    private String contactName;
+
+    @NotBlank(message = "담당자 연락처는 필수입니다.")
+    @Pattern(regexp = "^\\d{2,3}-\\d{3,4}-\\d{4}$", message = "유효한 전화번호 형식이 아닙니다.")
+    @Size(max = 13, message = "담당자 연락처는 13자 이하여야 합니다.")
+    private String contactPhone;
+
+    @NotBlank(message = "담당자 이메일은 필수입니다.")
+    @Email(message = "유효한 이메일 형식이 아닙니다.")
+    @Size(max = 100, message = "담당자 이메일은 100자 이하여야 합니다.")
+    private String contactEmail;
+
+    @NotNull(message = "프리미엄 여부는 필수입니다.")
+    private Boolean isPremium;
+
+    private Integer displayRank;
+}

--- a/src/main/java/com/myce/expo/dto/BoothRegistrationResponse.java
+++ b/src/main/java/com/myce/expo/dto/BoothRegistrationResponse.java
@@ -1,0 +1,23 @@
+package com.myce.expo.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BoothRegistrationResponse {
+    private Long id;
+    private String boothNumber;
+    private String name;
+    private String description;
+    private String mainImageUrl;
+    private String contactName;
+    private String contactPhone;
+    private String contactEmail;
+    private Boolean isPremium;
+    private Integer displayRank;
+}

--- a/src/main/java/com/myce/expo/entity/Booth.java
+++ b/src/main/java/com/myce/expo/entity/Booth.java
@@ -47,7 +47,7 @@ public class Booth {
     @Column(name = "is_premium", columnDefinition = "TINYINT(1)", nullable = false)
     private Boolean isPremium;
 
-    @Column(name = "display_rank", nullable = false)
+    @Column(name = "display_rank", nullable = false, columnDefinition = "INT DEFAULT 0")
     private Integer displayRank;
 
     @CreationTimestamp

--- a/src/main/java/com/myce/expo/repository/BoothRepository.java
+++ b/src/main/java/com/myce/expo/repository/BoothRepository.java
@@ -1,0 +1,11 @@
+package com.myce.expo.repository;
+
+import com.myce.expo.entity.Booth;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BoothRepository extends JpaRepository<Booth, Long> {
+    long countByExpoIdAndIsPremiumTrue(Long expoId);
+    boolean existsByExpoIdAndIsPremiumTrueAndDisplayRank(Long expoId, Integer displayRank);
+}

--- a/src/main/java/com/myce/expo/service/BoothService.java
+++ b/src/main/java/com/myce/expo/service/BoothService.java
@@ -1,0 +1,8 @@
+package com.myce.expo.service;
+
+import com.myce.expo.dto.BoothRegistrationRequest;
+import com.myce.expo.dto.BoothRegistrationResponse;
+
+public interface BoothService {
+    BoothRegistrationResponse saveBooth(Long expoId, BoothRegistrationRequest request, Long memberId);
+}

--- a/src/main/java/com/myce/expo/service/impl/BoothServiceImpl.java
+++ b/src/main/java/com/myce/expo/service/impl/BoothServiceImpl.java
@@ -1,0 +1,62 @@
+package com.myce.expo.service.impl;
+
+import com.myce.common.exception.CustomErrorCode;
+import com.myce.common.exception.CustomException;
+import com.myce.expo.dto.BoothRegistrationRequest;
+import com.myce.expo.dto.BoothRegistrationResponse;
+import com.myce.expo.entity.Booth;
+import com.myce.expo.entity.Expo;
+import com.myce.expo.repository.BoothRepository;
+import com.myce.expo.repository.ExpoRepository;
+import com.myce.expo.service.BoothService;
+import com.myce.expo.service.mapper.BoothMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class BoothServiceImpl implements BoothService {
+
+    private final BoothRepository boothRepository;
+    private final ExpoRepository expoRepository;
+    private final BoothMapper boothMapper;
+
+    // 부스 등록
+    @Override
+    public BoothRegistrationResponse saveBooth(Long expoId, BoothRegistrationRequest request, Long memberId) {
+        Expo expo = expoRepository.findById(expoId)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.EXPO_NOT_EXIST));
+
+        // 박람회 관리자 권한 검증
+        if (!expo.getMember().getId().equals(memberId)) {
+            // TODO: 하위 관리자 권한 체크
+            throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
+        }
+
+        // 프리미엄 부스 검증
+        if (request.getIsPremium()) { // 프리미엄 부스가 참일 경우
+            // 널 처리
+            if (request.getDisplayRank() == null) {
+                throw new CustomException(CustomErrorCode.BOOTH_PREMIUM_RANK_REQUIRED);
+            }
+            // 순위는 3위까지 부여 가능
+            if (request.getDisplayRank() < 1 || request.getDisplayRank() > 3) {
+                throw new CustomException(CustomErrorCode.BOOTH_PREMIUM_RANK_INVALID);
+            }
+            // 전체 부스 중 3개만 순위 부여 가능
+            if (boothRepository.countByExpoIdAndIsPremiumTrue(expoId) >= 3) {
+                throw new CustomException(CustomErrorCode.BOOTH_PREMIUM_MAX_CAPACITY_REACHED);
+            }
+            // 중복으로 순위 값을 입력했을 경우
+            if (boothRepository.existsByExpoIdAndIsPremiumTrueAndDisplayRank(expoId, request.getDisplayRank())) {
+                throw new CustomException(CustomErrorCode.BOOTH_PREMIUM_RANK_DUPLICATED);
+            }
+        }
+
+        Booth booth = boothMapper.toEntity(request, expo);
+        Booth savedBooth = boothRepository.save(booth);
+        return boothMapper.toResponse(savedBooth);
+    }
+}

--- a/src/main/java/com/myce/expo/service/mapper/BoothMapper.java
+++ b/src/main/java/com/myce/expo/service/mapper/BoothMapper.java
@@ -1,0 +1,41 @@
+package com.myce.expo.service.mapper;
+
+import com.myce.expo.dto.BoothRegistrationRequest;
+import com.myce.expo.dto.BoothRegistrationResponse;
+import com.myce.expo.entity.Booth;
+import com.myce.expo.entity.Expo;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BoothMapper {
+
+    public Booth toEntity(BoothRegistrationRequest request, Expo expo) {
+        return Booth.builder()
+                .expo(expo)
+                .boothNumber(request.getBoothNumber())
+                .name(request.getName())
+                .description(request.getDescription())
+                .mainImageUrl(request.getMainImageUrl())
+                .contactName(request.getContactName())
+                .contactPhone(request.getContactPhone())
+                .contactEmail(request.getContactEmail())
+                .isPremium(request.getIsPremium())
+                .displayRank(request.getIsPremium() ? request.getDisplayRank() : 0)
+                .build();
+    }
+
+    public BoothRegistrationResponse toResponse(Booth booth) {
+        return BoothRegistrationResponse.builder()
+                .id(booth.getId())
+                .boothNumber(booth.getBoothNumber())
+                .name(booth.getName())
+                .description(booth.getDescription())
+                .mainImageUrl(booth.getMainImageUrl())
+                .contactName(booth.getContactName())
+                .contactPhone(booth.getContactPhone())
+                .contactEmail(booth.getContactEmail())
+                .isPremium(booth.getIsPremium())
+                .displayRank(booth.getDisplayRank())
+                .build();
+    }
+}


### PR DESCRIPTION
## ✨ 새로운 기능
- **부스(Booth) 등록 API 추가**: 박람회(`Expo`)에 새로운 부스를 등록하는 기능을 구현했습니다.
  - `POST /api/expos/{expoId}/booths`
  - MVC 패턴에 따라 Controller, Service, Repository, DTO, Mapper를 추가했습니다.

## ⚙️ 기타
- **`.gitignore` 업데이트**: `GEMINI.md`, `.prompt`, `.prMessage` 파일이 Git 추적에서 제외되도록 설정했습니다.

## 🚀 부스(Booth) 기능 개선
- **프리미엄 부스 로직 변경**: `displayRank` 필드의 정책을 `nullable`에서 `NOT NULL`과 `DEFAULT 0`으로 변경했습니다.
  - `isPremium`이 `false`인 부스는 `displayRank`가 `0`의 기본값을 갖습니다.
  - `isPremium`이 `true`인 부스는 여전히 1~3 사이의 고유한 `displayRank` 값을 가져야 합니다.
  - 이 변경사항을 `Booth` 엔티티, `BoothMapper`에 반영했습니다.
- **Repository 수정**: 프리미엄 부스 검증을 위한 `countByExpoIdAndIsPremiumTrue`, `existsByExpoIdAndIsPremiumTrueAndDisplayRank` 메소드를 `BoothRepository`에 추가했습니다.
- **예외 코드 추가**: 프리미엄 부스 관련 유효성 검사를 위한 예외 코드(`B001`~`B004`)를 추가했습니다.