### PR TITLE
[CRM-88] feat: 마이페지이 결제내역 조회 구현

### DIFF
--- a/src/main/java/com/myce/member/controller/MemberController.java
+++ b/src/main/java/com/myce/member/controller/MemberController.java
@@ -2,6 +2,7 @@ package com.myce.member.controller;
 
 import com.myce.auth.dto.CustomUserDetails;
 import com.myce.member.dto.MemberInfoResponse;
+import com.myce.member.dto.PaymentHistoryResponse;
 import com.myce.member.dto.ReservedExpoResponse;
 import com.myce.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
@@ -49,5 +50,15 @@ public class MemberController {
         memberService.withdrawMember(memberId);
         
         return ResponseEntity.noContent().build();
+    }
+    
+    @GetMapping("/my-page/payment-history")
+    public ResponseEntity<List<PaymentHistoryResponse>> getPaymentHistory(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        
+        Long memberId = customUserDetails.getMemberId();
+        List<PaymentHistoryResponse> paymentHistory = memberService.getPaymentHistory(memberId);
+        
+        return ResponseEntity.ok(paymentHistory);
     }
 }

--- a/src/main/java/com/myce/member/dto/PaymentHistoryResponse.java
+++ b/src/main/java/com/myce/member/dto/PaymentHistoryResponse.java
@@ -1,0 +1,23 @@
+package com.myce.member.dto;
+
+import com.myce.payment.entity.type.PaymentStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PaymentHistoryResponse {
+    
+    private String paymentNumber;    // 결제번호
+    private LocalDateTime paymentDate;    // 날짜
+    private String expoTitle;        // 박람회이름
+    private Integer totalAmount;     // 결제금액
+    private PaymentStatus status;    // 상태
+    private String reservationCode;  // 예매 상세보기용
+}

--- a/src/main/java/com/myce/member/mapper/PaymentHistoryMapper.java
+++ b/src/main/java/com/myce/member/mapper/PaymentHistoryMapper.java
@@ -1,0 +1,35 @@
+package com.myce.member.mapper;
+
+import com.myce.expo.entity.Expo;
+import com.myce.member.dto.PaymentHistoryResponse;
+import com.myce.payment.entity.Payment;
+import com.myce.payment.entity.ReservationPaymentInfo;
+import com.myce.reservation.entity.Reservation;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class PaymentHistoryMapper {
+    
+    public List<PaymentHistoryResponse> toResponseDtoList(List<Object[]> paymentHistoryData) {
+        return paymentHistoryData.stream()
+                .map(data -> {
+                    Payment payment = (Payment) data[0];
+                    ReservationPaymentInfo paymentInfo = (ReservationPaymentInfo) data[1];
+                    Reservation reservation = (Reservation) data[2];
+                    Expo expo = (Expo) data[3];
+                    
+                    return PaymentHistoryResponse.builder()
+                            .paymentNumber(payment.getImpUid())
+                            .paymentDate(payment.getCreatedAt())
+                            .expoTitle(expo.getTitle())
+                            .totalAmount(paymentInfo.getTotalAmount())
+                            .status(paymentInfo.getStatus())
+                            .reservationCode(reservation.getReservationCode())
+                            .build();
+                })
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/myce/member/service/MemberService.java
+++ b/src/main/java/com/myce/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package com.myce.member.service;
 
 import com.myce.member.dto.MemberInfoResponse;
+import com.myce.member.dto.PaymentHistoryResponse;
 import com.myce.member.dto.ReservedExpoResponse;
 
 import java.util.List;
@@ -12,4 +13,6 @@ public interface MemberService {
     MemberInfoResponse getMemberInfo(Long memberId);
     
     void withdrawMember(Long memberId);
+    
+    List<PaymentHistoryResponse> getPaymentHistory(Long memberId);
 }

--- a/src/main/java/com/myce/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/myce/member/service/impl/MemberServiceImpl.java
@@ -3,12 +3,15 @@ package com.myce.member.service.impl;
 import com.myce.common.exception.CustomErrorCode;
 import com.myce.common.exception.CustomException;
 import com.myce.member.dto.MemberInfoResponse;
+import com.myce.member.dto.PaymentHistoryResponse;
 import com.myce.member.dto.ReservedExpoResponse;
 import com.myce.member.entity.Member;
 import com.myce.member.mapper.MemberInfoMapper;
+import com.myce.member.mapper.PaymentHistoryMapper;
 import com.myce.member.mapper.ReservedExpoMapper;
 import com.myce.member.repository.MemberRepository;
 import com.myce.member.service.MemberService;
+import com.myce.payment.repository.PaymentRepository;
 import com.myce.reservation.entity.Reservation;
 import com.myce.reservation.repository.ReservationRepository;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +29,8 @@ public class MemberServiceImpl implements MemberService {
     private final ReservedExpoMapper reservedExpoMapper;
     private final MemberRepository memberRepository;
     private final MemberInfoMapper memberInfoMapper;
+    private final PaymentRepository paymentRepository;
+    private final PaymentHistoryMapper paymentHistoryMapper;
     
     @Override
     public List<ReservedExpoResponse> getReservedExpos(Long memberId) {
@@ -46,5 +51,11 @@ public class MemberServiceImpl implements MemberService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new CustomException(CustomErrorCode.MEMBER_NOT_EXIST));
         member.withdraw();
+    }
+    
+    @Override
+    public List<PaymentHistoryResponse> getPaymentHistory(Long memberId) {
+        List<Object[]> paymentHistoryData = paymentRepository.findReservationPaymentHistoryByMemberId(memberId);
+        return paymentHistoryMapper.toResponseDtoList(paymentHistoryData);
     }
 }

--- a/src/main/java/com/myce/payment/entity/ReservationPaymentInfo.java
+++ b/src/main/java/com/myce/payment/entity/ReservationPaymentInfo.java
@@ -1,7 +1,7 @@
 package com.myce.payment.entity;
 
-import com.myce.member.entity.Member;
 import com.myce.payment.entity.type.PaymentStatus;
+import com.myce.reservation.entity.Reservation;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
@@ -22,8 +22,8 @@ public class ReservationPaymentInfo {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false)
-    private Member member;
+    @JoinColumn(name = "reservation_id", nullable = false)
+    private Reservation reservation;
 
     @Column(name = "used_mileage", nullable = false)
     private Integer usedMileage;
@@ -47,9 +47,9 @@ public class ReservationPaymentInfo {
     private LocalDateTime updatedAt;
 
     @Builder
-    public ReservationPaymentInfo(Member member, Integer usedMileage, Integer savedMileage,
+    public ReservationPaymentInfo(Reservation reservation, Integer usedMileage, Integer savedMileage,
                                   Integer totalAmount, PaymentStatus status) {
-        this.member = member;
+        this.reservation = reservation;
         this.usedMileage = usedMileage;
         this.savedMileage = savedMileage;
         this.totalAmount = totalAmount;

--- a/src/main/java/com/myce/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/myce/payment/repository/PaymentRepository.java
@@ -1,0 +1,20 @@
+package com.myce.payment.repository;
+
+import com.myce.payment.entity.Payment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+    
+    @Query("SELECT p, rpi, rpi.reservation, rpi.reservation.expo FROM Payment p " +
+           "JOIN ReservationPaymentInfo rpi ON p.targetId = rpi.id " +
+           "WHERE rpi.reservation.member.id = :memberId " +
+           "AND p.targetType = 'RESERVATION' " +
+           "ORDER BY p.createdAt DESC")
+    List<Object[]> findReservationPaymentHistoryByMemberId(@Param("memberId") Long memberId);
+}

--- a/src/main/java/com/myce/payment/repository/ReservationPaymentInfoRepository.java
+++ b/src/main/java/com/myce/payment/repository/ReservationPaymentInfoRepository.java
@@ -1,0 +1,17 @@
+package com.myce.payment.repository;
+
+import com.myce.payment.entity.ReservationPaymentInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface ReservationPaymentInfoRepository extends JpaRepository<ReservationPaymentInfo, Long> {
+    
+    @Query("SELECT rpi FROM ReservationPaymentInfo rpi " +
+           "WHERE rpi.id = :paymentInfoId")
+    Optional<ReservationPaymentInfo> findByIdWithMember(@Param("paymentInfoId") Long paymentInfoId);
+}


### PR DESCRIPTION
멤버 결제 상세 조회 구현
DTO에 reservation_code 담아서 눌렀을 때 예매 상세 화면 리다이렉트 가능
payment 중에 target_type이 reservation인 것들만 조회

reservation_payment_info 테이블

member_id 외래키 제거하고 reservation_id 추가