### PR TITLE
feat: Crm 237 feat implement centralized aws credentials provider system

### DIFF
--- a/src/main/java/com/myce/common/config/AwsConfig.java
+++ b/src/main/java/com/myce/common/config/AwsConfig.java
@@ -1,0 +1,76 @@
+package com.myce.common.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProviderChain;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.core.exception.SdkClientException;
+
+/**
+ * AWS 인증 중앙 관리 Configuration
+ * <p>
+ * 이 클래스는 모든 AWS 서비스가 사용할 통합 인증 제공자를 관리한다.
+ * 로컬 개발환경과 프로덕션 환경에서 자동으로 적절한 인증 방식을 선택한다.
+ * <p>
+ * 인증 우선순위:
+ * 1. Spring Properties (.env 파일의 AWS 자격증명) - 로컬 개발
+ * 2. DefaultCredentialsProvider (환경변수, AWS CLI, IAM 역할) - 프로덕션
+ * <p>
+ * 사용되는 AWS 서비스:
+ * - S3Client (파일 업로드/다운로드)
+ * - S3Presigner (Presigned URL 생성)
+ * - 향후 추가될 모든 AWS 서비스 (SES, SNS, Lambda 등)
+ * <p>
+ * 설계 이유:
+ * - 팀원들이 AWS CLI 설정을 배울 필요 없음
+ * - .env 파일만으로 로컬 개발 가능
+ * - 프로덕션에서는 IAM 역할 자동 사용
+ * - 단일 설정으로 모든 환경 지원
+ *
+ * @author 데브옵스 Team ㅋㅋㅋ
+ * @since 2025-08-07
+ */
+@Configuration
+@Slf4j
+public class AwsConfig {
+
+    @Value("${spring.cloud.aws.credentials.access-key:}")
+    private String accessKey;
+
+    @Value("${spring.cloud.aws.credentials.secret-key:}")
+    private String secretKey;
+
+    /**
+     * AWS 인증 제공자 - 모든 AWS 서비스가 사용하는 중앙 인증 소스
+     * 로컬 개발환경: .env 파일의 AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY 사용
+     * 프로덕션 환경: EC2 IAM 역할 자동 사용
+     *
+     * @return AwsCredentialsProvider 통합 인증 제공자
+     */
+    @Bean
+    @Primary
+    public AwsCredentialsProvider awsCredentialsProvider() {
+        log.info("AWS 인증 제공자 초기화 중...");
+
+        return AwsCredentialsProviderChain.of(
+                // 1순위: Spring Properties에서 AWS 자격증명 확인 (로컬 개발)
+                () -> {
+                    if (accessKey != null && !accessKey.trim().isEmpty() &&
+                            secretKey != null && !secretKey.trim().isEmpty()) {
+                        log.info("로컬 개발 모드: .env 파일의 AWS 자격증명 사용");
+                        return AwsBasicCredentials.create(accessKey, secretKey);
+                    }
+                    log.debug("Spring Properties에서 AWS 자격증명을 찾을 수 없음");
+                    throw SdkClientException.create("No credentials in Spring properties");
+                },
+
+                // 2순위: 표준 AWS 자격증명 체인 (프로덕션)
+                DefaultCredentialsProvider.create()
+        );
+    }
+}

--- a/src/main/java/com/myce/common/config/S3Config.java
+++ b/src/main/java/com/myce/common/config/S3Config.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -14,7 +15,7 @@ public class S3Config {
 
     @Value("${spring.cloud.aws.region.static}")
     private String region;
-    
+
     @Value("${spring.cloud.aws.credentials.access-key}")
     private String accessKey;
 
@@ -26,17 +27,17 @@ public class S3Config {
     public S3Client s3Client() {
         AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
         return S3Client.builder()
-            .region(Region.of(region))
-            .credentialsProvider(DefaultCredentialsProvider.create())
-            .build();
+                .region(Region.of(region))
+                .credentialsProvider(DefaultCredentialsProvider.create())
+                .build();
     }
 
     @Bean
     public S3Presigner s3Presigner() {
         AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
         return S3Presigner.builder()
-            .region(Region.of(region))
-            .credentialsProvider(DefaultCredentialsProvider.create())
-            .build();
+                .region(Region.of(region))
+                .credentialsProvider(DefaultCredentialsProvider.create())
+                .build();
     }
 }

--- a/src/main/java/com/myce/common/config/S3Config.java
+++ b/src/main/java/com/myce/common/config/S3Config.java
@@ -1,43 +1,44 @@
 package com.myce.common.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
+/**
+ * S3 서비스 Configuration
+ * <p>
+ * AWS S3 클라이언트와 Presigner를 설정합니다.
+ * AwsConfig에서 제공하는 통합 인증 제공자를 사용합니다.
+ *
+ * @see AwsConfig AWS 인증 설정
+ */
 @Configuration
+@RequiredArgsConstructor
 public class S3Config {
 
     @Value("${spring.cloud.aws.region.static}")
     private String region;
 
-    @Value("${spring.cloud.aws.credentials.access-key}")
-    private String accessKey;
-
-    @Value("${spring.cloud.aws.credentials.secret-key}")
-    private String secretKey;
-
+    private final AwsCredentialsProvider awsCredentialsProvider;
 
     @Bean
     public S3Client s3Client() {
-        AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
         return S3Client.builder()
                 .region(Region.of(region))
-                .credentialsProvider(DefaultCredentialsProvider.create())
+                .credentialsProvider(awsCredentialsProvider)
                 .build();
     }
 
     @Bean
     public S3Presigner s3Presigner() {
-        AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
         return S3Presigner.builder()
                 .region(Region.of(region))
-                .credentialsProvider(DefaultCredentialsProvider.create())
+                .credentialsProvider(awsCredentialsProvider)
                 .build();
     }
 }

--- a/src/main/java/com/myce/common/controller/ImageController.java
+++ b/src/main/java/com/myce/common/controller/ImageController.java
@@ -3,8 +3,6 @@ package com.myce.common.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
-//import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
@@ -15,62 +13,92 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.UUID;
 
+/**
+ * 이미지 업로드 Controller
+ * <p>
+ * S3 Presigned URL을 생성하여 클라이언트가 직접 S3에 이미지를 업로드할 수 있게 합니다.
+ * AwsConfig에서 제공하는 통합 인증을 통해 생성된 S3Client와 S3Presigner를 사용합니다.
+ *
+ * @see com.myce.common.config.AwsConfig 통합 AWS 인증 설정
+ * @see com.myce.common.config.S3Config S3 클라이언트 설정
+ */
 @RestController
 @RequestMapping("/api/images")
 @RequiredArgsConstructor
-@CrossOrigin(origins = "http://localhost:5173")
 public class ImageController {
 
+    // S3Config에서 AwsConfig의 통합 인증을 사용하여 생성된 Bean들을 주입
     private final S3Client s3Client;
     private final S3Presigner s3Presigner;
 
     @Value("${spring.cloud.aws.s3.bucket.media}")
     private String bucketName;
 
-
     @Value("${cloudfront.domain:https://media.myce.live}")
-
     private String cloudfrontDomain;
 
+    /**
+     * S3 Presigned URL 생성 API
+     * <p>
+     * 클라이언트가 직접 S3에 이미지를 업로드할 수 있는 임시 URL을 생성합니다.
+     * <p>
+     * 인증: @PreAuthorize("permitAll()") 제거됨
+     * - 이유: SecurityConfig에서 /api/images/** 경로를 permitAll()로 설정했으므로 중복
+     * - 일관성: 다른 컨트롤러들과 동일한 패턴 유지
+     * <p>
+     * CORS: @CrossOrigin 제거됨
+     * - 이유: CorsConfig에서 전역 CORS 설정이 이미 모든 필요한 도메인을 포함
+     * - 문제점: 컨트롤러별 CORS 설정은 전역 설정과 충돌 가능성 존재
+     *
+     * @param filename 업로드할 파일명 (확장자 추출용)
+     * @return Presigned URL과 CDN URL이 포함된 응답
+     */
     @GetMapping("/presign")
-    @PreAuthorize("permitAll()")
     public ResponseEntity<Map<String, String>> getPresignedUrl(
             @RequestParam String filename) {
-        
+
         try {
-            // 1. 고유 파일명 생성
+            // 1. 고유 파일명 생성 (UUID + 원본 확장자)
             String key = "images/" + UUID.randomUUID() + getFileExtension(filename);
-            
-            // 2. Presigned URL 생성 (15분 유효)
+
+            // 2. S3 업로드 요청 객체 생성
             PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                     .bucket(bucketName)
                     .key(key)
                     .build();
 
+            // 3. Presigned URL 생성 (15분 유효)
+            // AwsConfig의 통합 인증을 통해 생성된 S3Presigner 사용
             PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
                     .signatureDuration(Duration.ofMinutes(15))
                     .putObjectRequest(putObjectRequest)
                     .build();
 
             String uploadUrl = s3Presigner.presignPutObject(presignRequest).url().toString();
-            
-            // 3. CloudFront CDN URL 생성
+
+            // 4. CloudFront CDN URL 생성 (업로드 완료 후 접근용)
             String cdnUrl = cloudfrontDomain + "/" + key;
-            
-            // 4. 응답 반환
+
+            // 5. 클라이언트 응답 생성
             Map<String, String> response = Map.of(
-                "uploadUrl", uploadUrl,
-                "cdnUrl", cdnUrl
+                    "uploadUrl", uploadUrl,  // 클라이언트가 PUT 요청할 URL
+                    "cdnUrl", cdnUrl        // 업로드 완료 후 이미지 접근 URL
             );
-            
+
             return ResponseEntity.ok(response);
-            
+
         } catch (Exception e) {
             return ResponseEntity.status(500)
-                .body(Map.of("error", "Presigned URL 생성 실패: " + e.getMessage()));
+                    .body(Map.of("error", "Presigned URL 생성 실패: " + e.getMessage()));
         }
     }
-    
+
+    /**
+     * 파일명에서 확장자 추출
+     *
+     * @param filename 원본 파일명
+     * @return 확장자 (점 포함, 예: ".jpg") 또는 빈 문자열
+     */
     private String getFileExtension(String filename) {
         int lastDot = filename.lastIndexOf(".");
         return lastDot != -1 ? filename.substring(lastDot) : "";


### PR DESCRIPTION
 feat: AWS 통합 인증 시스템 구현

  - 모든 환경에서 통합 AWS 인증을 위한 AwsConfig 추가
  - 자동 자격증명 감지 지원: .env (로컬) -> IAM 역할 (프로덕션)
  - 통합 AWS 자격증명 제공자를 사용하도록 S3Config 리팩토링
  - ImageController 정리: 중복된 @PreAuthorize 및 @CrossOrigin 제거
  - 개발자 머신에서 AWS CLI 설정 필요성 제거
  - .env 파일만으로 원활한 로컬 개발 지원
  - 환경별 코드 분기 제거

  인증 우선순위:
  1. Spring Properties (.env 파일) - 로컬 개발
  2. DefaultCredentialsProvider (IAM 역할) - 프로덕션

  수정된 파일:
  - 추가: src/main/java/com/myce/common/config/AwsConfig.java
  - 수정: src/main/java/com/myce/common/config/S3Config.java
  - 수정: src/main/java/com/myce/common/controller/ImageController.java

  기존 코드 리팩토링 이유:
  - @PreAuthorize 제거: SecurityConfig에서 이미 /api/images/** permitAll 처리
  - @CrossOrigin 제거: 전역 CorsConfig에서 모든 필요한 도메인 처리

  장점:
  - 개발자의 AWS CLI 학습 필요 없음
  - 모든 환경에서 작동하는 단일 코드베이스
  - 향후 AWS 서비스를 확장을 위한 통합 AWS 자격증명 관리
  - 코드 일관성 향상 및 중복 제거
  - 개발자 경험 및 팀 생산성 향상