### PR TITLE
[CRM-100] feat: 마이페이지 박람회 신청 목록 조회, 신청 상세 조회 기능 구현

### DIFF
--- a/src/main/java/com/myce/common/exception/CustomErrorCode.java
+++ b/src/main/java/com/myce/common/exception/CustomErrorCode.java
@@ -38,7 +38,8 @@ public enum CustomErrorCode {
 
     // 엑스포 E
     EXPO_NOT_EXIST(HttpStatus.NOT_FOUND, "E001", "운영중인 박람회가 존재하지 않습니다."),
-    CATEGORY_NOT_EXIST(HttpStatus.NOT_FOUND, "E002", "카테고리가 존재하지 않습니다."),
+    EXPO_NOT_FOUND(HttpStatus.NOT_FOUND, "E002", "박람회를 찾을 수 없습니다."),
+    CATEGORY_NOT_EXIST(HttpStatus.NOT_FOUND, "E005", "카테고리가 존재하지 않습니다."),
     EXPO_ACCESS_DENIED(HttpStatus.FORBIDDEN, "E003", "해당 박람회에 대한 접근 권한이 없습니다."),
     EXPO_UPDATE_DENIED(HttpStatus.FORBIDDEN, "E004", "해당 박람회에 대한 수정 권한이 없습니다."),
 

--- a/src/main/java/com/myce/expo/repository/ExpoRepository.java
+++ b/src/main/java/com/myce/expo/repository/ExpoRepository.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 public interface ExpoRepository extends JpaRepository<Expo, Long> {
     Optional<Expo> findFirstByMemberIdAndStatusInOrderByCreatedAtDesc(Long memberId, List<ExpoStatus> status);
     List<Expo> findByMemberIdAndStatusIn(Long memberId, List<ExpoStatus> status);
+    List<Expo> findByMemberIdOrderByCreatedAtDesc(Long memberId);
     Boolean existsByIdAndMemberId(Long id, Long memberId);
 }
 

--- a/src/main/java/com/myce/expo/repository/TicketRepository.java
+++ b/src/main/java/com/myce/expo/repository/TicketRepository.java
@@ -9,4 +9,5 @@ import java.util.List;
 @Repository
 public interface TicketRepository extends JpaRepository<Ticket,Long> {
     List<Ticket> findByExpoId(Long id);
+    List<Ticket> findByExpoIdOrderByCreatedAtAsc(Long expoId);
 }

--- a/src/main/java/com/myce/member/controller/MemberController.java
+++ b/src/main/java/com/myce/member/controller/MemberController.java
@@ -141,4 +141,25 @@ public class MemberController {
         
         return ResponseEntity.ok(refundReceipt);
     }
+    
+    @GetMapping("/my-page/expos")
+    public ResponseEntity<List<MemberExpoResponse>> getMemberExpos(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        
+        Long memberId = customUserDetails.getMemberId();
+        List<MemberExpoResponse> expos = memberService.getMemberExpos(memberId);
+        
+        return ResponseEntity.ok(expos);
+    }
+    
+    @GetMapping("/my-page/expos/{expoId}")
+    public ResponseEntity<MemberExpoDetailResponse> getMemberExpoDetail(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @PathVariable Long expoId) {
+        
+        Long memberId = customUserDetails.getMemberId();
+        MemberExpoDetailResponse expoDetail = memberService.getMemberExpoDetail(memberId, expoId);
+        
+        return ResponseEntity.ok(expoDetail);
+    }
 }

--- a/src/main/java/com/myce/member/dto/MemberExpoDetailResponse.java
+++ b/src/main/java/com/myce/member/dto/MemberExpoDetailResponse.java
@@ -1,0 +1,81 @@
+package com.myce.member.dto;
+
+import com.myce.expo.entity.type.ExpoStatus;
+import com.myce.expo.entity.type.TicketType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MemberExpoDetailResponse {
+    
+    // 박람회 기본 정보
+    private Long expoId;
+    private String title;
+    private String thumbnailUrl;
+    private String location;
+    private String locationDetail;
+    private Integer maxReserverCount;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private LocalTime startTime;
+    private LocalTime endTime;
+    private LocalDate displayStartDate;
+    private LocalDate displayEndDate;
+    private String description;
+    private ExpoStatus status;
+    
+    // 결제 정보
+    private PaymentInfo paymentInfo;
+    
+    // 티켓 정보 리스트
+    private List<TicketInfo> tickets;
+    
+    // 사업자 정보
+    private BusinessInfo businessInfo;
+    
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class PaymentInfo {
+        private Integer deposit;              // 등록금
+        private Integer premiumDeposit;       // 프리미엄 등록금
+        private Integer totalAmount;          // 총 결제 금액 (일일사용료 * 게시기간 + 등록금)
+        private Integer dailyUsageFee;        // 일일 사용료
+        private Integer totalDay;             // 게시 기간(일)
+    }
+    
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class TicketInfo {
+        private Long ticketId;
+        private String name;                  // 티켓 이름
+        private Integer price;                // 티켓 가격
+        private Integer totalQuantity;        // 총 티켓 수
+        private TicketType type;              // 티켓 타입
+    }
+    
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class BusinessInfo {
+        private String companyName;           // 회사명
+        private String ceoName;              // 대표자명
+        private String address;              // 회사주소
+        private String contactPhone;         // 대표 연락처
+        private String contactEmail;         // 대표 이메일
+        private String businessRegistrationNumber; // 사업자번호
+    }
+}

--- a/src/main/java/com/myce/member/dto/MemberExpoResponse.java
+++ b/src/main/java/com/myce/member/dto/MemberExpoResponse.java
@@ -1,0 +1,27 @@
+package com.myce.member.dto;
+
+import com.myce.expo.entity.type.ExpoStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MemberExpoResponse {
+    
+    private Long expoId;
+    private String title;
+    private LocalDateTime createdAt;
+    private LocalDate displayStartDate;
+    private LocalDate displayEndDate;
+    private String location;
+    private String locationDetail;
+    private ExpoStatus status;
+    private Boolean isPremium;
+}

--- a/src/main/java/com/myce/member/mapper/MemberExpoDetailMapper.java
+++ b/src/main/java/com/myce/member/mapper/MemberExpoDetailMapper.java
@@ -1,0 +1,85 @@
+package com.myce.member.mapper;
+
+import com.myce.common.entity.BusinessProfile;
+import com.myce.expo.entity.Expo;
+import com.myce.expo.entity.Ticket;
+import com.myce.member.dto.MemberExpoDetailResponse;
+import com.myce.payment.entity.ExpoPaymentInfo;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class MemberExpoDetailMapper {
+    
+    public MemberExpoDetailResponse toMemberExpoDetailResponse(Expo expo, 
+                                                               ExpoPaymentInfo paymentInfo, 
+                                                               List<Ticket> tickets,
+                                                               BusinessProfile businessProfile) {
+        
+        return MemberExpoDetailResponse.builder()
+                .expoId(expo.getId())
+                .title(expo.getTitle())
+                .thumbnailUrl(expo.getThumbnailUrl())
+                .location(expo.getLocation())
+                .locationDetail(expo.getLocationDetail())
+                .maxReserverCount(expo.getMaxReserverCount())
+                .startDate(expo.getStartDate())
+                .endDate(expo.getEndDate())
+                .startTime(expo.getStartTime())
+                .endTime(expo.getEndTime())
+                .displayStartDate(expo.getDisplayStartDate())
+                .displayEndDate(expo.getDisplayEndDate())
+                .description(expo.getDescription())
+                .status(expo.getStatus())
+                .paymentInfo(buildPaymentInfo(paymentInfo))
+                .tickets(buildTicketInfoList(tickets))
+                .businessInfo(buildBusinessInfo(businessProfile))
+                .build();
+    }
+    
+    private MemberExpoDetailResponse.PaymentInfo buildPaymentInfo(ExpoPaymentInfo paymentInfo) {
+        if (paymentInfo == null) {
+            return null;
+        }
+        
+        return MemberExpoDetailResponse.PaymentInfo.builder()
+                .deposit(paymentInfo.getDeposit())
+                .premiumDeposit(paymentInfo.getPremiumDeposit())
+                .totalAmount(paymentInfo.getTotalAmount())
+                .dailyUsageFee(paymentInfo.getDailyUsageFee())
+                .totalDay(paymentInfo.getTotalDay())
+                .build();
+    }
+    
+    private List<MemberExpoDetailResponse.TicketInfo> buildTicketInfoList(List<Ticket> tickets) {
+        return tickets.stream()
+                .map(this::buildTicketInfo)
+                .toList();
+    }
+    
+    private MemberExpoDetailResponse.TicketInfo buildTicketInfo(Ticket ticket) {
+        return MemberExpoDetailResponse.TicketInfo.builder()
+                .ticketId(ticket.getId())
+                .name(ticket.getName())
+                .price(ticket.getPrice())
+                .totalQuantity(ticket.getTotalQuantity())
+                .type(ticket.getType())
+                .build();
+    }
+    
+    private MemberExpoDetailResponse.BusinessInfo buildBusinessInfo(BusinessProfile businessProfile) {
+        if (businessProfile == null) {
+            return null;
+        }
+        
+        return MemberExpoDetailResponse.BusinessInfo.builder()
+                .companyName(businessProfile.getCompanyName())
+                .ceoName(businessProfile.getCeoName())
+                .address(businessProfile.getAddress())
+                .contactPhone(businessProfile.getContactPhone())
+                .contactEmail(businessProfile.getContactEmail())
+                .businessRegistrationNumber(businessProfile.getBusinessRegistrationNumber())
+                .build();
+    }
+}

--- a/src/main/java/com/myce/member/mapper/MemberExpoMapper.java
+++ b/src/main/java/com/myce/member/mapper/MemberExpoMapper.java
@@ -1,0 +1,31 @@
+package com.myce.member.mapper;
+
+import com.myce.expo.entity.Expo;
+import com.myce.member.dto.MemberExpoResponse;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class MemberExpoMapper {
+    
+    public MemberExpoResponse toMemberExpoResponse(Expo expo) {
+        return MemberExpoResponse.builder()
+                .expoId(expo.getId())
+                .title(expo.getTitle())
+                .createdAt(expo.getCreatedAt())
+                .displayStartDate(expo.getDisplayStartDate())
+                .displayEndDate(expo.getDisplayEndDate())
+                .location(expo.getLocation())
+                .locationDetail(expo.getLocationDetail())
+                .status(expo.getStatus())
+                .isPremium(expo.getIsPremium())
+                .build();
+    }
+    
+    public List<MemberExpoResponse> toMemberExpoResponseList(List<Expo> expos) {
+        return expos.stream()
+                .map(this::toMemberExpoResponse)
+                .toList();
+    }
+}

--- a/src/main/java/com/myce/member/service/MemberService.java
+++ b/src/main/java/com/myce/member/service/MemberService.java
@@ -29,4 +29,8 @@ public interface MemberService {
     AdvertisementPaymentDetailResponse getAdvertisementPaymentDetail(Long memberId, Long advertisementId);
     
     AdvertisementRefundReceiptResponse getAdvertisementRefundReceipt(Long memberId, Long advertisementId);
+    
+    List<MemberExpoResponse> getMemberExpos(Long memberId);
+    
+    MemberExpoDetailResponse getMemberExpoDetail(Long memberId, Long expoId);
 }

--- a/src/main/java/com/myce/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/myce/member/service/impl/MemberServiceImpl.java
@@ -7,6 +7,10 @@ import com.myce.advertisement.repository.AdvertisementRepository;
 import com.myce.common.entity.BusinessProfile;
 import com.myce.common.entity.type.TargetType;
 import com.myce.common.repository.BusinessProfileRepository;
+import com.myce.expo.entity.Expo;
+import com.myce.expo.entity.Ticket;
+import com.myce.expo.repository.ExpoRepository;
+import com.myce.expo.repository.TicketRepository;
 import com.myce.member.dto.*;
 import java.time.temporal.ChronoUnit;
 import java.time.LocalDate;
@@ -19,7 +23,9 @@ import com.myce.member.repository.MemberRepository;
 import com.myce.member.repository.MemberSettingRepository;
 import com.myce.member.service.MemberService;
 import com.myce.payment.entity.AdPaymentInfo;
+import com.myce.payment.entity.ExpoPaymentInfo;
 import com.myce.payment.repository.AdPaymentInfoRepository;
+import com.myce.payment.repository.ExpoPaymentInfoRepository;
 import com.myce.payment.repository.PaymentRepository;
 import com.myce.reservation.entity.Reservation;
 import com.myce.reservation.entity.code.UserType;
@@ -49,8 +55,13 @@ public class MemberServiceImpl implements MemberService {
     private final MemberAdvertisementMapper memberAdvertisementMapper;
     private final AdvertisementDetailMapper advertisementDetailMapper;
     private final AdvertisementRefundReceiptMapper advertisementRefundReceiptMapper;
+    private final MemberExpoMapper memberExpoMapper;
+    private final MemberExpoDetailMapper memberExpoDetailMapper;
     private final BusinessProfileRepository businessProfileRepository;
     private final AdPaymentInfoRepository adPaymentInfoRepository;
+    private final ExpoPaymentInfoRepository expoPaymentInfoRepository;
+    private final ExpoRepository expoRepository;
+    private final TicketRepository ticketRepository;
 
     @Override
     public List<ReservedExpoResponse> getReservedExpos(Long memberId) {
@@ -181,5 +192,35 @@ public class MemberServiceImpl implements MemberService {
                 .orElseThrow(() -> new CustomException(CustomErrorCode.PAYMENT_INFO_NOT_FOUND));
         
         return advertisementRefundReceiptMapper.toRefundReceiptDto(advertisement, businessProfile, adPaymentInfo);
+    }
+    
+    @Override
+    public List<MemberExpoResponse> getMemberExpos(Long memberId) {
+        List<Expo> expos = expoRepository.findByMemberIdOrderByCreatedAtDesc(memberId);
+        return memberExpoMapper.toMemberExpoResponseList(expos);
+    }
+    
+    @Override
+    public MemberExpoDetailResponse getMemberExpoDetail(Long memberId, Long expoId) {
+        // 박람회가 해당 회원의 것인지 확인
+        Expo expo = expoRepository.findById(expoId)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.EXPO_NOT_FOUND));
+        
+        if (!expo.getMember().getId().equals(memberId)) {
+            throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
+        }
+        
+        // 결제 정보 조회
+        ExpoPaymentInfo paymentInfo = expoPaymentInfoRepository.findByExpoId(expoId)
+                .orElse(null);
+        
+        // 티켓 목록 조회
+        List<Ticket> tickets = ticketRepository.findByExpoIdOrderByCreatedAtAsc(expoId);
+        
+        // 사업자 정보 조회
+        BusinessProfile businessProfile = businessProfileRepository.findByTargetIdAndTargetType(expoId, TargetType.EXPO)
+                .orElse(null);
+        
+        return memberExpoDetailMapper.toMemberExpoDetailResponse(expo, paymentInfo, tickets, businessProfile);
     }
 }

--- a/src/main/java/com/myce/payment/repository/ExpoPaymentInfoRepository.java
+++ b/src/main/java/com/myce/payment/repository/ExpoPaymentInfoRepository.java
@@ -1,0 +1,13 @@
+package com.myce.payment.repository;
+
+import com.myce.payment.entity.ExpoPaymentInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface ExpoPaymentInfoRepository extends JpaRepository<ExpoPaymentInfo, Long> {
+    
+    Optional<ExpoPaymentInfo> findByExpoId(Long expoId);
+}


### PR DESCRIPTION
feat: 마이페이지 관리자로써 신청한 박람회 리스트 조회 / 정보 상세조회 기능추가

상세 조회에서는 다양한 정보가 필요해서
.
EXPO 정보, 티켓 정보, 비즈니스 프로필 정보를 다가져와서 DTO에 담았습니다 


상세 조회 DTO

{
  "expoId": 9,
  "title": "2025 투슬리스 박람회",
  "thumbnailUrl": "https://cdn.myce.com/poster.jpg",
  "location": "천안시",
  "locationDetail": "코엑스 A홀",
  "maxReserverCount": 5000,
  "startDate": "2025-10-15",
  "endDate": "2025-10-17",
  "startTime": "10:00:00",
  "endTime": "18:00:00",
  "displayStartDate": "2025-08-01",
  "displayEndDate": "2025-10-14",
  "description": "드래곤 박람회",
  "status": "PENDING_APPROVAL",
  "paymentInfo": {
    "deposit": 100000,
    "premiumDeposit": 200000,
    "totalAmount": 215000,
    "dailyUsageFee": 5000,
    "totalDay": 3
  },
  "tickets": [
    {
      "ticketId": 1,
      "name": "IT 박람회 얼리버드 티켓",
      "price": 15000,
      "totalQuantity": 100,
      "type": "EARLY_BIRD"
    },
    {
      "ticketId": 2,
      "name": "IT 박람회 일반 티켓",
      "price": 20000,
      "totalQuantity": 500,
      "type": "GENERAL"
    }
  ],
  "businessInfo": {
    "companyName": "MYCE 주식회사",
    "ceoName": "찍찍이이",
    "address": "서울시 강남구 테헤란로 123",
    "contactPhone": "010-1234-5678",
    "contactEmail": "ceo@myce.com",
    "businessRegistrationNumber": "123-45-67890"
  }
}