### PR TITLE
[CRM-101] feat: 마이페이지 박람회 관리 기능 추가 

### DIFF
--- a/src/main/java/com/myce/common/exception/CustomErrorCode.java
+++ b/src/main/java/com/myce/common/exception/CustomErrorCode.java
@@ -80,9 +80,11 @@ public enum CustomErrorCode {
 
     // 예약 R
     RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "R001", "해당 예약 정보를 조회 할수 없습니다."),
-    RESERVATION_STATUS_INVALID(HttpStatus.BAD_REQUEST, "R002", "유효하지 않은 예약 상태값입니다.");
+    RESERVATION_STATUS_INVALID(HttpStatus.BAD_REQUEST, "R002", "유효하지 않은 예약 상태값입니다."),
 
     // 정산 S
+
+    FEE_SETTING_NOT_FOUND(HttpStatus.NOT_FOUND, "F001" , "요금 설정이 없습니다");
 
     // 환경 Y
 

--- a/src/main/java/com/myce/expo/entity/Expo.java
+++ b/src/main/java/com/myce/expo/entity/Expo.java
@@ -135,4 +135,12 @@ public class Expo {
         this.endTime = dto.getEndTime();
         this.isPremium = dto.getIsPremium();
     }
+    
+    public void cancel() {
+        if (this.status != ExpoStatus.PENDING_APPROVAL && 
+            this.status != ExpoStatus.PENDING_PAYMENT) {
+            throw new IllegalStateException("취소할 수 없는 박람회 상태입니다: " + this.status);
+        }
+        this.status = ExpoStatus.CANCELLED;
+    }
 }

--- a/src/main/java/com/myce/expo/repository/AdminCodeRepository.java
+++ b/src/main/java/com/myce/expo/repository/AdminCodeRepository.java
@@ -1,10 +1,16 @@
 package com.myce.expo.repository;
 
 import com.myce.expo.entity.AdminCode;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface AdminCodeRepository extends JpaRepository<AdminCode, Long> {
 
     Optional<AdminCode> findByCode(String code);
+    
+    @Query("SELECT ac FROM AdminCode ac WHERE ac.expo.id = :expoId ORDER BY ac.createdAt DESC LIMIT 5")
+    List<AdminCode> findTop5ByExpoIdOrderByCreatedAtDesc(@Param("expoId") Long expoId);
 }

--- a/src/main/java/com/myce/member/controller/MemberController.java
+++ b/src/main/java/com/myce/member/controller/MemberController.java
@@ -2,6 +2,7 @@ package com.myce.member.controller;
 
 import com.myce.auth.dto.CustomUserDetails;
 import com.myce.member.dto.*;
+import com.myce.member.dto.ExpoPaymentDetailResponse;
 import com.myce.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -161,5 +162,49 @@ public class MemberController {
         MemberExpoDetailResponse expoDetail = memberService.getMemberExpoDetail(memberId, expoId);
         
         return ResponseEntity.ok(expoDetail);
+    }
+    
+    @DeleteMapping("/my-page/expos/{expoId}")
+    public ResponseEntity<Void> cancelExpo(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @PathVariable Long expoId) {
+        
+        Long memberId = customUserDetails.getMemberId();
+        memberService.cancelExpo(memberId, expoId);
+        
+        return ResponseEntity.noContent().build();
+    }
+    
+    @GetMapping("/my-page/expos/{expoId}/payment")
+    public ResponseEntity<ExpoPaymentDetailResponse> getExpoPaymentDetail(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @PathVariable Long expoId) {
+        
+        Long memberId = customUserDetails.getMemberId();
+        ExpoPaymentDetailResponse paymentDetail = memberService.getExpoPaymentDetail(memberId, expoId);
+        
+        return ResponseEntity.ok(paymentDetail);
+    }
+    
+    @GetMapping("/my-page/expos/{expoId}/admin-codes")
+    public ResponseEntity<List<ExpoAdminCodeResponse>> getExpoAdminCodes(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @PathVariable Long expoId) {
+        
+        Long memberId = customUserDetails.getMemberId();
+        List<ExpoAdminCodeResponse> adminCodes = memberService.getExpoAdminCodes(memberId, expoId);
+        
+        return ResponseEntity.ok(adminCodes);
+    }
+    
+    @GetMapping("/my-page/expos/{expoId}/settlement-receipt")
+    public ResponseEntity<ExpoSettlementReceiptResponse> getExpoSettlementReceipt(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @PathVariable Long expoId) {
+        
+        Long memberId = customUserDetails.getMemberId();
+        ExpoSettlementReceiptResponse settlementReceipt = memberService.getExpoSettlementReceipt(memberId, expoId);
+        
+        return ResponseEntity.ok(settlementReceipt);
     }
 }

--- a/src/main/java/com/myce/member/dto/ExpoAdminCodeResponse.java
+++ b/src/main/java/com/myce/member/dto/ExpoAdminCodeResponse.java
@@ -1,0 +1,20 @@
+package com.myce.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ExpoAdminCodeResponse {
+    
+    private Long adminCodeId;
+    private String code;
+    private LocalDateTime expiredAt;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/myce/member/dto/ExpoPaymentDetailResponse.java
+++ b/src/main/java/com/myce/member/dto/ExpoPaymentDetailResponse.java
@@ -1,0 +1,31 @@
+package com.myce.member.dto;
+
+import com.myce.expo.entity.type.ExpoStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ExpoPaymentDetailResponse {
+    
+    // 박람회 기본 정보
+    private String expoTitle;
+    private String applicantName;  // 신청자 (회사명)
+    private LocalDate displayStartDate;
+    private LocalDate displayEndDate;
+    private ExpoStatus status;
+    
+    // 결제 정보
+    private Integer totalDays;         // 총 일수
+    private Integer dailyUsageFee;     // 일당 사용료
+    private Integer usageFeeAmount;    // 사용료 총액 (일당 * 총일수)
+    private Integer depositAmount;     // 등록금 (프리미엄이면 premiumDeposit, 아니면 deposit)
+    private Integer totalAmount;       // 총 결제해야 할 금액
+    private Boolean isPremium;         // 프리미엄 여부
+}

--- a/src/main/java/com/myce/member/dto/ExpoSettlementReceiptResponse.java
+++ b/src/main/java/com/myce/member/dto/ExpoSettlementReceiptResponse.java
@@ -1,0 +1,48 @@
+package com.myce.member.dto;
+
+import com.myce.expo.entity.type.ExpoStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ExpoSettlementReceiptResponse {
+    
+    // 박람회 기본 정보
+    private String expoTitle;
+    private LocalDate displayStartDate;
+    private LocalDate displayEndDate;
+    private ExpoStatus status;
+    
+    // 티켓별 판매 정보
+    private List<TicketSalesInfo> ticketSales;
+    
+    // 정산 정보
+    private Integer totalRevenue;           // 총 매출 (모든 티켓 판매금액 합계)
+    private BigDecimal commissionRate;      // 수수료율 (퍼센트)
+    private Integer commissionAmount;       // 수수료 금액
+    private Integer netProfit;              // 순수익 (총매출 - 수수료)
+    
+    // 영수증 정보
+    private LocalDate issueDate;            // 영수증 발행일 (오늘)
+    
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class TicketSalesInfo {
+        private Long ticketId;
+        private String ticketName;          // 티켓명
+        private Integer ticketPrice;        // 티켓 단가
+        private Integer soldCount;          // 판매된 수량
+        private Integer totalSales;         // 티켓별 총 판매금액 (단가 * 수량)
+    }
+}

--- a/src/main/java/com/myce/member/mapper/ExpoAdminCodeMapper.java
+++ b/src/main/java/com/myce/member/mapper/ExpoAdminCodeMapper.java
@@ -1,0 +1,26 @@
+package com.myce.member.mapper;
+
+import com.myce.expo.entity.AdminCode;
+import com.myce.member.dto.ExpoAdminCodeResponse;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class ExpoAdminCodeMapper {
+    
+    public ExpoAdminCodeResponse toExpoAdminCodeResponse(AdminCode adminCode) {
+        return ExpoAdminCodeResponse.builder()
+                .adminCodeId(adminCode.getId())
+                .code(adminCode.getCode())
+                .expiredAt(adminCode.getExpiredAt())
+                .createdAt(adminCode.getCreatedAt())
+                .build();
+    }
+    
+    public List<ExpoAdminCodeResponse> toExpoAdminCodeResponseList(List<AdminCode> adminCodes) {
+        return adminCodes.stream()
+                .map(this::toExpoAdminCodeResponse)
+                .toList();
+    }
+}

--- a/src/main/java/com/myce/member/mapper/ExpoPaymentDetailMapper.java
+++ b/src/main/java/com/myce/member/mapper/ExpoPaymentDetailMapper.java
@@ -1,0 +1,38 @@
+package com.myce.member.mapper;
+
+import com.myce.common.entity.BusinessProfile;
+import com.myce.expo.entity.Expo;
+import com.myce.member.dto.ExpoPaymentDetailResponse;
+import com.myce.payment.entity.ExpoPaymentInfo;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ExpoPaymentDetailMapper {
+    
+    public ExpoPaymentDetailResponse toExpoPaymentDetailResponse(Expo expo, 
+                                                                BusinessProfile businessProfile, 
+                                                                ExpoPaymentInfo expoPaymentInfo) {
+        
+        // 사용료 총액 계산 (일당 * 총일수)
+        int usageFeeAmount = expoPaymentInfo.getDailyUsageFee() * expoPaymentInfo.getTotalDay();
+        
+        // 등록금 계산 (프리미엄이면 premiumDeposit, 아니면 deposit)
+        int depositAmount = expo.getIsPremium() ? 
+                expoPaymentInfo.getPremiumDeposit() : 
+                expoPaymentInfo.getDeposit();
+        
+        return ExpoPaymentDetailResponse.builder()
+                .expoTitle(expo.getTitle())
+                .applicantName(businessProfile != null ? businessProfile.getCompanyName() : "")
+                .displayStartDate(expo.getDisplayStartDate())
+                .displayEndDate(expo.getDisplayEndDate())
+                .status(expo.getStatus())
+                .totalDays(expoPaymentInfo.getTotalDay())
+                .dailyUsageFee(expoPaymentInfo.getDailyUsageFee())
+                .usageFeeAmount(usageFeeAmount)
+                .depositAmount(depositAmount)
+                .totalAmount(expoPaymentInfo.getTotalAmount())
+                .isPremium(expo.getIsPremium())
+                .build();
+    }
+}

--- a/src/main/java/com/myce/member/mapper/ExpoSettlementReceiptMapper.java
+++ b/src/main/java/com/myce/member/mapper/ExpoSettlementReceiptMapper.java
@@ -1,0 +1,66 @@
+package com.myce.member.mapper;
+
+import com.myce.expo.entity.Expo;
+import com.myce.expo.entity.Ticket;
+import com.myce.member.dto.ExpoSettlementReceiptResponse;
+import com.myce.system.entity.ExpoFeeSetting;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.util.List;
+
+@Component
+public class ExpoSettlementReceiptMapper {
+    
+    public ExpoSettlementReceiptResponse toSettlementReceiptResponse(Expo expo, 
+                                                                    List<Ticket> tickets, 
+                                                                    ExpoFeeSetting feeSetting) {
+        
+        // 티켓별 판매 정보 계산
+        List<ExpoSettlementReceiptResponse.TicketSalesInfo> ticketSales = tickets.stream()
+                .map(this::buildTicketSalesInfo)
+                .toList();
+        
+        // 총 매출 계산
+        int totalRevenue = ticketSales.stream()
+                .mapToInt(ExpoSettlementReceiptResponse.TicketSalesInfo::getTotalSales)
+                .sum();
+        
+        // 수수료 계산
+        BigDecimal commissionRate = feeSetting.getSettlementCommission();
+        int commissionAmount = totalRevenue * commissionRate.intValue() / 100;
+        
+        // 순수익 계산
+        int netProfit = totalRevenue - commissionAmount;
+        
+        return ExpoSettlementReceiptResponse.builder()
+                .expoTitle(expo.getTitle())
+                .displayStartDate(expo.getDisplayStartDate())
+                .displayEndDate(expo.getDisplayEndDate())
+                .status(expo.getStatus())
+                .ticketSales(ticketSales)
+                .totalRevenue(totalRevenue)
+                .commissionRate(commissionRate)
+                .commissionAmount(commissionAmount)
+                .netProfit(netProfit)
+                .issueDate(LocalDate.now())
+                .build();
+    }
+    
+    private ExpoSettlementReceiptResponse.TicketSalesInfo buildTicketSalesInfo(Ticket ticket) {
+        // 판매된 수량 = 총 수량 - 남은 수량
+        int soldCount = ticket.getTotalQuantity() - ticket.getRemainingQuantity();
+        // 티켓별 총 판매금액 = 판매된 수량 * 티켓 가격
+        int totalSales = soldCount * ticket.getPrice();
+        
+        return ExpoSettlementReceiptResponse.TicketSalesInfo.builder()
+                .ticketId(ticket.getId())
+                .ticketName(ticket.getName())
+                .ticketPrice(ticket.getPrice())
+                .soldCount(soldCount)
+                .totalSales(totalSales)
+                .build();
+    }
+}

--- a/src/main/java/com/myce/member/service/MemberService.java
+++ b/src/main/java/com/myce/member/service/MemberService.java
@@ -33,4 +33,12 @@ public interface MemberService {
     List<MemberExpoResponse> getMemberExpos(Long memberId);
     
     MemberExpoDetailResponse getMemberExpoDetail(Long memberId, Long expoId);
+    
+    void cancelExpo(Long memberId, Long expoId);
+    
+    ExpoPaymentDetailResponse getExpoPaymentDetail(Long memberId, Long expoId);
+    
+    List<ExpoAdminCodeResponse> getExpoAdminCodes(Long memberId, Long expoId);
+    
+    ExpoSettlementReceiptResponse getExpoSettlementReceipt(Long memberId, Long expoId);
 }

--- a/src/main/java/com/myce/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/myce/member/service/impl/MemberServiceImpl.java
@@ -7,17 +7,21 @@ import com.myce.advertisement.repository.AdvertisementRepository;
 import com.myce.common.entity.BusinessProfile;
 import com.myce.common.entity.type.TargetType;
 import com.myce.common.repository.BusinessProfileRepository;
+import com.myce.expo.entity.AdminCode;
 import com.myce.expo.entity.Expo;
 import com.myce.expo.entity.Ticket;
+import com.myce.expo.repository.AdminCodeRepository;
 import com.myce.expo.repository.ExpoRepository;
 import com.myce.expo.repository.TicketRepository;
 import com.myce.member.dto.*;
+import com.myce.member.dto.ExpoPaymentDetailResponse;
 import java.time.temporal.ChronoUnit;
 import java.time.LocalDate;
 import com.myce.member.entity.Favorite;
 import com.myce.member.entity.Member;
 import com.myce.member.entity.MemberSetting;
 import com.myce.member.mapper.*;
+import com.myce.member.mapper.ExpoPaymentDetailMapper;
 import com.myce.member.repository.FavoriteRepository;
 import com.myce.member.repository.MemberRepository;
 import com.myce.member.repository.MemberSettingRepository;
@@ -27,6 +31,8 @@ import com.myce.payment.entity.ExpoPaymentInfo;
 import com.myce.payment.repository.AdPaymentInfoRepository;
 import com.myce.payment.repository.ExpoPaymentInfoRepository;
 import com.myce.payment.repository.PaymentRepository;
+import com.myce.system.entity.ExpoFeeSetting;
+import com.myce.system.repository.ExpoFeeSettingRepository;
 import com.myce.reservation.entity.Reservation;
 import com.myce.reservation.entity.code.UserType;
 import com.myce.reservation.repository.ReservationRepository;
@@ -57,11 +63,16 @@ public class MemberServiceImpl implements MemberService {
     private final AdvertisementRefundReceiptMapper advertisementRefundReceiptMapper;
     private final MemberExpoMapper memberExpoMapper;
     private final MemberExpoDetailMapper memberExpoDetailMapper;
+    private final ExpoPaymentDetailMapper expoPaymentDetailMapper;
+    private final ExpoAdminCodeMapper expoAdminCodeMapper;
+    private final ExpoSettlementReceiptMapper expoSettlementReceiptMapper;
     private final BusinessProfileRepository businessProfileRepository;
     private final AdPaymentInfoRepository adPaymentInfoRepository;
     private final ExpoPaymentInfoRepository expoPaymentInfoRepository;
     private final ExpoRepository expoRepository;
     private final TicketRepository ticketRepository;
+    private final AdminCodeRepository adminCodeRepository;
+    private final ExpoFeeSettingRepository expoFeeSettingRepository;
 
     @Override
     public List<ReservedExpoResponse> getReservedExpos(Long memberId) {
@@ -222,5 +233,75 @@ public class MemberServiceImpl implements MemberService {
                 .orElse(null);
         
         return memberExpoDetailMapper.toMemberExpoDetailResponse(expo, paymentInfo, tickets, businessProfile);
+    }
+    
+    @Override
+    @Transactional
+    public void cancelExpo(Long memberId, Long expoId) {
+        Expo expo = expoRepository.findById(expoId)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.EXPO_NOT_FOUND));
+        
+        if (!expo.getMember().getId().equals(memberId)) {
+            throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
+        }
+        
+        expo.cancel();
+    }
+    
+    @Override
+    public ExpoPaymentDetailResponse getExpoPaymentDetail(Long memberId, Long expoId) {
+        // 박람회 정보 조회
+        Expo expo = expoRepository.findById(expoId)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.EXPO_NOT_FOUND));
+        
+        if (!expo.getMember().getId().equals(memberId)) {
+            throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
+        }
+        
+        // 사업자 정보 조회
+        BusinessProfile businessProfile = businessProfileRepository.findByTargetIdAndTargetType(expoId, TargetType.EXPO)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.BUSINESS_NOT_EXIST));
+        
+        // 박람회 결제 정보 조회
+        ExpoPaymentInfo expoPaymentInfo = expoPaymentInfoRepository.findByExpoId(expoId)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.PAYMENT_INFO_NOT_FOUND));
+        
+        return expoPaymentDetailMapper.toExpoPaymentDetailResponse(expo, businessProfile, expoPaymentInfo);
+    }
+    
+    @Override
+    public List<ExpoAdminCodeResponse> getExpoAdminCodes(Long memberId, Long expoId) {
+        // 박람회가 해당 회원의 것인지 확인
+        Expo expo = expoRepository.findById(expoId)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.EXPO_NOT_FOUND));
+        
+        if (!expo.getMember().getId().equals(memberId)) {
+            throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
+        }
+        
+        // 해당 박람회의 관리자 코드 5개 조회
+        List<AdminCode> adminCodes = adminCodeRepository.findTop5ByExpoIdOrderByCreatedAtDesc(expoId);
+        
+        return expoAdminCodeMapper.toExpoAdminCodeResponseList(adminCodes);
+    }
+    
+    @Override
+    public ExpoSettlementReceiptResponse getExpoSettlementReceipt(Long memberId, Long expoId) {
+        // 박람회가 해당 회원의 것인지 확인
+        Expo expo = expoRepository.findById(expoId)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.EXPO_NOT_FOUND));
+        
+        if (!expo.getMember().getId().equals(memberId)) {
+            throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
+        }
+        
+        // 해당 박람회의 티켓 목록 조회
+        List<Ticket> tickets = ticketRepository.findByExpoId(expoId);
+        
+        // 현재 활성화된 수수료 설정 조회
+        ExpoFeeSetting feeSetting = expoFeeSettingRepository.findActiveFeeSetting()
+                .orElseThrow(() -> new CustomException(CustomErrorCode.FEE_SETTING_NOT_FOUND));
+        
+        return expoSettlementReceiptMapper.toSettlementReceiptResponse(expo, tickets, feeSetting);
     }
 }

--- a/src/main/java/com/myce/system/repository/ExpoFeeSettingRepository.java
+++ b/src/main/java/com/myce/system/repository/ExpoFeeSettingRepository.java
@@ -1,0 +1,15 @@
+package com.myce.system.repository;
+
+import com.myce.system.entity.ExpoFeeSetting;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface ExpoFeeSettingRepository extends JpaRepository<ExpoFeeSetting, Long> {
+    
+    @Query("SELECT efs FROM ExpoFeeSetting efs WHERE efs.isActive = true ORDER BY efs.createdAt DESC LIMIT 1")
+    Optional<ExpoFeeSetting> findActiveFeeSetting();
+}


### PR DESCRIPTION
feat: 마이페이지 관리자로써 신청한 박람회 금액 관련 기능 추가ㅋ


@DeleteMapping("/my-page/expos/{expoId}") -> 엑스포 신청 취소

@GetMapping("/my-page/expos/{expoId}/payment") -> 엑스포 결제 영수증 조회

프리미엄일경우 프리미엄등록금이 totalAmount, 일반일경우 일반등록금이 totalAMount에합산됨
{
  "expoTitle": "2025 투슬리스 박람회",
  "applicantName": "MYCE 주식회사",
  "displayStartDate": "2025-08-01",
  "displayEndDate": "2025-10-14",
  "status": "PENDING_APPROVAL",
  "totalDays": 3,
  "dailyUsageFee": 5000,
  "usageFeeAmount": 15000,
  "depositAmount": 200000,
  "totalAmount": 215000,
  "isPremium": true
}

@GetMapping("/my-page/expos/{expoId}/admin-codes") -> 박람회 관리자 코드 조회
    
[
  {
    "adminCodeId": 1,
    "code": "CODE123A",
    "expiredAt": "2025-12-31T23:59:59",
    "createdAt": "2025-08-04T13:50:11"
  },
  {
    "adminCodeId": 2,
    "code": "CODE456B",
    "expiredAt": "2025-12-31T23:59:59",
    "createdAt": "2025-08-04T13:50:11"
  },
  {
    "adminCodeId": 3,
    "code": "CODE789C",
    "expiredAt": "2025-12-31T23:59:59",
    "createdAt": "2025-08-04T13:50:11"
  },
  {
    "adminCodeId": 4,
    "code": "CODE101D",
    "expiredAt": "2025-12-31T23:59:59",
    "createdAt": "2025-08-04T13:50:11"
  }
]    

@GetMapping("/my-page/expos/{expoId}/settlement-receipt") -> 정산 영수증 조회(끝나고 난뒤)

{
  "expoTitle": "2025 투슬리스 박람회",
  "displayStartDate": "2025-08-01",
  "displayEndDate": "2025-10-14",
  "status": "PENDING_APPROVAL",
  "ticketSales": [
    {
      "ticketId": 1,
      "ticketName": "IT 박람회 얼리버드 티켓",
      "ticketPrice": 15000,
      "soldCount": 20,
      "totalSales": 300000
    },
    {
      "ticketId": 2,
      "ticketName": "IT 박람회 일반 티켓",
      "ticketPrice": 20000,
      "soldCount": 50,
      "totalSales": 1000000
    }
  ],
  "totalRevenue": 1300000,
  "commissionRate": 10,
  "commissionAmount": 130000,
  "netProfit": 1170000,
  "issueDate": "2025-08-08"
}

티켓별 판매금액 수량과 총 판매금액, 플랫폼 수수료 , 수수료로 제할 금액, 순수익 데이터 제공

