### PR TITLE
[CRM-61] fix : AdminCodeRepository 사용하지 않는 메소드 제거

### DIFF
--- a/src/main/java/com/myce/common/config/.gitkeep
+++ b/src/main/java/com/myce/common/config/.gitkeep
@@ -1,1 +1,0 @@
-.gitkeep

--- a/src/main/java/com/myce/expo/repository/AdminCodeRepository.java
+++ b/src/main/java/com/myce/expo/repository/AdminCodeRepository.java
@@ -1,10 +1,14 @@
 package com.myce.expo.repository;
 
 import com.myce.expo.entity.AdminCode;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface AdminCodeRepository extends JpaRepository<AdminCode, Long> {
 
     Optional<AdminCode> findByCode(String code);
+    
 }


### PR DESCRIPTION
## 수정 사항
- AdminCode에 expo 관계성 제거로 인한 오류 메소드 삭제