### PR TITLE
[CRM-108] Feat: 박람회 중도 환불 영수증 기능 추가

### DIFF
--- a/src/main/java/com/myce/common/exception/CustomErrorCode.java
+++ b/src/main/java/com/myce/common/exception/CustomErrorCode.java
@@ -46,6 +46,7 @@ public enum CustomErrorCode {
     CATEGORY_NOT_EXIST(HttpStatus.NOT_FOUND, "E005", "카테고리가 존재하지 않습니다."),
     EXPO_ACCESS_DENIED(HttpStatus.FORBIDDEN, "E003", "해당 박람회에 대한 접근 권한이 없습니다."),
     EXPO_UPDATE_DENIED(HttpStatus.FORBIDDEN, "E004", "해당 박람회에 대한 수정 권한이 없습니다."),
+    INVALID_EXPO_STATUS(HttpStatus.NOT_FOUND, "E005" , "영수증을 조회 할 수 없습니다."),
 
     // 티켓 T
     TICKET_NOT_EXIST(HttpStatus.NOT_FOUND, "T001", "티켓이 존재하지 않습니다."),

--- a/src/main/java/com/myce/member/controller/MemberController.java
+++ b/src/main/java/com/myce/member/controller/MemberController.java
@@ -207,4 +207,15 @@ public class MemberController {
         
         return ResponseEntity.ok(settlementReceipt);
     }
+    
+    @GetMapping("/my-page/expos/{expoId}/refund-receipt")
+    public ResponseEntity<ExpoRefundReceiptResponse> getExpoRefundReceipt(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @PathVariable Long expoId) {
+        
+        Long memberId = customUserDetails.getMemberId();
+        ExpoRefundReceiptResponse refundReceipt = memberService.getExpoRefundReceipt(memberId, expoId);
+        
+        return ResponseEntity.ok(refundReceipt);
+    }
 }

--- a/src/main/java/com/myce/member/dto/ExpoRefundReceiptResponse.java
+++ b/src/main/java/com/myce/member/dto/ExpoRefundReceiptResponse.java
@@ -1,0 +1,37 @@
+package com.myce.member.dto;
+
+import com.myce.expo.entity.type.ExpoStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ExpoRefundReceiptResponse {
+    
+    // 박람회 기본 정보
+    private String expoTitle;
+    private String applicantName;  // 신청자 (회사명)
+    private LocalDate displayStartDate;  // 게시 시작일
+    private LocalDate displayEndDate;    // 게시 종료일
+    private ExpoStatus status;
+    
+    // 원본 결제 정보
+    private Integer totalDays;         // 총 게시 일수
+    private Integer dailyUsageFee;     // 일일 이용료
+    private Integer totalAmount;       // 총 결제 금액
+    
+    // 사용 정보
+    private LocalDate refundRequestDate;  // 환불 요청일 (오늘)
+    private Integer usedDays;             // 사용한 일수
+    private Integer usedAmount;           // 사용한 금액
+    
+    // 환불 정보
+    private Integer remainingDays;        // 남은 게시 일수
+    private Integer refundAmount;         // 환불 금액 (남은일수 * 일일이용료)
+}

--- a/src/main/java/com/myce/member/mapper/ExpoRefundReceiptMapper.java
+++ b/src/main/java/com/myce/member/mapper/ExpoRefundReceiptMapper.java
@@ -1,0 +1,51 @@
+package com.myce.member.mapper;
+
+import com.myce.common.entity.BusinessProfile;
+import com.myce.expo.entity.Expo;
+import com.myce.member.dto.ExpoRefundReceiptResponse;
+import com.myce.payment.entity.ExpoPaymentInfo;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+
+@Component
+public class ExpoRefundReceiptMapper {
+    
+    public ExpoRefundReceiptResponse toRefundReceiptDto(Expo expo, 
+                                                       BusinessProfile businessProfile, 
+                                                       ExpoPaymentInfo expoPaymentInfo) {
+        
+        // 환불 계산
+        LocalDate today = LocalDate.now();
+        LocalDate displayStartDate = expo.getDisplayStartDate();
+        
+        // 사용한 일수 계산 (게시 시작일부터 오늘까지)
+        int usedDays = (int) ChronoUnit.DAYS.between(displayStartDate, today) + 1; // +1은 시작일 포함
+        if (usedDays < 0) usedDays = 0;
+        
+        // 남은 일수 계산
+        int remainingDays = expoPaymentInfo.getTotalDay() - usedDays;
+        if (remainingDays < 0) remainingDays = 0;
+        
+        // 금액 계산
+        int usedAmount = usedDays * expoPaymentInfo.getDailyUsageFee();
+        int refundAmount = remainingDays * expoPaymentInfo.getDailyUsageFee();
+        
+        return ExpoRefundReceiptResponse.builder()
+                .expoTitle(expo.getTitle())
+                .applicantName(businessProfile.getCompanyName())
+                .displayStartDate(expo.getDisplayStartDate())
+                .displayEndDate(expo.getDisplayEndDate())
+                .status(expo.getStatus())
+                .totalDays(expoPaymentInfo.getTotalDay())
+                .dailyUsageFee(expoPaymentInfo.getDailyUsageFee())
+                .totalAmount(expoPaymentInfo.getTotalAmount())
+                .refundRequestDate(today)
+                .usedDays(usedDays)
+                .usedAmount(usedAmount)
+                .remainingDays(remainingDays)
+                .refundAmount(refundAmount)
+                .build();
+    }
+}

--- a/src/main/java/com/myce/member/service/MemberService.java
+++ b/src/main/java/com/myce/member/service/MemberService.java
@@ -41,4 +41,6 @@ public interface MemberService {
     List<ExpoAdminCodeResponse> getExpoAdminCodes(Long memberId, Long expoId);
     
     ExpoSettlementReceiptResponse getExpoSettlementReceipt(Long memberId, Long expoId);
+    
+    ExpoRefundReceiptResponse getExpoRefundReceipt(Long memberId, Long expoId);
 }

--- a/src/main/java/com/myce/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/myce/member/service/impl/MemberServiceImpl.java
@@ -17,6 +17,7 @@ import com.myce.expo.repository.ExpoRepository;
 import com.myce.expo.repository.TicketRepository;
 import com.myce.member.dto.*;
 import com.myce.member.dto.ExpoPaymentDetailResponse;
+import com.myce.member.mapper.ExpoRefundReceiptMapper;
 import java.time.temporal.ChronoUnit;
 import java.time.LocalDate;
 import com.myce.member.entity.Favorite;
@@ -75,6 +76,7 @@ public class MemberServiceImpl implements MemberService {
     private final TicketRepository ticketRepository;
     private final AdminCodeRepository adminCodeRepository;
     private final ExpoFeeSettingRepository expoFeeSettingRepository;
+    private final ExpoRefundReceiptMapper expoRefundReceiptMapper;
 
     @Override
     public List<ReservedExpoResponse> getReservedExpos(Long memberId) {
@@ -312,5 +314,32 @@ public class MemberServiceImpl implements MemberService {
                 .orElseThrow(() -> new CustomException(CustomErrorCode.FEE_SETTING_NOT_FOUND));
 
         return expoSettlementReceiptMapper.toSettlementReceiptResponse(expo, tickets, feeSetting);
+    }
+
+    @Override
+    public ExpoRefundReceiptResponse getExpoRefundReceipt(Long memberId, Long expoId) {
+        // 박람회가 해당 회원의 것인지 확인
+        Expo expo = expoRepository.findById(expoId)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.EXPO_NOT_FOUND));
+
+        if (!expo.getMember().getId().equals(memberId)) {
+            throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
+        }
+
+        // 게시 중인 박람회만 환불 가능
+        if (expo.getStatus() != com.myce.expo.entity.type.ExpoStatus.PUBLISHED) {
+            throw new CustomException(CustomErrorCode.INVALID_EXPO_STATUS);
+        }
+
+        // 사업자 정보 조회
+        BusinessProfile businessProfile = businessProfileRepository.findByTargetIdAndTargetType(expoId,
+                        TargetType.EXPO)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.BUSINESS_NOT_EXIST));
+
+        // 박람회 결제 정보 조회
+        ExpoPaymentInfo expoPaymentInfo = expoPaymentInfoRepository.findByExpoId(expoId)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.PAYMENT_INFO_NOT_FOUND));
+
+        return expoRefundReceiptMapper.toRefundReceiptDto(expo, businessProfile, expoPaymentInfo);
     }
 }


### PR DESCRIPTION
 @GetMapping("/my-page/expos/{expoId}/refund-receipt")
   
{
  "expoTitle": "2025 투슬리스 박람회",
  "applicantName": "MYCE 주식회사",
  "displayStartDate": "2025-08-01",
  "displayEndDate": "2025-10-14",
  "status": "PUBLISHED",
  "totalDays": 3,
  "dailyUsageFee": 5000,
  "totalAmount": 215000,
  "refundRequestDate": "2025-08-08",
  "usedDays": 8,
  "usedAmount": 40000,
  "remainingDays": 0,
  "refundAmount": 0
}
    