### PR TITLE
[CRM-243] feat: 배너 결제 내역 및 취소 내역 조회

### DIFF
--- a/src/main/java/com/myce/advertisement/controller/PlatformAdminAdvertisementController.java
+++ b/src/main/java/com/myce/advertisement/controller/PlatformAdminAdvertisementController.java
@@ -1,7 +1,6 @@
 package com.myce.advertisement.controller;
 
 import com.myce.advertisement.dto.*;
-import com.myce.advertisement.dto.AdPaymentHistoryResponse;
 import com.myce.advertisement.dto.AdRejectInfoResponse;
 import com.myce.advertisement.dto.DetailApplyAdvertisement;
 import com.myce.advertisement.dto.RejectAdRequest;

--- a/src/main/java/com/myce/advertisement/controller/PlatformAdminAdvertisementController.java
+++ b/src/main/java/com/myce/advertisement/controller/PlatformAdminAdvertisementController.java
@@ -1,5 +1,6 @@
 package com.myce.advertisement.controller;
 
+import com.myce.advertisement.dto.*;
 import com.myce.advertisement.dto.AdPaymentHistoryResponse;
 import com.myce.advertisement.dto.AdRejectInfoResponse;
 import com.myce.advertisement.dto.DetailApplyAdvertisement;
@@ -61,8 +62,13 @@ public class PlatformAdminAdvertisementController {
     }
 
     @GetMapping("/detail/{bannerId}/payment-history")
-    public AdPaymentHistoryResponse getPaymentHistory(@PathVariable Long bannerId) {
-        return service.getPaymentHistory(bannerId);
+    public AdPaymentInfoResponse getPaymentInfo(@PathVariable Long bannerId) {
+        return service.getPaymentInfo(bannerId);
+    }
+
+    @GetMapping("/detail/{bannerId}/cancel-history")
+    public AdCancelInfoResponse getCancelInfo(@PathVariable Long bannerId) {
+        return service.getCancelInfo(bannerId);
     }
 
 }

--- a/src/main/java/com/myce/advertisement/controller/PlatformAdminAdvertisementController.java
+++ b/src/main/java/com/myce/advertisement/controller/PlatformAdminAdvertisementController.java
@@ -1,5 +1,6 @@
 package com.myce.advertisement.controller;
 
+import com.myce.advertisement.dto.AdPaymentHistoryResponse;
 import com.myce.advertisement.dto.AdRejectInfoResponse;
 import com.myce.advertisement.dto.DetailApplyAdvertisement;
 import com.myce.advertisement.dto.RejectAdRequest;
@@ -57,6 +58,11 @@ public class PlatformAdminAdvertisementController {
     @GetMapping("/detail/{bannerId}/reject")
     public AdRejectInfoResponse getRejectInfo(@PathVariable Long bannerId) {
         return service.getRejectInfo(bannerId);
+    }
+
+    @GetMapping("/detail/{bannerId}/payment-history")
+    public AdPaymentHistoryResponse getPaymentHistory(@PathVariable Long bannerId) {
+        return service.getPaymentHistory(bannerId);
     }
 
 }

--- a/src/main/java/com/myce/advertisement/dto/AdCancelInfoResponse.java
+++ b/src/main/java/com/myce/advertisement/dto/AdCancelInfoResponse.java
@@ -1,0 +1,31 @@
+package com.myce.advertisement.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+public class AdCancelInfoResponse {
+    private String title;
+    private String requesterName;
+    private LocalDate startAt;
+    private LocalDate endAt;
+    private String paymentType;
+    private String paymentCompanyName;
+    private String paymentAccountInfo;
+    private Integer totalAmount;
+    @Builder
+    public AdCancelInfoResponse(String title, String requesterName, LocalDate startAt, LocalDate endAt, String paymentType, String paymentCompanyName, String paymentAccountInfo, Integer totalAmount) {
+        this.title = title;
+        this.requesterName = requesterName;
+        this.startAt = startAt;
+        this.endAt = endAt;
+        this.paymentType = paymentType;
+        this.paymentCompanyName = paymentCompanyName;
+        this.paymentAccountInfo = paymentAccountInfo;
+        this.totalAmount = totalAmount;
+    }
+}

--- a/src/main/java/com/myce/advertisement/dto/AdPaymentHistoryResponse.java
+++ b/src/main/java/com/myce/advertisement/dto/AdPaymentHistoryResponse.java
@@ -1,0 +1,27 @@
+package com.myce.advertisement.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+public class AdPaymentHistoryResponse {
+    private String title;
+    private String requesterName;
+    private LocalDate startAt;
+    private LocalDate endAt;
+    private Integer totalPrice;
+    private Integer totalPayment;
+    @Builder
+    public AdPaymentHistoryResponse(String title, String requesterName, LocalDate startAt, LocalDate endAt, Integer totalPrice, Integer totalPayment) {
+        this.title = title;
+        this.requesterName = requesterName;
+        this.startAt = startAt;
+        this.endAt = endAt;
+        this.totalPrice = totalPrice;
+        this.totalPayment = totalPayment;
+    }
+}

--- a/src/main/java/com/myce/advertisement/dto/AdPaymentInfoResponse.java
+++ b/src/main/java/com/myce/advertisement/dto/AdPaymentInfoResponse.java
@@ -8,7 +8,7 @@ import java.time.LocalDate;
 
 @Getter
 @NoArgsConstructor
-public class AdPaymentHistoryResponse {
+public class AdPaymentInfoResponse {
     private String title;
     private String requesterName;
     private LocalDate startAt;
@@ -16,7 +16,7 @@ public class AdPaymentHistoryResponse {
     private Integer totalPrice;
     private Integer totalPayment;
     @Builder
-    public AdPaymentHistoryResponse(String title, String requesterName, LocalDate startAt, LocalDate endAt, Integer totalPrice, Integer totalPayment) {
+    public AdPaymentInfoResponse(String title, String requesterName, LocalDate startAt, LocalDate endAt, Integer totalPrice, Integer totalPayment) {
         this.title = title;
         this.requesterName = requesterName;
         this.startAt = startAt;

--- a/src/main/java/com/myce/advertisement/dto/AdPositionResponse.java
+++ b/src/main/java/com/myce/advertisement/dto/AdPositionResponse.java
@@ -3,11 +3,16 @@ package com.myce.advertisement.dto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@Builder
-@AllArgsConstructor
+@NoArgsConstructor
 public class AdPositionResponse {
-  private Long id;
-  private String name;
+    private Long id;
+    private String name;
+    @Builder
+    public AdPositionResponse(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
 }

--- a/src/main/java/com/myce/advertisement/service/PlatformAdminAdvertisementService.java
+++ b/src/main/java/com/myce/advertisement/service/PlatformAdminAdvertisementService.java
@@ -1,11 +1,6 @@
 package com.myce.advertisement.service;
 
 import com.myce.advertisement.dto.*;
-import com.myce.advertisement.dto.AdPaymentHistoryResponse;
-import com.myce.advertisement.dto.AdRejectInfoResponse;
-import com.myce.advertisement.dto.DetailApplyAdvertisement;
-import com.myce.advertisement.dto.RejectAdRequest;
-import com.myce.advertisement.dto.SimpleApplyAdvertisement;
 import com.myce.common.dto.PageResponse;
 
 public interface PlatformAdminAdvertisementService {

--- a/src/main/java/com/myce/advertisement/service/PlatformAdminAdvertisementService.java
+++ b/src/main/java/com/myce/advertisement/service/PlatformAdminAdvertisementService.java
@@ -1,5 +1,6 @@
 package com.myce.advertisement.service;
 
+import com.myce.advertisement.dto.*;
 import com.myce.advertisement.dto.AdPaymentHistoryResponse;
 import com.myce.advertisement.dto.AdRejectInfoResponse;
 import com.myce.advertisement.dto.DetailApplyAdvertisement;
@@ -22,5 +23,7 @@ public interface PlatformAdminAdvertisementService {
 
     AdRejectInfoResponse getRejectInfo(Long bannerId);
 
-    AdPaymentHistoryResponse getPaymentHistory(Long bannerId);
+    AdPaymentInfoResponse getPaymentInfo(Long bannerId);
+
+    AdCancelInfoResponse getCancelInfo(Long bannerId);
 }

--- a/src/main/java/com/myce/advertisement/service/PlatformAdminAdvertisementService.java
+++ b/src/main/java/com/myce/advertisement/service/PlatformAdminAdvertisementService.java
@@ -1,5 +1,6 @@
 package com.myce.advertisement.service;
 
+import com.myce.advertisement.dto.AdPaymentHistoryResponse;
 import com.myce.advertisement.dto.AdRejectInfoResponse;
 import com.myce.advertisement.dto.DetailApplyAdvertisement;
 import com.myce.advertisement.dto.RejectAdRequest;
@@ -20,4 +21,6 @@ public interface PlatformAdminAdvertisementService {
     void rejectApply(Long bannerId, RejectAdRequest request);
 
     AdRejectInfoResponse getRejectInfo(Long bannerId);
+
+    AdPaymentHistoryResponse getPaymentHistory(Long bannerId);
 }

--- a/src/main/java/com/myce/advertisement/service/impl/PlatformAdminAdvertisementServiceImpl.java
+++ b/src/main/java/com/myce/advertisement/service/impl/PlatformAdminAdvertisementServiceImpl.java
@@ -1,5 +1,6 @@
 package com.myce.advertisement.service.impl;
 
+import com.myce.advertisement.dto.*;
 import com.myce.advertisement.dto.AdPaymentHistoryResponse;
 import com.myce.advertisement.dto.AdRejectInfoResponse;
 import com.myce.advertisement.dto.DetailApplyAdvertisement;
@@ -19,7 +20,12 @@ import com.myce.common.exception.CustomException;
 import com.myce.common.repository.BusinessProfileRepository;
 import com.myce.common.repository.RejectInfoRepository;
 import com.myce.payment.entity.AdPaymentInfo;
+import com.myce.payment.entity.Payment;
+import com.myce.payment.entity.Refund;
+import com.myce.payment.entity.type.PaymentTargetType;
 import com.myce.payment.repository.AdPaymentInfoRepository;
+import com.myce.payment.repository.PaymentRepository;
+import com.myce.payment.repository.RefundRepository;
 import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
@@ -37,10 +43,15 @@ public class PlatformAdminAdvertisementServiceImpl implements PlatformAdminAdver
     private AdvertisementRepository advertisementRepository;
     @Autowired
     private BusinessProfileRepository businessProfileRepository;
+    // PlatformAdminAdvertisementDetailService로 분리 예정
     @Autowired
     private RejectInfoRepository rejectInfoRepository;
     @Autowired
     private AdPaymentInfoRepository adPaymentInfoRepository;
+    @Autowired
+    private PaymentRepository paymentRepository;
+    @Autowired
+    private RefundRepository refundRepository;
 
     public PageResponse<SimpleApplyAdvertisement> getAllAdList(
             int page, int pageSize,
@@ -106,12 +117,26 @@ public class PlatformAdminAdvertisementServiceImpl implements PlatformAdminAdver
         return AdvertisementMapper.getAdRejectInfoResponse(rejectInfo);
     }
 
-    public AdPaymentHistoryResponse getPaymentHistory(Long bannerId) {
-        AdPaymentInfo targetHistory = adPaymentInfoRepository
+    public AdPaymentInfoResponse getPaymentInfo(Long bannerId) {
+        AdPaymentInfo paymentInfo = adPaymentInfoRepository
                 .findByAdvertisementId(bannerId)
                 .orElseThrow(() -> new CustomException(CustomErrorCode.PAYMENT_INFO_NOT_FOUND));
 
-        return AdvertisementMapper.getPaymentHistoryRequest(targetHistory);
+        return AdvertisementMapper.getPaymentInfoRequest(paymentInfo);
+    }
+
+    public AdCancelInfoResponse getCancelInfo(Long bannerId) {
+        Advertisement advertisement = advertisementRepository
+                .findById(bannerId)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.BANNER_NOT_EXIST));
+        Payment payment = paymentRepository
+                .findByTargetIdAndTargetType(bannerId, PaymentTargetType.AD)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.PAYMENT_INFO_NOT_FOUND));
+        Refund refund = refundRepository
+                .findByPayment(payment)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.REFUND_NOT_FOUND));
+
+        return AdvertisementMapper.getAdCancelInfoResponse(advertisement, payment, refund);
     }
 
     private List<AdvertisementStatus> getApplyStatusList(boolean isApply) {
@@ -119,6 +144,7 @@ public class PlatformAdminAdvertisementServiceImpl implements PlatformAdminAdver
             return List.of(AdvertisementStatus.PENDING_APPROVAL,
                     AdvertisementStatus.PENDING_PAYMENT,
                     AdvertisementStatus.REJECTED,
+                    AdvertisementStatus.CANCELLED,
                     AdvertisementStatus.COMPLETED);
         } else {
             return List.of(AdvertisementStatus.PUBLISHED,

--- a/src/main/java/com/myce/advertisement/service/impl/PlatformAdminAdvertisementServiceImpl.java
+++ b/src/main/java/com/myce/advertisement/service/impl/PlatformAdminAdvertisementServiceImpl.java
@@ -1,11 +1,6 @@
 package com.myce.advertisement.service.impl;
 
 import com.myce.advertisement.dto.*;
-import com.myce.advertisement.dto.AdPaymentHistoryResponse;
-import com.myce.advertisement.dto.AdRejectInfoResponse;
-import com.myce.advertisement.dto.DetailApplyAdvertisement;
-import com.myce.advertisement.dto.RejectAdRequest;
-import com.myce.advertisement.dto.SimpleApplyAdvertisement;
 import com.myce.advertisement.entity.Advertisement;
 import com.myce.advertisement.entity.type.AdvertisementStatus;
 import com.myce.advertisement.repository.AdvertisementRepository;

--- a/src/main/java/com/myce/advertisement/service/impl/PlatformAdminAdvertisementServiceImpl.java
+++ b/src/main/java/com/myce/advertisement/service/impl/PlatformAdminAdvertisementServiceImpl.java
@@ -1,5 +1,6 @@
 package com.myce.advertisement.service.impl;
 
+import com.myce.advertisement.dto.AdPaymentHistoryResponse;
 import com.myce.advertisement.dto.AdRejectInfoResponse;
 import com.myce.advertisement.dto.DetailApplyAdvertisement;
 import com.myce.advertisement.dto.RejectAdRequest;
@@ -17,6 +18,8 @@ import com.myce.common.exception.CustomErrorCode;
 import com.myce.common.exception.CustomException;
 import com.myce.common.repository.BusinessProfileRepository;
 import com.myce.common.repository.RejectInfoRepository;
+import com.myce.payment.entity.AdPaymentInfo;
+import com.myce.payment.repository.AdPaymentInfoRepository;
 import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
@@ -36,6 +39,8 @@ public class PlatformAdminAdvertisementServiceImpl implements PlatformAdminAdver
     private BusinessProfileRepository businessProfileRepository;
     @Autowired
     private RejectInfoRepository rejectInfoRepository;
+    @Autowired
+    private AdPaymentInfoRepository adPaymentInfoRepository;
 
     public PageResponse<SimpleApplyAdvertisement> getAllAdList(
             int page, int pageSize,
@@ -98,11 +103,16 @@ public class PlatformAdminAdvertisementServiceImpl implements PlatformAdminAdver
                 .findByTargetIdAndTargetType(bannerId, TargetType.ADVERTISEMENT)
                 .orElseThrow(() -> new CustomException(CustomErrorCode.REJECT_INFO_NOT_FOUND));
 
-        return AdRejectInfoResponse.builder()
-                .description(rejectInfo.getDescription())
-                .build();
+        return AdvertisementMapper.getAdRejectInfoResponse(rejectInfo);
     }
 
+    public AdPaymentHistoryResponse getPaymentHistory(Long bannerId) {
+        AdPaymentInfo targetHistory = adPaymentInfoRepository
+                .findByAdvertisementId(bannerId)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.PAYMENT_INFO_NOT_FOUND));
+
+        return AdvertisementMapper.getPaymentHistoryRequest(targetHistory);
+    }
 
     private List<AdvertisementStatus> getApplyStatusList(boolean isApply) {
         if (isApply) {

--- a/src/main/java/com/myce/advertisement/service/mapper/AdvertisementMapper.java
+++ b/src/main/java/com/myce/advertisement/service/mapper/AdvertisementMapper.java
@@ -1,11 +1,15 @@
 package com.myce.advertisement.service.mapper;
 
+import com.myce.advertisement.dto.AdPaymentHistoryResponse;
+import com.myce.advertisement.dto.AdRejectInfoResponse;
 import com.myce.advertisement.dto.DetailApplyAdvertisement;
 import com.myce.advertisement.dto.SimpleApplyAdvertisement;
 import com.myce.advertisement.entity.AdPosition;
 import com.myce.advertisement.entity.Advertisement;
 import com.myce.common.entity.BusinessProfile;
+import com.myce.common.entity.RejectInfo;
 import com.myce.member.entity.Member;
+import com.myce.payment.entity.AdPaymentInfo;
 
 public class AdvertisementMapper {
     public static SimpleApplyAdvertisement getSimpleAdvertisement(Advertisement advertisement,
@@ -45,6 +49,25 @@ public class AdvertisementMapper {
                 .businessPhone(businessProfile.getContactPhone())
                 .address(businessProfile.getAddress())
                 .businessNumber(businessProfile.getBusinessRegistrationNumber())
+                .build();
+    }
+
+    public static AdRejectInfoResponse getAdRejectInfoResponse(RejectInfo rejectInfo) {
+        return AdRejectInfoResponse.builder()
+                .description(rejectInfo.getDescription())
+                .build();
+    }
+
+    public static AdPaymentHistoryResponse getPaymentHistoryRequest(AdPaymentInfo adPaymentInfo){
+        Advertisement advertisement = adPaymentInfo.getAdvertisement();
+
+        return AdPaymentHistoryResponse.builder()
+                .title(advertisement.getTitle())
+                .requesterName(advertisement.getMember().getName())
+                .startAt(advertisement.getDisplayStartDate())
+                .endAt(advertisement.getDisplayEndDate())
+                .totalPrice(adPaymentInfo.getFeePerDay() * adPaymentInfo.getTotalDay())
+                .totalPayment(adPaymentInfo.getTotalAmount())
                 .build();
     }
 

--- a/src/main/java/com/myce/advertisement/service/mapper/AdvertisementMapper.java
+++ b/src/main/java/com/myce/advertisement/service/mapper/AdvertisementMapper.java
@@ -1,15 +1,15 @@
 package com.myce.advertisement.service.mapper;
 
-import com.myce.advertisement.dto.AdPaymentHistoryResponse;
-import com.myce.advertisement.dto.AdRejectInfoResponse;
-import com.myce.advertisement.dto.DetailApplyAdvertisement;
-import com.myce.advertisement.dto.SimpleApplyAdvertisement;
+import com.myce.advertisement.dto.*;
 import com.myce.advertisement.entity.AdPosition;
 import com.myce.advertisement.entity.Advertisement;
 import com.myce.common.entity.BusinessProfile;
 import com.myce.common.entity.RejectInfo;
 import com.myce.member.entity.Member;
 import com.myce.payment.entity.AdPaymentInfo;
+import com.myce.payment.entity.Payment;
+import com.myce.payment.entity.Refund;
+import com.myce.payment.entity.type.PaymentMethod;
 
 public class AdvertisementMapper {
     public static SimpleApplyAdvertisement getSimpleAdvertisement(Advertisement advertisement,
@@ -58,16 +58,43 @@ public class AdvertisementMapper {
                 .build();
     }
 
-    public static AdPaymentHistoryResponse getPaymentHistoryRequest(AdPaymentInfo adPaymentInfo){
+    public static AdPaymentInfoResponse getPaymentInfoRequest(AdPaymentInfo adPaymentInfo){
         Advertisement advertisement = adPaymentInfo.getAdvertisement();
 
-        return AdPaymentHistoryResponse.builder()
+        return AdPaymentInfoResponse.builder()
                 .title(advertisement.getTitle())
                 .requesterName(advertisement.getMember().getName())
                 .startAt(advertisement.getDisplayStartDate())
                 .endAt(advertisement.getDisplayEndDate())
                 .totalPrice(adPaymentInfo.getFeePerDay() * adPaymentInfo.getTotalDay())
                 .totalPayment(adPaymentInfo.getTotalAmount())
+                .build();
+    }
+
+    public static AdCancelInfoResponse getAdCancelInfoResponse(Advertisement advertisement, Payment payment, Refund refund) {
+        PaymentMethod paymentMethod = payment.getPaymentMethod();
+        String paymentCompanyName;
+        String paymentAccountInfo;
+        // 계좌이체일때 - account_number
+        // 나머지 - card_number
+        // todo: EASY_PAY, FOREIGN_PAY 어떻게 처리할지
+        if(paymentMethod == PaymentMethod.TRANSFER){
+            paymentCompanyName = payment.getAccountBank();
+            paymentAccountInfo = payment.getAccountNumber();
+        }else{
+            paymentCompanyName = payment.getCardCompany();
+            paymentAccountInfo = payment.getCardNumber();
+        }
+
+        return AdCancelInfoResponse.builder()
+                .title(advertisement.getTitle())
+                .requesterName(advertisement.getMember().getName())
+                .startAt(advertisement.getDisplayStartDate())
+                .endAt(advertisement.getDisplayEndDate())
+                .paymentType(paymentMethod.name())
+                .paymentCompanyName(paymentCompanyName)
+                .paymentAccountInfo(paymentAccountInfo)
+                .totalAmount(refund.getAmount())
                 .build();
     }
 

--- a/src/main/java/com/myce/common/exception/CustomErrorCode.java
+++ b/src/main/java/com/myce/common/exception/CustomErrorCode.java
@@ -99,8 +99,12 @@ public enum CustomErrorCode {
     // 거부사유 RJ
     REJECT_INFO_NOT_FOUND(HttpStatus.NOT_FOUND, "RJ001", "거부 사유가 존재하지 않습니다."),
 
+    // 환불 RF
+    REFUND_NOT_FOUND(HttpStatus.NOT_FOUND, "RF001", "환불 정보가 존재하지 않습니다."),
+
     // 시스템 설정 에러
     NOT_EXIST_MESSAGE_TEMPLATE(HttpStatus.NOT_FOUND, "SY001", "메시지 템플릿이 존재하지 않습니다.");
+
 
     private final HttpStatus status;
     private final String errorCode;

--- a/src/main/java/com/myce/payment/entity/Payment.java
+++ b/src/main/java/com/myce/payment/entity/Payment.java
@@ -41,10 +41,6 @@ public class Payment {
     @Column(name = "payment_id")
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false)
-    private Member member;
-
     @Enumerated(EnumType.STRING)
     @Column(name = "target_type", nullable = false, columnDefinition = "VARCHAR(20)")
     private PaymentTargetType targetType;

--- a/src/main/java/com/myce/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/myce/payment/repository/PaymentRepository.java
@@ -1,6 +1,7 @@
 package com.myce.payment.repository;
 
 import com.myce.payment.entity.Payment;
+import com.myce.payment.entity.type.PaymentTargetType;
 import com.myce.reservation.entity.code.UserType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -8,6 +9,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
@@ -17,6 +19,8 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
            "WHERE rpi.reservation.userType = :userType AND rpi.reservation.userId = :userId " +
            "AND p.targetType = 'RESERVATION' " +
            "ORDER BY p.createdAt DESC")
-    List<Object[]> findReservationPaymentHistoryByUserTypeAndUserId(@Param("userType") UserType userType, 
+    List<Object[]> findReservationPaymentHistoryByUserTypeAndUserId(@Param("userType") UserType userType,
                                                                     @Param("userId") Long userId);
+
+    Optional<Payment> findByTargetIdAndTargetType(Long targetId, PaymentTargetType targetType);
 }

--- a/src/main/java/com/myce/payment/repository/RefundRepository.java
+++ b/src/main/java/com/myce/payment/repository/RefundRepository.java
@@ -1,0 +1,13 @@
+package com.myce.payment.repository;
+
+import com.myce.payment.entity.Payment;
+import com.myce.payment.entity.Refund;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface RefundRepository extends JpaRepository<Refund, Long> {
+    Optional<Refund> findByPayment(Payment payment);
+}


### PR DESCRIPTION
### 구현 기능
* 플랫폼 관리자 - 배너 결제 내역 상세 조회
* 플랫폼 관리자 - 배너 취소 내역 상세 조회
* Payment 엔티티의 member 필드 삭제(DB에 없음)

### 구현해야 할 것
* EASY_PAY와 FOREIGN_PAY 시 account_number로 들어가는지 card_number로 들어가는지 결정 시 수정 필요

리베이스 하고 우겨넣어서 커밋이 더럽습니다 양해 부탁드립니다..