### PR TITLE
[CRM-256] refactor : 박람회 하위 관리자 권한 체크 로직 추가

### DIFF
--- a/src/main/java/com/myce/common/controller/ExpoAdminBusinessProfileController.java
+++ b/src/main/java/com/myce/common/controller/ExpoAdminBusinessProfileController.java
@@ -1,6 +1,7 @@
 package com.myce.common.controller;
 
 import com.myce.auth.dto.CustomUserDetails;
+import com.myce.auth.dto.type.LoginType;
 import com.myce.common.dto.ExpoAdminBusinessProfileRequestDto;
 import com.myce.common.dto.ExpoAdminBusinessProfileResponseDto;
 import com.myce.common.service.ExpoAdminBusinessProfileService;
@@ -16,20 +17,22 @@ public class ExpoAdminBusinessProfileController {
 
     private final ExpoAdminBusinessProfileService service;
 
-    @GetMapping//TODO:하위관리자
+    @GetMapping
     public ResponseEntity<ExpoAdminBusinessProfileResponseDto> getMyBusinessProfile(
             @PathVariable Long expoId,
             @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         Long memberId = customUserDetails.getMemberId();
-        return ResponseEntity.ok(service.getMyBusinessProfile(expoId,memberId));
+        LoginType loginType = customUserDetails.getLoginType();
+        return ResponseEntity.ok(service.getMyBusinessProfile(expoId,memberId,loginType));
     }
 
-    @PutMapping//TODO:하위관리자
+    @PutMapping
     public ResponseEntity<ExpoAdminBusinessProfileResponseDto> updateMyBusinessProfile(
             @PathVariable Long expoId,
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @RequestBody ExpoAdminBusinessProfileRequestDto dto) {
         Long memberId = customUserDetails.getMemberId();
-        return ResponseEntity.ok(service.updateMyBusinessProfile(expoId,memberId, dto));
+        LoginType loginType = customUserDetails.getLoginType();
+        return ResponseEntity.ok(service.updateMyBusinessProfile(expoId,memberId,loginType,dto));
     }
 }

--- a/src/main/java/com/myce/common/service/ExpoAdminBusinessProfileService.java
+++ b/src/main/java/com/myce/common/service/ExpoAdminBusinessProfileService.java
@@ -1,9 +1,13 @@
 package com.myce.common.service;
 
+import com.myce.auth.dto.type.LoginType;
 import com.myce.common.dto.ExpoAdminBusinessProfileRequestDto;
 import com.myce.common.dto.ExpoAdminBusinessProfileResponseDto;
 
 public interface ExpoAdminBusinessProfileService {
-    ExpoAdminBusinessProfileResponseDto getMyBusinessProfile(Long expoId, Long memberId);
-    ExpoAdminBusinessProfileResponseDto updateMyBusinessProfile(Long expoId, Long memberId, ExpoAdminBusinessProfileRequestDto dto);
+    ExpoAdminBusinessProfileResponseDto getMyBusinessProfile(Long expoId, Long memberId, LoginType loginType);
+    ExpoAdminBusinessProfileResponseDto updateMyBusinessProfile(Long expoId,
+                                                                Long memberId,
+                                                                LoginType loginType,
+                                                                ExpoAdminBusinessProfileRequestDto dto);
 }

--- a/src/main/java/com/myce/common/service/impl/ExpoAdminBusinessProfileServiceImpl.java
+++ b/src/main/java/com/myce/common/service/impl/ExpoAdminBusinessProfileServiceImpl.java
@@ -1,5 +1,6 @@
 package com.myce.common.service.impl;
 
+import com.myce.auth.dto.type.LoginType;
 import com.myce.common.dto.ExpoAdminBusinessProfileRequestDto;
 import com.myce.common.dto.ExpoAdminBusinessProfileResponseDto;
 import com.myce.common.entity.BusinessProfile;
@@ -9,6 +10,7 @@ import com.myce.common.exception.CustomException;
 import com.myce.common.repository.BusinessProfileRepository;
 import com.myce.common.service.ExpoAdminBusinessProfileService;
 import com.myce.common.service.mapper.ExpoAdminBusinessProfileMapper;
+import com.myce.expo.repository.AdminPermissionRepository;
 import com.myce.expo.repository.ExpoRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -20,20 +22,25 @@ public class ExpoAdminBusinessProfileServiceImpl implements ExpoAdminBusinessPro
 
     private final ExpoRepository expoRepository;
     private final BusinessProfileRepository businessProfileRepository;
+    private final AdminPermissionRepository adminPermissionRepository;
     private final ExpoAdminBusinessProfileMapper mapper;
 
-    @Override//TODO:하위관리자
-    public ExpoAdminBusinessProfileResponseDto getMyBusinessProfile(Long expoId, Long memberId) {
-        BusinessProfile profile = validateMyBusinessProfileAccess(expoId, memberId);
+    @Override
+    public ExpoAdminBusinessProfileResponseDto getMyBusinessProfile(Long expoId, Long memberId, LoginType loginType) {
+        validateMyAccess(expoId, memberId, loginType);
+        BusinessProfile profile = getMyBusinessProfile(expoId);
+
         return mapper.toDto(profile);
     }
 
-    @Override//TODO:하위관리자
+    @Override
     @Transactional
     public ExpoAdminBusinessProfileResponseDto updateMyBusinessProfile(Long expoId,
                                         Long memberId,
+                                        LoginType loginType,
                                         ExpoAdminBusinessProfileRequestDto dto) {
-        BusinessProfile profile = validateMyBusinessProfileAccess(expoId, memberId);
+        validateMyAccess(expoId, memberId, loginType);
+        BusinessProfile profile = getMyBusinessProfile(expoId);
 
         profile.updateProfileInfo(
                 dto.getLogoUrl(),
@@ -48,11 +55,28 @@ public class ExpoAdminBusinessProfileServiceImpl implements ExpoAdminBusinessPro
         return mapper.toDto(profile);
     }
 
-    private BusinessProfile validateMyBusinessProfileAccess(Long expoId, Long memberId){
-        if (!expoRepository.existsByIdAndMemberId(expoId, memberId)) {
-            throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
-        }
+    private BusinessProfile getMyBusinessProfile(Long expoId){
         return businessProfileRepository.findByTargetIdAndTargetType(expoId,TargetType.EXPO)
                 .orElseThrow(() -> new CustomException(CustomErrorCode.BUSINESS_NOT_EXIST));
+    }
+
+    private void validateMyAccess(Long expoId, Long memberId, LoginType loginType) {
+        if(memberId == null || loginType == null){
+            throw new CustomException(CustomErrorCode.MEMBER_NOT_EXIST);
+        }
+
+        switch(loginType){
+            case MEMBER -> {
+                if (!expoRepository.existsByIdAndMemberId(expoId, memberId)) {
+                    throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
+                }
+            }
+            case ADMIN_CODE -> {
+                if(!adminPermissionRepository.existsByAdminCodeIdAndAdminCodeExpoIdAndIsOperationsConfigUpdateTrue(memberId, expoId)){
+                    throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
+                }
+            }
+            default -> throw new CustomException(CustomErrorCode.INVALID_LOGIN_TYPE);
+        }
     }
 }

--- a/src/main/java/com/myce/expo/controller/ExpoAdminManagerController.java
+++ b/src/main/java/com/myce/expo/controller/ExpoAdminManagerController.java
@@ -1,6 +1,7 @@
 package com.myce.expo.controller;
 
 import com.myce.auth.dto.CustomUserDetails;
+import com.myce.auth.dto.type.LoginType;
 import com.myce.expo.dto.ExpoAdminManagerRequest;
 import com.myce.expo.dto.ExpoAdminManagerResponse;
 import com.myce.expo.service.ExpoAdminManagerService;
@@ -18,20 +19,22 @@ public class ExpoAdminManagerController {
 
     private final ExpoAdminManagerService service;
 
-    @GetMapping//TODO:하위관리자
+    @GetMapping
     public ResponseEntity<List<ExpoAdminManagerResponse>> getMyExpoManagers(
             @PathVariable Long expoId,
             @AuthenticationPrincipal CustomUserDetails userDetails){
         Long memberId = userDetails.getMemberId();
-        return ResponseEntity.ok(service.getMyExpoManagers(expoId,memberId));
+        LoginType loginType = userDetails.getLoginType();
+        return ResponseEntity.ok(service.getMyExpoManagers(expoId,memberId,loginType));
     }
 
-    @PutMapping//TODO:하위관리자
+    @PutMapping
     public ResponseEntity<List<ExpoAdminManagerResponse>> updateMyExpoManagers(
             @PathVariable Long expoId,
             @RequestBody List<ExpoAdminManagerRequest> dtos,
             @AuthenticationPrincipal CustomUserDetails userDetails){
         Long memberId = userDetails.getMemberId();
-        return ResponseEntity.ok(service.updateMyExpoManagers(expoId,memberId,dtos));
+        LoginType loginType = userDetails.getLoginType();
+        return ResponseEntity.ok(service.updateMyExpoManagers(expoId,memberId,loginType,dtos));
     }
 }

--- a/src/main/java/com/myce/expo/controller/ExpoAdminTicketController.java
+++ b/src/main/java/com/myce/expo/controller/ExpoAdminTicketController.java
@@ -1,6 +1,7 @@
 package com.myce.expo.controller;
 
 import com.myce.auth.dto.CustomUserDetails;
+import com.myce.auth.dto.type.LoginType;
 import com.myce.expo.dto.ExpoAdminTicketRequestDto;
 import com.myce.expo.dto.ExpoAdminTicketResponseDto;
 import com.myce.expo.service.ExpoAdminTicketService;
@@ -20,40 +21,44 @@ public class ExpoAdminTicketController {
 
     private final ExpoAdminTicketService service;
 
-    @GetMapping//TODO:하위관리자
+    @GetMapping
     public ResponseEntity<List<ExpoAdminTicketResponseDto>> getMyExpoTickets(
             @PathVariable Long expoId,
             @AuthenticationPrincipal CustomUserDetails customUserDetails){
         Long memberId = customUserDetails.getMemberId();
-        return ResponseEntity.ok(service.getMyExpoTickets(expoId,memberId));
+        LoginType loginType = customUserDetails.getLoginType();
+        return ResponseEntity.ok(service.getMyExpoTickets(expoId,memberId,loginType));
     }
 
-    @DeleteMapping("/{ticketId}")//TODO:하위관리자
+    @DeleteMapping("/{ticketId}")
     public ResponseEntity<Void> deleteMyExpoTicket(
             @PathVariable Long expoId,
             @PathVariable Long ticketId,
             @AuthenticationPrincipal CustomUserDetails customUserDetails){
         Long memberId = customUserDetails.getMemberId();
-        service.deleteMyExpoTicket(expoId,memberId,ticketId);
+        LoginType loginType = customUserDetails.getLoginType();
+        service.deleteMyExpoTicket(expoId,memberId,loginType,ticketId);
         return ResponseEntity.ok().build();
     }
 
-    @PostMapping//TODO:하위관리자
+    @PostMapping
     public ResponseEntity<ExpoAdminTicketResponseDto> saveMyExpoTicket(
             @PathVariable Long expoId,
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @Valid @RequestBody ExpoAdminTicketRequestDto dto){
         Long memberId = customUserDetails.getMemberId();
-        return ResponseEntity.status(HttpStatus.CREATED).body(service.saveMyExpoTicket(expoId,memberId,dto));
+        LoginType loginType = customUserDetails.getLoginType();
+        return ResponseEntity.status(HttpStatus.CREATED).body(service.saveMyExpoTicket(expoId,memberId,loginType,dto));
     }
 
-    @PutMapping("/{ticketId}")//TODO:하위관리자
+    @PutMapping("/{ticketId}")
     public ResponseEntity<ExpoAdminTicketResponseDto> updateMyExpoTicket(
             @PathVariable Long expoId,
             @PathVariable Long ticketId,
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @Valid @RequestBody ExpoAdminTicketRequestDto dto){
         Long memberId = customUserDetails.getMemberId();
-        return ResponseEntity.ok(service.updateMyExpoTicket(expoId,memberId,ticketId,dto));
+        LoginType loginType = customUserDetails.getLoginType();
+        return ResponseEntity.ok(service.updateMyExpoTicket(expoId,memberId,loginType,ticketId,dto));
     }
 }

--- a/src/main/java/com/myce/expo/dto/ExpoAdminTicketRequestDto.java
+++ b/src/main/java/com/myce/expo/dto/ExpoAdminTicketRequestDto.java
@@ -38,4 +38,22 @@ public class ExpoAdminTicketRequestDto {
         if (saleStartDate == null || saleEndDate == null) return true;
         return !saleEndDate.isBefore(saleStartDate);
     }
+
+    @NotNull(message = "사용 시작일은 필수입니다.")
+    private LocalDate useStartDate;
+
+    @NotNull(message = "사용 종료일은 필수입니다.")
+    private LocalDate useEndDate;
+
+    @AssertTrue(message = "사용 종료일은 시작일과 같거나 이후여야 합니다.")
+    public boolean isUseEndDateValid(){
+        if (useStartDate == null || useEndDate == null) return true;
+        return !useEndDate.isBefore(useStartDate);
+    }
+
+    @AssertTrue(message = "사용 시작일은 판매 시작일과 같거나 이후여야 합니다.")
+    public boolean isUseStartAfterSaleStart(){
+        if (useStartDate == null || saleStartDate == null) return true;
+        return !useStartDate.isBefore(saleStartDate);
+    }
 }

--- a/src/main/java/com/myce/expo/dto/ExpoAdminTicketResponseDto.java
+++ b/src/main/java/com/myce/expo/dto/ExpoAdminTicketResponseDto.java
@@ -16,4 +16,6 @@ public class ExpoAdminTicketResponseDto {
     private Integer totalQuantity;
     private LocalDate saleStartDate;
     private LocalDate saleEndDate;
+    private LocalDate useStartDate;
+    private LocalDate useEndDate;
 }

--- a/src/main/java/com/myce/expo/entity/Ticket.java
+++ b/src/main/java/com/myce/expo/entity/Ticket.java
@@ -50,6 +50,12 @@ public class Ticket {
     @Column(name = "sale_end_date", nullable = false)
     private LocalDate saleEndDate;
 
+    @Column(name = "use_start_date", nullable = false)
+    private LocalDate useStartDate;
+
+    @Column(name = "use_end_date", nullable = false)
+    private LocalDate useEndDate;
+
     @CreationTimestamp
     @Column(name = "created_at", updatable = false, columnDefinition = "TIMESTAMP", nullable = false)
     private LocalDateTime createdAt;
@@ -61,6 +67,7 @@ public class Ticket {
     @Builder
     public Ticket(Expo expo, String name, String description, TicketType type,
                   Integer price, Integer remainingQuantity, Integer totalQuantity,
+                  LocalDate useStartDate, LocalDate useEndDate,
                   LocalDate saleStartDate, LocalDate saleEndDate) {
         this.expo = expo;
         this.name = name;
@@ -69,13 +76,16 @@ public class Ticket {
         this.price = price;
         this.remainingQuantity = remainingQuantity;
         this.totalQuantity = totalQuantity;
+        this.useStartDate = useStartDate;
+        this.useEndDate = useEndDate;
         this.saleStartDate = saleStartDate;
         this.saleEndDate = saleEndDate;
     }
 
     public void updateTicketInfo(String name, String description, TicketType type,
                                  Integer price, Integer remainingQuantity, Integer totalQuantity,
-                                 LocalDate saleStartDate, LocalDate saleEndDate) {
+                                 LocalDate saleStartDate, LocalDate saleEndDate,
+                                 LocalDate useStartDate, LocalDate useEndDate) {
         this.name = name;
         this.description = description;
         this.type = type;
@@ -84,5 +94,7 @@ public class Ticket {
         this.totalQuantity = totalQuantity;
         this.saleStartDate = saleStartDate;
         this.saleEndDate = saleEndDate;
+        this.useStartDate = useStartDate;
+        this.useEndDate = useEndDate;
     }
 }

--- a/src/main/java/com/myce/expo/repository/AdminPermissionRepository.java
+++ b/src/main/java/com/myce/expo/repository/AdminPermissionRepository.java
@@ -1,0 +1,20 @@
+package com.myce.expo.repository;
+
+import com.myce.expo.entity.AdminPermission;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface AdminPermissionRepository extends JpaRepository<AdminPermission, Long> {
+    boolean existsByAdminCodeIdAndAdminCodeExpoIdAndIsExpoDetailUpdateTrue(Long adminCodeId, Long expoId);
+    boolean existsByAdminCodeIdAndAdminCodeExpoIdAndIsBoothInfoUpdateTrue(Long adminCodeId, Long expoId);
+    boolean existsByAdminCodeIdAndAdminCodeExpoIdAndIsScheduleUpdateTrue(Long adminCodeId, Long expoId);
+    boolean existsByAdminCodeIdAndAdminCodeExpoIdAndIsReserverListViewTrue(Long adminCodeId, Long expoId);
+    boolean existsByAdminCodeIdAndAdminCodeExpoIdAndIsPaymentViewTrue(Long adminCodeId, Long expoId);
+    boolean existsByAdminCodeIdAndAdminCodeExpoIdAndIsEmailLogViewTrue(Long adminCodeId, Long expoId);
+    boolean existsByAdminCodeIdAndAdminCodeExpoIdAndIsOperationsConfigUpdateTrue(Long adminCodeId, Long expoId);
+    boolean existsByAdminCodeIdAndAdminCodeExpoIdAndIsSettlementViewTrue(Long adminCodeId, Long expoId);
+    boolean existsByAdminCodeIdAndAdminCodeExpoIdAndIsInquiryViewTrue(Long adminCodeId, Long expoId);
+}

--- a/src/main/java/com/myce/expo/service/ExpoAdminManagerService.java
+++ b/src/main/java/com/myce/expo/service/ExpoAdminManagerService.java
@@ -1,11 +1,15 @@
 package com.myce.expo.service;
 
+import com.myce.auth.dto.type.LoginType;
 import com.myce.expo.dto.ExpoAdminManagerRequest;
 import com.myce.expo.dto.ExpoAdminManagerResponse;
 
 import java.util.List;
 
 public interface ExpoAdminManagerService {
-    List<ExpoAdminManagerResponse> getMyExpoManagers(Long expoId, Long memberId);
-    List<ExpoAdminManagerResponse> updateMyExpoManagers(Long expoId, Long memberId, List<ExpoAdminManagerRequest> dtos);
+    List<ExpoAdminManagerResponse> getMyExpoManagers(Long expoId, Long memberId, LoginType loginType);
+    List<ExpoAdminManagerResponse> updateMyExpoManagers(Long expoId,
+                                                        Long memberId,
+                                                        LoginType loginType,
+                                                        List<ExpoAdminManagerRequest> dtos);
 }

--- a/src/main/java/com/myce/expo/service/ExpoAdminTicketService.java
+++ b/src/main/java/com/myce/expo/service/ExpoAdminTicketService.java
@@ -1,13 +1,23 @@
 package com.myce.expo.service;
 
+import com.myce.auth.dto.type.LoginType;
 import com.myce.expo.dto.ExpoAdminTicketRequestDto;
 import com.myce.expo.dto.ExpoAdminTicketResponseDto;
 
 import java.util.List;
 
 public interface ExpoAdminTicketService {
-    List<ExpoAdminTicketResponseDto> getMyExpoTickets(Long expoId, Long memberId);
-    void deleteMyExpoTicket(Long expoId, Long memberId, Long ticketId);
-    ExpoAdminTicketResponseDto saveMyExpoTicket(Long expoId, Long memberId, ExpoAdminTicketRequestDto dto);
-    ExpoAdminTicketResponseDto updateMyExpoTicket(Long expoId, Long memberId, Long ticketId, ExpoAdminTicketRequestDto dto);
+    List<ExpoAdminTicketResponseDto> getMyExpoTickets(Long expoId, Long memberId, LoginType loginType);
+
+    void deleteMyExpoTicket(Long expoId, Long memberId, LoginType loginType, Long ticketId);
+
+    ExpoAdminTicketResponseDto saveMyExpoTicket(Long expoId,
+                                                Long memberId,
+                                                LoginType loginType,
+                                                ExpoAdminTicketRequestDto dto);
+    ExpoAdminTicketResponseDto updateMyExpoTicket(Long expoId,
+                                                  Long memberId,
+                                                  LoginType loginType,
+                                                  Long ticketId,
+                                                  ExpoAdminTicketRequestDto dto);
 }

--- a/src/main/java/com/myce/expo/service/impl/ExpoAdminManagerServiceImpl.java
+++ b/src/main/java/com/myce/expo/service/impl/ExpoAdminManagerServiceImpl.java
@@ -1,5 +1,6 @@
 package com.myce.expo.service.impl;
 
+import com.myce.auth.dto.type.LoginType;
 import com.myce.common.exception.CustomErrorCode;
 import com.myce.common.exception.CustomException;
 import com.myce.expo.dto.ExpoAdminManagerRequest;
@@ -7,6 +8,7 @@ import com.myce.expo.dto.ExpoAdminManagerResponse;
 import com.myce.expo.entity.AdminCode;
 import com.myce.expo.entity.AdminPermission;
 import com.myce.expo.repository.AdminCodeRepository;
+import com.myce.expo.repository.AdminPermissionRepository;
 import com.myce.expo.repository.ExpoRepository;
 import com.myce.expo.service.ExpoAdminManagerService;
 import com.myce.expo.service.mapper.ExpoAdminMangerMapper;
@@ -23,12 +25,13 @@ import java.util.stream.Collectors;
 public class ExpoAdminManagerServiceImpl implements ExpoAdminManagerService {
 
     private final AdminCodeRepository adminCodeRepository;
+    private final AdminPermissionRepository adminPermissionRepository;
     private final ExpoRepository expoRepository;
     private final ExpoAdminMangerMapper mapper;
 
-    @Override//TODO:하위관리자
-    public List<ExpoAdminManagerResponse> getMyExpoManagers(Long expoId, Long memberId) {
-        validateMyExpoAccess(expoId, memberId);
+    @Override
+    public List<ExpoAdminManagerResponse> getMyExpoManagers(Long expoId, Long memberId, LoginType loginType) {
+        validateMyAccess(expoId, memberId, loginType);
         List<AdminCode> adminCodes = adminCodeRepository.findAllWithAdminPermissionByExpoId(expoId);
 
         return adminCodes.stream()
@@ -37,13 +40,14 @@ public class ExpoAdminManagerServiceImpl implements ExpoAdminManagerService {
     }
 
     @Override
-    @Transactional//TODO:하위관리자
+    @Transactional
     public List<ExpoAdminManagerResponse> updateMyExpoManagers(
             Long expoId,
             Long memberId,
+            LoginType loginType,
             List<ExpoAdminManagerRequest> dtos) {
 
-        validateMyExpoAccess(expoId, memberId);
+        validateMyAccess(expoId, memberId, loginType);
 
         List<Long> ids = dtos.stream()
                 .map(ExpoAdminManagerRequest::getId)
@@ -73,9 +77,23 @@ public class ExpoAdminManagerServiceImpl implements ExpoAdminManagerService {
                 .toList();
     }
 
-    private void validateMyExpoAccess(Long expoId, Long memberId) {
-        if (!expoRepository.existsByIdAndMemberId(expoId, memberId)) {
-            throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
+    private void validateMyAccess(Long expoId, Long memberId, LoginType loginType) {
+        if(memberId == null || loginType == null){
+            throw new CustomException(CustomErrorCode.MEMBER_NOT_EXIST);
+        }
+
+        switch(loginType){
+            case MEMBER -> {
+                if (!expoRepository.existsByIdAndMemberId(expoId, memberId)) {
+                    throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
+                }
+            }
+            case ADMIN_CODE -> {
+                if(!adminPermissionRepository.existsByAdminCodeIdAndAdminCodeExpoIdAndIsOperationsConfigUpdateTrue(memberId, expoId)){
+                    throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
+                }
+            }
+            default -> throw new CustomException(CustomErrorCode.INVALID_LOGIN_TYPE);
         }
     }
 }

--- a/src/main/java/com/myce/expo/service/impl/ExpoAdminTicketServiceImpl.java
+++ b/src/main/java/com/myce/expo/service/impl/ExpoAdminTicketServiceImpl.java
@@ -91,7 +91,9 @@ public class ExpoAdminTicketServiceImpl implements ExpoAdminTicketService {
                 dto.getTotalQuantity(),
                 dto.getTotalQuantity(),
                 dto.getSaleStartDate(),
-                dto.getSaleEndDate()
+                dto.getSaleEndDate(),
+                dto.getUseStartDate(),
+                dto.getUseEndDate()
         );
 
        return mapper.toDto(ticket);

--- a/src/main/java/com/myce/expo/service/impl/ExpoAdminTicketServiceImpl.java
+++ b/src/main/java/com/myce/expo/service/impl/ExpoAdminTicketServiceImpl.java
@@ -1,5 +1,6 @@
 package com.myce.expo.service.impl;
 
+import com.myce.auth.dto.type.LoginType;
 import com.myce.common.exception.CustomErrorCode;
 import com.myce.common.exception.CustomException;
 import com.myce.expo.dto.ExpoAdminTicketRequestDto;
@@ -7,6 +8,7 @@ import com.myce.expo.dto.ExpoAdminTicketResponseDto;
 import com.myce.expo.entity.Expo;
 import com.myce.expo.entity.Ticket;
 import com.myce.expo.entity.type.TicketType;
+import com.myce.expo.repository.AdminPermissionRepository;
 import com.myce.expo.repository.ExpoRepository;
 import com.myce.expo.repository.TicketRepository;
 import com.myce.expo.service.ExpoAdminTicketService;
@@ -24,20 +26,21 @@ public class ExpoAdminTicketServiceImpl implements ExpoAdminTicketService {
     private final TicketRepository ticketRepository;
     private final ExpoRepository expoRepository;
     private final ExpoAdminTicketMapper mapper;
+    private final AdminPermissionRepository adminPermissionRepository;
 
-    @Override//TODO:하위 관리자
-    public List<ExpoAdminTicketResponseDto> getMyExpoTickets(Long expoId, Long memberId) {
-        validateMyExpoAccess(expoId, memberId);
+    @Override
+    public List<ExpoAdminTicketResponseDto> getMyExpoTickets(Long expoId, Long memberId, LoginType loginType) {
+        validateMyAccess(expoId, memberId, loginType);
         List<Ticket> tickets = ticketRepository.findByExpoId(expoId);
         return tickets.stream()
                 .map(mapper::toDto)
                 .toList();
     }
 
-    @Override//TODO:하위 관리자
+    @Override
     @Transactional
-    public void deleteMyExpoTicket(Long expoId, Long memberId, Long ticketId) {
-        validateMyExpoAccess(expoId, memberId);
+    public void deleteMyExpoTicket(Long expoId, Long memberId, LoginType loginType, Long ticketId) {
+        validateMyAccess(expoId, memberId, loginType);
 
         Ticket ticket = ticketRepository.findById(ticketId)
                 .orElseThrow(()-> new CustomException(CustomErrorCode.TICKET_NOT_EXIST));
@@ -49,23 +52,29 @@ public class ExpoAdminTicketServiceImpl implements ExpoAdminTicketService {
         ticketRepository.delete(ticket);
     }
 
-    @Override//TODO:하위 관리자
+    @Override
     @Transactional
-    public ExpoAdminTicketResponseDto saveMyExpoTicket(Long expoId, Long memberId, ExpoAdminTicketRequestDto dto) {
-        Expo expo =  getMyExpo(expoId,memberId);
+    public ExpoAdminTicketResponseDto saveMyExpoTicket(Long expoId,
+                                                       Long memberId,
+                                                       LoginType loginType,
+                                                       ExpoAdminTicketRequestDto dto) {
+        validateMyAccess(expoId, memberId, loginType);
+
+        Expo expo =  getMyExpo(expoId);
         Ticket ticket = mapper.toEntity(dto,expo);
         Ticket saved = ticketRepository.save(ticket);
 
         return mapper.toDto(saved);
     }
 
-    @Override//TODO:하위 관리자
+    @Override
     @Transactional
     public ExpoAdminTicketResponseDto updateMyExpoTicket(Long expoId,
                                                          Long memberId,
+                                                         LoginType loginType,
                                                          Long ticketId,
                                                          ExpoAdminTicketRequestDto dto) {
-        validateMyExpoAccess(expoId, memberId);
+        validateMyAccess(expoId, memberId, loginType);
 
         Ticket ticket = ticketRepository.findById(ticketId)
                 .orElseThrow(()-> new CustomException(CustomErrorCode.TICKET_NOT_EXIST));
@@ -85,25 +94,31 @@ public class ExpoAdminTicketServiceImpl implements ExpoAdminTicketService {
                 dto.getSaleEndDate()
         );
 
-       Ticket saved = ticketRepository.save(ticket);
-
-       return mapper.toDto(saved);
+       return mapper.toDto(ticket);
     }
 
-    private Expo getMyExpo(Long expoId, Long memberId) {
-        Expo expo = expoRepository.findById(expoId)
+    private Expo getMyExpo(Long expoId) {
+        return expoRepository.findById(expoId)
                 .orElseThrow(() -> new CustomException(CustomErrorCode.EXPO_NOT_EXIST));
+    }
 
-        if (!expo.getMember().getId().equals(memberId)) {
-            throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
+    private void validateMyAccess(Long expoId, Long memberId, LoginType loginType) {
+        if(memberId == null || loginType == null){
+            throw new CustomException(CustomErrorCode.MEMBER_NOT_EXIST);
         }
 
-        return expo;
-    }
-
-    private void validateMyExpoAccess(Long expoId, Long memberId) {
-        if (!expoRepository.existsByIdAndMemberId(expoId, memberId)) {
-            throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
+        switch(loginType){
+            case MEMBER -> {
+                if (!expoRepository.existsByIdAndMemberId(expoId, memberId)) {
+                    throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
+                }
+            }
+            case ADMIN_CODE -> {
+                if(!adminPermissionRepository.existsByAdminCodeIdAndAdminCodeExpoIdAndIsExpoDetailUpdateTrue(memberId, expoId)){
+                    throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
+                }
+            }
+            default -> throw new CustomException(CustomErrorCode.INVALID_LOGIN_TYPE);
         }
     }
 }

--- a/src/main/java/com/myce/expo/service/mapper/ExpoAdminTicketMapper.java
+++ b/src/main/java/com/myce/expo/service/mapper/ExpoAdminTicketMapper.java
@@ -19,6 +19,8 @@ public class ExpoAdminTicketMapper {
                 .totalQuantity(ticket.getTotalQuantity())
                 .saleStartDate(ticket.getSaleStartDate())
                 .saleEndDate(ticket.getSaleEndDate())
+                .useStartDate(ticket.getUseStartDate())
+                .useEndDate(ticket.getUseEndDate())
                 .build();
     }
 
@@ -33,6 +35,8 @@ public class ExpoAdminTicketMapper {
                 .totalQuantity(dto.getTotalQuantity())
                 .saleStartDate(dto.getSaleStartDate())
                 .saleEndDate(dto.getSaleEndDate())
+                .useStartDate(dto.getUseStartDate())
+                .useEndDate(dto.getUseEndDate())
                 .build();
     }
 }

--- a/src/main/java/com/myce/reservation/controller/ExpoAdminPaymentController.java
+++ b/src/main/java/com/myce/reservation/controller/ExpoAdminPaymentController.java
@@ -1,6 +1,7 @@
 package com.myce.reservation.controller;
 
 import com.myce.auth.dto.CustomUserDetails;
+import com.myce.auth.dto.type.LoginType;
 import com.myce.reservation.dto.ExpoAdminPaymentResponse;
 import com.myce.reservation.entity.code.ReservationStatus;
 import com.myce.reservation.service.ExpoAdminPaymentService;
@@ -20,7 +21,7 @@ public class ExpoAdminPaymentController {
 
     private final ExpoAdminPaymentService service;
 
-    @GetMapping//TODO:하위관리자
+    @GetMapping
     public ResponseEntity<Page<ExpoAdminPaymentResponse>> getExpoAdminPayment(
             @PathVariable Long expoId,
             @RequestParam(defaultValue = "desc") String sort,
@@ -31,10 +32,12 @@ public class ExpoAdminPaymentController {
             @RequestParam(required = false) String phone,
             @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         Long memberId = customUserDetails.getMemberId();
+        LoginType loginType = customUserDetails.getLoginType();
+
         Sort.Direction direction = sort.equalsIgnoreCase("asc") ? Sort.Direction.ASC : Sort.Direction.DESC;
         Pageable pageable = PageRequest.of(page, size, Sort.by(direction, "createdAt"));
 
-        Page<ExpoAdminPaymentResponse> result = service.getMyExpoPayments(expoId, memberId, status, name, phone, pageable);
+        Page<ExpoAdminPaymentResponse> result = service.getMyExpoPayments(expoId, memberId, loginType, status, name, phone, pageable);
 
         return ResponseEntity.ok(result);
     }

--- a/src/main/java/com/myce/reservation/service/ExpoAdminPaymentService.java
+++ b/src/main/java/com/myce/reservation/service/ExpoAdminPaymentService.java
@@ -1,5 +1,6 @@
 package com.myce.reservation.service;
 
+import com.myce.auth.dto.type.LoginType;
 import com.myce.reservation.dto.ExpoAdminPaymentResponse;
 import com.myce.reservation.entity.code.ReservationStatus;
 import org.springframework.data.domain.Page;
@@ -8,6 +9,7 @@ import org.springframework.data.domain.Pageable;
 public interface ExpoAdminPaymentService {
     Page<ExpoAdminPaymentResponse> getMyExpoPayments(Long expoId,
                                                      Long memberId,
+                                                     LoginType loginType,
                                                      ReservationStatus status,
                                                      String name,
                                                      String phone,

--- a/src/main/java/com/myce/reservation/service/Impl/ExpoAdminPaymentServiceImpl.java
+++ b/src/main/java/com/myce/reservation/service/Impl/ExpoAdminPaymentServiceImpl.java
@@ -1,7 +1,9 @@
 package com.myce.reservation.service.Impl;
 
+import com.myce.auth.dto.type.LoginType;
 import com.myce.common.exception.CustomErrorCode;
 import com.myce.common.exception.CustomException;
+import com.myce.expo.repository.AdminPermissionRepository;
 import com.myce.expo.repository.ExpoRepository;
 import com.myce.reservation.dto.ExpoAdminPaymentBasicResponse;
 import com.myce.reservation.dto.ExpoAdminPaymentResponse;
@@ -20,23 +22,43 @@ public class ExpoAdminPaymentServiceImpl implements ExpoAdminPaymentService {
 
     private final ExpoRepository expoRepository;
     private final ReservationRepository reservationRepository;
+    private final AdminPermissionRepository adminPermissionRepository;
     private final ExpoAdminPaymentMapper mapper;
 
-    @Override//TODO:하위관리자
+    @Override
     public Page<ExpoAdminPaymentResponse> getMyExpoPayments(Long expoId,
                                                             Long memberId,
+                                                            LoginType loginType,
                                                             ReservationStatus status,
                                                             String name,
                                                             String phone,
                                                             Pageable pageable) {
 
-        if(!expoRepository.existsByIdAndMemberId(expoId, memberId)){
-            throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
-        }
+        validateMyAccess(expoId, memberId, loginType);
 
         Page<ExpoAdminPaymentBasicResponse> responses =
                 reservationRepository.findAllResponsesByExpoId(expoId, status, name, phone, pageable);
 
         return responses.map(mapper::toDto);
+    }
+
+    private void validateMyAccess(Long expoId, Long memberId, LoginType loginType) {
+        if(memberId == null || loginType == null){
+            throw new CustomException(CustomErrorCode.MEMBER_NOT_EXIST);
+        }
+
+        switch(loginType){
+            case MEMBER -> {
+                if (!expoRepository.existsByIdAndMemberId(expoId, memberId)) {
+                    throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
+                }
+            }
+            case ADMIN_CODE -> {
+                if(!adminPermissionRepository.existsByAdminCodeIdAndAdminCodeExpoIdAndIsPaymentViewTrue(memberId, expoId)){
+                    throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
+                }
+            }
+            default -> throw new CustomException(CustomErrorCode.INVALID_LOGIN_TYPE);
+        }
     }
 }


### PR DESCRIPTION
## 구현 기능
### 박람회 하위 관리자 권한 체크 로직 추가
- 로그인한 사용자의 memberId와 loginType을 사용하여 박람회 상위/하위 관리자의 권한 체크 로직을 추가하였습니다.

### ticket 테이블 컬럼 추가(useStartDate, useEndDate)로 인한 ticket CRUD 로직 수정
- request/response dto에 useStartDate와 useEndDate를 추가하였습니다.