### PR TITLE
[CRM-247] QR코드 스케쥴러 수정 및 실시간 혼잡도 체크 API 구현

### DIFF
--- a/src/main/java/com/myce/common/exception/CustomErrorCode.java
+++ b/src/main/java/com/myce/common/exception/CustomErrorCode.java
@@ -41,6 +41,7 @@ public enum CustomErrorCode {
     RESERVER_NOT_FOUND(HttpStatus.NOT_FOUND, "Q007", "예약자를 찾을 수 없습니다."),
     QR_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Q008", "QR 코드 생성 중 오류가 발생했습니다."),
     QR_REISSUE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Q009", "QR 코드 재발급 중 오류가 발생했습니다."),
+    QR_APPROVED(HttpStatus.BAD_REQUEST , "Q010" , "QR 코드 발급 기간이 아닙니다."  ),
 
     // S3 S
     S3_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S001", "S3 파일 업로드에 실패했습니다."),

--- a/src/main/java/com/myce/expo/controller/ExpoController.java
+++ b/src/main/java/com/myce/expo/controller/ExpoController.java
@@ -1,6 +1,7 @@
 package com.myce.expo.controller;
 
 import com.myce.auth.dto.CustomUserDetails;
+import com.myce.expo.dto.CongestionResponse;
 import com.myce.expo.dto.ExpoRegistrationRequest;
 import com.myce.expo.service.ExpoService;
 import jakarta.validation.Valid;
@@ -25,5 +26,12 @@ public class ExpoController {
         Long memberId = customUserDetails.getMemberId();
         exposervice.saveExpo(memberId, expoRegistrationRequest);
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+    
+    // 박람회 실시간 혼잡도 조회
+    @GetMapping("/{expoId}/congestion")
+    public ResponseEntity<CongestionResponse> getCongestionLevel(@PathVariable Long expoId) {
+        CongestionResponse congestionResponse = exposervice.getCongestionLevel(expoId);
+        return ResponseEntity.ok(congestionResponse);
     }
 }

--- a/src/main/java/com/myce/expo/dto/CongestionResponse.java
+++ b/src/main/java/com/myce/expo/dto/CongestionResponse.java
@@ -1,0 +1,40 @@
+package com.myce.expo.dto;
+
+import com.myce.expo.entity.type.CongestionLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CongestionResponse {
+    
+    private Long expoId;
+    private String expoTitle;
+    private long hourlyVisitors;        // 현재 입장자 수 (1시간 내)
+    private int hourlyCapacity;             // 1시간 내 적정 입장자 수
+    private double congestionPercentage; // 혼잡도 비율 (%)
+    private CongestionLevel level;       // 혼잡도 레벨
+    private String levelDisplayName;     // 혼잡도 레벨 표시명
+    private String message;              // 혼잡도 메시지
+    private String lastUpdated;          // 마지막 업데이트 시간
+    
+    public static CongestionResponse of(Long expoId, String expoTitle, 
+                                       long hourlyVisitors, int hourlyCapacity) {
+        double percentage = hourlyCapacity > 0 ?
+            (double) hourlyVisitors / hourlyCapacity * 100 : 0.0;
+        
+        CongestionLevel level = CongestionLevel.fromPercentage(percentage);
+        
+        return CongestionResponse.builder()
+                .expoId(expoId)
+                .expoTitle(expoTitle)
+                .hourlyVisitors(hourlyVisitors)
+                .hourlyCapacity(hourlyCapacity)
+                .congestionPercentage(Math.round(percentage * 100.0) / 100.0) // 소수점 2자리
+                .level(level)
+                .levelDisplayName(level.getDisplayName())
+                .message(level.getMessage())
+                .lastUpdated(java.time.LocalDateTime.now().toString())
+                .build();
+    }
+}

--- a/src/main/java/com/myce/expo/entity/type/CongestionLevel.java
+++ b/src/main/java/com/myce/expo/entity/type/CongestionLevel.java
@@ -1,0 +1,37 @@
+package com.myce.expo.entity.type;
+
+public enum CongestionLevel {
+    
+    LOW("여유", "입장하기 좋은 시간입니다"),
+    MODERATE("보통", "적당한 인원이 방문 중입니다"),
+    HIGH("혼잡", "많은 인원이 방문 중입니다"),
+    VERY_HIGH("매우혼잡", "입장 대기가 있을 수 있습니다");
+    
+    private final String displayName;
+    private final String message;
+    
+    CongestionLevel(String displayName, String message) {
+        this.displayName = displayName;
+        this.message = message;
+    }
+    
+    public String getDisplayName() {
+        return displayName;
+    }
+    
+    public String getMessage() {
+        return message;
+    }
+    
+    public static CongestionLevel fromPercentage(double percentage) {
+        if (percentage <= 25.0) {
+            return LOW;
+        } else if (percentage <= 50.0) {
+            return MODERATE;
+        } else if (percentage <= 75.0) {
+            return HIGH;
+        } else {
+            return VERY_HIGH;
+        }
+    }
+}

--- a/src/main/java/com/myce/expo/repository/ExpoRepository.java
+++ b/src/main/java/com/myce/expo/repository/ExpoRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -26,5 +27,8 @@ public interface ExpoRepository extends JpaRepository<Expo, Long> {
 
     List<Expo> findByMemberIdOrderByCreatedAtDesc(Long memberId);
     Boolean existsByIdAndMemberId(Long id, Long memberId);
+    
+    // QR코드 일괄 생성용 - 시작일이 특정 날짜이고 게시된 박람회 조회
+    List<Expo> findByStartDateAndStatus(LocalDate startDate, ExpoStatus status);
 }
 

--- a/src/main/java/com/myce/expo/service/ExpoService.java
+++ b/src/main/java/com/myce/expo/service/ExpoService.java
@@ -1,9 +1,12 @@
 package com.myce.expo.service;
 
+import com.myce.expo.dto.CongestionResponse;
 import com.myce.expo.dto.ExpoRegistrationRequest;
 
 public interface ExpoService {
 
     void saveExpo(Long memberId, ExpoRegistrationRequest request);
+    
+    CongestionResponse getCongestionLevel(Long expoId);
 }
 

--- a/src/main/java/com/myce/expo/service/impl/ExpoServiceImpl.java
+++ b/src/main/java/com/myce/expo/service/impl/ExpoServiceImpl.java
@@ -7,6 +7,7 @@ import com.myce.common.exception.CustomErrorCode;
 import com.myce.common.exception.CustomException;
 import com.myce.common.repository.BusinessProfileRepository;
 import com.myce.common.service.mapper.BusinessProfileMapper;
+import com.myce.expo.dto.CongestionResponse;
 import com.myce.expo.dto.ExpoRegistrationRequest;
 import com.myce.expo.entity.Category;
 import com.myce.expo.entity.Expo;
@@ -17,19 +18,25 @@ import com.myce.expo.service.ExpoService;
 import com.myce.expo.service.mapper.ExpoMapper;
 import com.myce.member.entity.Member;
 import com.myce.member.repository.MemberRepository;
+import com.myce.qrcode.repository.QrCodeRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
 
 @Service
 @Transactional
 @RequiredArgsConstructor
+@Slf4j
 public class ExpoServiceImpl implements ExpoService {
 
     private final MemberRepository memberRepository;
     private final ExpoRepository expoRepository;
     private final CategoryRepository categoryRepository;
     private final BusinessProfileRepository businessProfileRepository;
+    private final QrCodeRepository qrCodeRepository;
 
     @Override
     public void saveExpo(Long memberId, ExpoRegistrationRequest request) {
@@ -62,5 +69,54 @@ public class ExpoServiceImpl implements ExpoService {
         BusinessProfile businessProfile = BusinessProfileMapper.toEntity(company, TargetType.EXPO, savedExpo.getId());
 
         businessProfileRepository.save(businessProfile);
+    }
+    
+    @Override
+    @Transactional(readOnly = true)
+    public CongestionResponse getCongestionLevel(Long expoId) {
+        log.info("박람회 혼잡도 조회 시작 - 박람회 ID: {}", expoId);
+        
+        // 박람회 정보 조회
+        Expo expo = expoRepository.findById(expoId)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.EXPO_NOT_FOUND));
+        
+        // 현재 시간 기준 1시간 전부터 현재까지 입장한 인원 수 조회
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime oneHourAgo = now.minusHours(1);
+        
+        long hourlyVisitors = qrCodeRepository.countRecentlyUsedQrCodesByExpo(
+                expoId, oneHourAgo, now);
+        
+        // 시간당 수용 인원 계산
+        int hourlyCapacity = calculateHourlyCapacity(expo);
+        
+        log.info("박람회 혼잡도 - 박람회: {}, 현재 1시간 입장자: {}, 시간당 수용인원: {}", 
+                expo.getTitle(), hourlyVisitors, hourlyCapacity);
+        
+        return CongestionResponse.of(expoId, expo.getTitle(),
+                hourlyVisitors, hourlyCapacity);
+    }
+    
+    /**
+     * 시간당 수용 인원 계산
+     * = 총 수용인원 / 박람회 기간(일) / 하루 운영시간
+     */
+    private int calculateHourlyCapacity(Expo expo) {
+        // 박람회 기간 계산 (일수)
+        long expoDays = expo.getStartDate().until(expo.getEndDate()).getDays() + 1;
+        
+        // 하루 운영 시간 계산
+        long dailyHours = expo.getStartTime().until(expo.getEndTime(), java.time.temporal.ChronoUnit.HOURS);
+        
+        // 시간당 수용 인원 = 총 수용인원 / 총 운영시간
+        long totalOperatingHours = expoDays * dailyHours;
+        
+        int hourlyCapacity = totalOperatingHours > 0 ? 
+            (int) (expo.getMaxReserverCount() / totalOperatingHours) : expo.getMaxReserverCount();
+            
+        log.debug("시간당 수용인원 계산 - 박람회기간: {}일, 일일운영시간: {}시간, 총운영시간: {}시간, 시간당수용인원: {}", 
+                expoDays, dailyHours, totalOperatingHours, hourlyCapacity);
+                
+        return hourlyCapacity;
     }
 }

--- a/src/main/java/com/myce/qrcode/repository/QrCodeRepository.java
+++ b/src/main/java/com/myce/qrcode/repository/QrCodeRepository.java
@@ -4,6 +4,9 @@ import com.myce.qrcode.entity.QrCode;
 import com.myce.qrcode.entity.code.QrCodeStatus;
 import com.myce.reservation.entity.Reserver;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
@@ -20,5 +23,41 @@ public interface QrCodeRepository extends JpaRepository<QrCode, Long> {
     // 스케줄링용 메서드들
     List<QrCode> findByStatusAndActivatedAtBefore(QrCodeStatus status, LocalDateTime activatedAt);
     List<QrCode> findByStatusAndExpiredAtBefore(QrCodeStatus status, LocalDateTime expiredAt);
+    
+    // 혼잡도 계산용 - 특정 박람회의 1시간 내 입장자 수 조회
+    @Query("SELECT COUNT(qr) FROM QrCode qr " +
+           "JOIN qr.reserver r " +
+           "JOIN r.reservation res " +
+           "WHERE res.expo.id = :expoId " +
+           "AND qr.usedAt >= :oneHourAgo " +
+           "AND qr.usedAt <= :now")
+    long countRecentlyUsedQrCodesByExpo(@Param("expoId") Long expoId, 
+                                       @Param("oneHourAgo") LocalDateTime oneHourAgo,
+                                       @Param("now") LocalDateTime now);
+    
+    // QR코드 일괄 생성용 - 특정 박람회의 QR코드가 이미 생성된 예약자 수 확인
+    @Query("SELECT COUNT(qr) FROM QrCode qr " +
+           "JOIN qr.reserver r " +
+           "JOIN r.reservation res " +
+           "WHERE res.expo.id = :expoId")
+    long countExistingQrCodesByExpo(@Param("expoId") Long expoId);
+    
+    // QR코드 상태 일괄 업데이트 - APPROVED -> ACTIVE
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE QrCode qr SET qr.status = :newStatus " +
+           "WHERE qr.status = :currentStatus " +
+           "AND qr.activatedAt <= :currentTime")
+    int bulkUpdateStatusToActive(@Param("currentStatus") QrCodeStatus currentStatus,
+                                @Param("newStatus") QrCodeStatus newStatus,
+                                @Param("currentTime") LocalDateTime currentTime);
+    
+    // QR코드 상태 일괄 업데이트 - ACTIVE -> EXPIRED
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE QrCode qr SET qr.status = :newStatus " +
+           "WHERE qr.status = :currentStatus " +
+           "AND qr.expiredAt <= :currentTime")
+    int bulkUpdateStatusToExpired(@Param("currentStatus") QrCodeStatus currentStatus,
+                                 @Param("newStatus") QrCodeStatus newStatus,
+                                 @Param("currentTime") LocalDateTime currentTime);
 
 }

--- a/src/main/java/com/myce/qrcode/service/impl/QrCodeServiceImpl.java
+++ b/src/main/java/com/myce/qrcode/service/impl/QrCodeServiceImpl.java
@@ -103,6 +103,10 @@ public class QrCodeServiceImpl implements QrCodeService {
             throw new CustomException(CustomErrorCode.QR_EXPIRED);
         }
 
+        if (qr.getStatus() == QrCodeStatus.APPROVED) {
+            throw new CustomException(CustomErrorCode.QR_APPROVED);
+        }
+
         qr.markAsUsed();
         log.info("QR 코드 사용 처리 완료 - QR ID: {}, 예약자 ID: {}", 
                 qr.getId(), qr.getReserver().getId());
@@ -204,10 +208,11 @@ public class QrCodeServiceImpl implements QrCodeService {
     }
 
     /**
-     * 티켓의 use_end_date 당일 23:59:59로 만료 시간 계산
+     * 티켓의 use_end_date 다음날 00:00:00으로 만료 시간 계산
+     * (use_end_date 당일 종일 사용 가능하도록)
      */
     private LocalDateTime calculateExpiredAt(Reserver reserver) {
         LocalDate ticketUseEndDate = reserver.getReservation().getTicket().getUseEndDate();
-        return ticketUseEndDate.atTime(23, 59, 59);
+        return ticketUseEndDate.plusDays(1).atStartOfDay();
     }
 }

--- a/src/main/java/com/myce/reservation/repository/ReserverRepository.java
+++ b/src/main/java/com/myce/reservation/repository/ReserverRepository.java
@@ -3,6 +3,8 @@ package com.myce.reservation.repository;
 import com.myce.reservation.entity.Reservation;
 import com.myce.reservation.entity.Reserver;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -11,4 +13,11 @@ import java.util.List;
 public interface ReserverRepository extends JpaRepository<Reserver, Long> {
     
     List<Reserver> findByReservation(Reservation reservation);
+    
+    // QR코드 일괄 생성용 - 특정 박람회의 모든 예약자 조회 (QR코드가 없는 경우만)
+    @Query("SELECT r FROM Reserver r " +
+           "JOIN r.reservation res " +
+           "WHERE res.expo.id = :expoId " +
+           "AND NOT EXISTS (SELECT 1 FROM QrCode qr WHERE qr.reserver = r)")
+    List<Reserver> findReserversWithoutQrCodeByExpo(@Param("expoId") Long expoId);
 }

--- a/src/main/java/com/myce/schedule/jobs/ExpoQrGenerateScheduler.java
+++ b/src/main/java/com/myce/schedule/jobs/ExpoQrGenerateScheduler.java
@@ -1,0 +1,99 @@
+package com.myce.schedule.jobs;
+
+import com.myce.expo.entity.Expo;
+import com.myce.expo.entity.type.ExpoStatus;
+import com.myce.expo.repository.ExpoRepository;
+import com.myce.qrcode.service.QrCodeService;
+import com.myce.reservation.entity.Reserver;
+import com.myce.reservation.repository.ReserverRepository;
+import com.myce.schedule.TaskScheduler;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import jakarta.annotation.PostConstruct;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ExpoQrGenerateScheduler implements TaskScheduler {
+
+    private final ExpoRepository expoRepository;
+    private final ReserverRepository reserverRepository;
+    private final QrCodeService qrCodeService;
+
+    @Value("${scheduler.expo-qr-generate:0 0 0 * * *}")
+    private String cronExpression;
+
+    @PostConstruct
+    public void init() {
+        log.info("박람회 QR코드 일괄 생성 스케줄러가 등록되었습니다. cron: {}", cronExpression);
+    }
+
+    @Override
+    @Transactional
+    @Scheduled(cron = "${scheduler.expo-qr-generate:0 0 0 * * *}")
+    public void run() {
+        try {
+            process();
+        } catch (Exception e) {
+            log.error("박람회 QR코드 일괄 생성 스케줄러 실행 중 오류 발생", e);
+        }
+    }
+
+    @Transactional
+    public void process() {
+        log.info("박람회 QR코드 일괄 생성 프로세스 시작");
+        
+        // 이틀 후 시작하는 게시된 박람회들 조회
+        LocalDate twoDaysLater = LocalDate.now().plusDays(2);
+        
+        List<Expo> targetExpos = expoRepository.findByStartDateAndStatus(twoDaysLater, ExpoStatus.PUBLISHED);
+        
+        log.info("QR코드 생성 대상 박람회 수: {} 개 ({})", targetExpos.size(), twoDaysLater);
+        
+        for (Expo expo : targetExpos) {
+            generateQrCodesForExpo(expo);
+        }
+        
+        log.info("박람회 QR코드 일괄 생성 프로세스 완료");
+    }
+
+    private void generateQrCodesForExpo(Expo expo) {
+        log.info("박람회 QR코드 생성 시작 - 박람회: {} (ID: {})", expo.getTitle(), expo.getId());
+        
+        // QR코드가 없는 예약자들만 조회
+        List<Reserver> reserversWithoutQr = reserverRepository.findReserversWithoutQrCodeByExpo(expo.getId());
+        
+        if (reserversWithoutQr.isEmpty()) {
+            log.info("QR코드 생성 대상이 없습니다 - 박람회: {}", expo.getTitle());
+            return;
+        }
+        
+        log.info("QR코드 생성 시작 - 박람회: {}, 대상 예약자 수: {} 명", 
+                expo.getTitle(), reserversWithoutQr.size());
+        
+        int successCount = 0;
+        int failCount = 0;
+        
+        for (Reserver reserver : reserversWithoutQr) {
+            try {
+                qrCodeService.issueQr(reserver.getId());
+                successCount++;
+            } catch (Exception e) {
+                log.error("QR코드 생성 실패 - 예약자 ID: {}, 오류: {}", 
+                        reserver.getId(), e.getMessage());
+                failCount++;
+            }
+        }
+        
+        log.info("박람회 QR코드 생성 완료 - 박람회: {}, 성공: {} 명, 실패: {} 명", 
+                expo.getTitle(), successCount, failCount);
+    }
+}

--- a/src/main/java/com/myce/schedule/jobs/QrCodeActivateScheduler.java
+++ b/src/main/java/com/myce/schedule/jobs/QrCodeActivateScheduler.java
@@ -32,6 +32,7 @@ public class QrCodeActivateScheduler implements TaskScheduler {
 
     @Override
     @Scheduled(cron = "${scheduler.qr-code-activate:0 * * * * *}")
+    @Transactional
     public void run() {
         try {
             process();
@@ -47,20 +48,12 @@ public class QrCodeActivateScheduler implements TaskScheduler {
         LocalDateTime now = LocalDateTime.now();
         log.info("스케줄러 실행 - 현재 시간: {}", now);
 
-        List<QrCode> qrCodesToActivate = qrCodeRepository.findByStatusAndActivatedAtBefore(
-                QrCodeStatus.APPROVED, now);
-
-        log.info("활성화 대상 QR코드 수: {}", qrCodesToActivate.size());
-        // ...
+        // Bulk Update로 성능 최적화
+        int updatedCount = qrCodeRepository.bulkUpdateStatusToActive(
+                QrCodeStatus.APPROVED, QrCodeStatus.ACTIVE, now);
         
-        if (!qrCodesToActivate.isEmpty()) {
-            qrCodesToActivate.forEach(qrCode -> {
-                log.info("QR코드 ID: {}, 변경 전 상태: {}", qrCode.getId(), qrCode.getStatus());
-                qrCode.activate();
-                log.info("QR코드 ID: {}, 변경 후 상태: {}", qrCode.getId(), qrCode.getStatus());
-            });
-            qrCodeRepository.saveAll(qrCodesToActivate);
-            log.info("QR 코드 활성화 완료 - {} 개", qrCodesToActivate.size());
+        if (updatedCount > 0) {
+            log.info("QR 코드 활성화 완료 - {} 개", updatedCount);
         } else {
             log.debug("활성화할 QR 코드가 없습니다.");
         }

--- a/src/main/java/com/myce/schedule/jobs/QrCodeExpireScheduler.java
+++ b/src/main/java/com/myce/schedule/jobs/QrCodeExpireScheduler.java
@@ -13,7 +13,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import jakarta.annotation.PostConstruct;
 import java.time.LocalDateTime;
-import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -32,6 +31,7 @@ public class QrCodeExpireScheduler implements TaskScheduler {
 
     @Override
     @Scheduled(cron = "${scheduler.qr-code-expire:0 * * * * *}")
+    @Transactional
     public void run() {
         try {
             process();
@@ -47,19 +47,12 @@ public class QrCodeExpireScheduler implements TaskScheduler {
         LocalDateTime now = LocalDateTime.now();
         log.info("만료 스케줄러 실행 - 현재 시간: {}", now);
         
-        List<QrCode> qrCodesToExpire = qrCodeRepository.findByStatusAndExpiredAtBefore(
-                QrCodeStatus.ACTIVE, now);
+        // Bulk Update로 성능 최적화
+        int updatedCount = qrCodeRepository.bulkUpdateStatusToExpired(
+                QrCodeStatus.ACTIVE, QrCodeStatus.EXPIRED, now);
         
-        log.info("만료 대상 QR코드 수: {}", qrCodesToExpire.size());
-        
-        if (!qrCodesToExpire.isEmpty()) {
-            qrCodesToExpire.forEach(qrCode -> {
-                log.info("QR코드 ID: {}, 변경 전 상태: {}", qrCode.getId(), qrCode.getStatus());
-                qrCode.expire();
-                log.info("QR코드 ID: {}, 변경 후 상태: {}", qrCode.getId(), qrCode.getStatus());
-            });
-            qrCodeRepository.saveAll(qrCodesToExpire);
-            log.info("QR 코드 만료 처리 완료 - {} 개", qrCodesToExpire.size());
+        if (updatedCount > 0) {
+            log.info("QR 코드 만료 처리 완료 - {} 개", updatedCount);
         } else {
             log.debug("만료 처리할 QR 코드가 없습니다.");
         }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -143,5 +143,6 @@ management:
   #test-mode: false
 scheduler:
   test: 0 * * * * * # every minute
-  qr-code-activate: 0 * * * * * # QR 코드 활성화 - 매분 실행
-  qr-code-expire: 0 * * * * * # QR 코드 만료 처리 - 매분 실행
+  qr-code-activate: 0 10 0 * * * # QR 코드 활성화 - 매일 00:10에 실행
+  qr-code-expire: 0 20 0 * * * # QR 코드 만료 처리 - 매일 00:20에 실행
+  expo-qr-generate: 0 0 0 * * * # 박람회 QR코드 일괄 생성 - 매일 00:00에 실행


### PR DESCRIPTION
Feat: QR CODE 생성 스케쥴러 등록( 박람회 개최 2일전인 친구 자정에 QR코드 생성 , 

활성화 스케쥴러 수정: 매일 00:10 분,current_time 이 activate_at 보다 클시 approved -> activate 전환

만료 스케쥴러 수정: 매일 00:20분,current_time 이 expired_at 보다 클시 activate -> expired 전환

===============================

박람회 실시간 혼잡도 API 생성
    @GetMapping("/{expoId}/congestion")
{
  "expoId": 1,
  "expoTitle": "2024 서울 IT 박람회",
  "hourlyVisitors": 0,
  "hourlyCapacity": 27,
  "congestionPercentage": 0,
  "level": "LOW",
  "levelDisplayName": "여유",
  "message": "입장하기 좋은 시간입니다",
  "lastUpdated": "2025-08-10T21:20:51.452516200"
}

GET 쏠시 복잡도 설명하는 데이터 리턴