### PR TITLE
[CRM-138] 박람회 관리자 예약자 리스트 조회

### DIFF
--- a/src/main/java/com/myce/MyceApplication.java
+++ b/src/main/java/com/myce/MyceApplication.java
@@ -2,10 +2,8 @@ package com.myce;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.web.config.EnableSpringDataWebSupport;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-import static org.springframework.data.web.config.EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO;
 
 @SpringBootApplication
 @EnableScheduling

--- a/src/main/java/com/myce/MyceApplication.java
+++ b/src/main/java/com/myce/MyceApplication.java
@@ -9,7 +9,6 @@ import static org.springframework.data.web.config.EnableSpringDataWebSupport.Pag
 
 @SpringBootApplication
 @EnableScheduling
-@EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO)
 public class MyceApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/myce/MyceApplication.java
+++ b/src/main/java/com/myce/MyceApplication.java
@@ -4,7 +4,6 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-
 @SpringBootApplication
 @EnableScheduling
 public class MyceApplication {

--- a/src/main/java/com/myce/MyceApplication.java
+++ b/src/main/java/com/myce/MyceApplication.java
@@ -2,10 +2,14 @@ package com.myce;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
 import org.springframework.scheduling.annotation.EnableScheduling;
+
+import static org.springframework.data.web.config.EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO;
 
 @SpringBootApplication
 @EnableScheduling
+@EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO)
 public class MyceApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/myce/reservation/controller/ExpoAdminPaymentController.java
+++ b/src/main/java/com/myce/reservation/controller/ExpoAdminPaymentController.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PagedModel;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -22,7 +23,7 @@ public class ExpoAdminPaymentController {
     private final ExpoAdminPaymentService service;
 
     @GetMapping
-    public ResponseEntity<Page<ExpoAdminPaymentResponse>> getMyExpoPayments(
+    public ResponseEntity<PagedModel<ExpoAdminPaymentResponse>> getMyExpoPayments(
             @PathVariable Long expoId,
             @RequestParam(defaultValue = "desc") String sort,
             @RequestParam(defaultValue = "0") int page,
@@ -39,6 +40,6 @@ public class ExpoAdminPaymentController {
 
         Page<ExpoAdminPaymentResponse> result = service.getMyExpoPayments(expoId, memberId, loginType, status, name, phone, pageable);
 
-        return ResponseEntity.ok(result);
+        return ResponseEntity.ok(new PagedModel<>(result));
     }
 }

--- a/src/main/java/com/myce/reservation/controller/ExpoAdminPaymentController.java
+++ b/src/main/java/com/myce/reservation/controller/ExpoAdminPaymentController.java
@@ -22,7 +22,7 @@ public class ExpoAdminPaymentController {
     private final ExpoAdminPaymentService service;
 
     @GetMapping
-    public ResponseEntity<Page<ExpoAdminPaymentResponse>> getExpoAdminPayment(
+    public ResponseEntity<Page<ExpoAdminPaymentResponse>> getMyExpoPayments(
             @PathVariable Long expoId,
             @RequestParam(defaultValue = "desc") String sort,
             @RequestParam(defaultValue = "0") int page,

--- a/src/main/java/com/myce/reservation/controller/ExpoAdminReservationController.java
+++ b/src/main/java/com/myce/reservation/controller/ExpoAdminReservationController.java
@@ -1,0 +1,45 @@
+package com.myce.reservation.controller;
+
+import com.myce.auth.dto.CustomUserDetails;
+import com.myce.auth.dto.type.LoginType;
+import com.myce.reservation.dto.ExpoAdminReservationResponse;
+import com.myce.reservation.service.ExpoAdminReservationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/expos/{expoId}/reservations")
+@RequiredArgsConstructor
+public class ExpoAdminReservationController {
+
+    private final ExpoAdminReservationService service;
+
+    @GetMapping
+    public ResponseEntity<Page<ExpoAdminReservationResponse>> getExpoAdminReservation(
+            @PathVariable Long expoId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(required = false) String entranceStatus,
+            @RequestParam(required = false) String name,
+            @RequestParam(required = false) String phone,
+            @RequestParam(required = false) String reservationCode,
+            @RequestParam(required = false) String ticketName,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails){
+        Long memberId = customUserDetails.getMemberId();
+        LoginType loginType = customUserDetails.getLoginType();
+
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.ASC, "createdAt"));
+        Page<ExpoAdminReservationResponse> result = service.getMyExpoReservation(
+                expoId, memberId, loginType,
+                entranceStatus, name, phone, reservationCode, ticketName,
+                pageable);
+
+        return ResponseEntity.ok(result);
+    }
+}

--- a/src/main/java/com/myce/reservation/controller/ExpoAdminReservationController.java
+++ b/src/main/java/com/myce/reservation/controller/ExpoAdminReservationController.java
@@ -13,15 +13,27 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
-@RequestMapping("/api/expos/{expoId}/reservations")
+@RequestMapping("/api/expos/{expoId}")
 @RequiredArgsConstructor
 public class ExpoAdminReservationController {
 
     private final ExpoAdminReservationService service;
 
-    @GetMapping
-    public ResponseEntity<Page<ExpoAdminReservationResponse>> getExpoAdminReservation(
+    @GetMapping("/reservations/ticket-name")
+    public ResponseEntity<List<String>> getExpoTicketNames(
+            @PathVariable Long expoId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        Long memberId = customUserDetails.getMemberId();
+        LoginType loginType = customUserDetails.getLoginType();
+
+        return ResponseEntity.ok(service.getExpoTicketNames(expoId,memberId,loginType));
+    }
+
+    @GetMapping("/reservations")
+    public ResponseEntity<Page<ExpoAdminReservationResponse>> getMyExpoReservations(
             @PathVariable Long expoId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,
@@ -35,7 +47,7 @@ public class ExpoAdminReservationController {
         LoginType loginType = customUserDetails.getLoginType();
 
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.ASC, "createdAt"));
-        Page<ExpoAdminReservationResponse> result = service.getMyExpoReservation(
+        Page<ExpoAdminReservationResponse> result = service.getMyExpoReservations(
                 expoId, memberId, loginType,
                 entranceStatus, name, phone, reservationCode, ticketName,
                 pageable);

--- a/src/main/java/com/myce/reservation/controller/ExpoAdminReservationController.java
+++ b/src/main/java/com/myce/reservation/controller/ExpoAdminReservationController.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PagedModel;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -33,7 +34,7 @@ public class ExpoAdminReservationController {
     }
 
     @GetMapping("/reservations")
-    public ResponseEntity<Page<ExpoAdminReservationResponse>> getMyExpoReservations(
+    public ResponseEntity<PagedModel<ExpoAdminReservationResponse>> getMyExpoReservations(
             @PathVariable Long expoId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,
@@ -52,6 +53,6 @@ public class ExpoAdminReservationController {
                 entranceStatus, name, phone, reservationCode, ticketName,
                 pageable);
 
-        return ResponseEntity.ok(result);
+        return ResponseEntity.ok(new PagedModel<>(result));
     }
 }

--- a/src/main/java/com/myce/reservation/dto/ExpoAdminReservationResponse.java
+++ b/src/main/java/com/myce/reservation/dto/ExpoAdminReservationResponse.java
@@ -1,0 +1,20 @@
+package com.myce.reservation.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ExpoAdminReservationResponse {
+    private Long reserverId;
+    private String reservationCode;
+    private String name;
+    private String gender;
+    private String phone;
+    private String email;
+    private String ticketName;
+    private LocalDateTime entranceAt;
+    private String entranceStatus;
+}

--- a/src/main/java/com/myce/reservation/entity/Reserver.java
+++ b/src/main/java/com/myce/reservation/entity/Reserver.java
@@ -54,7 +54,7 @@ public class Reserver {
         this.phone = phone;
         this.email = email;
     }
-    
+
     public void updateReserverInfo(String name, Gender gender, String phone, String email) {
         this.name = name;
         this.gender = gender;

--- a/src/main/java/com/myce/reservation/repository/ReserverRepository.java
+++ b/src/main/java/com/myce/reservation/repository/ReserverRepository.java
@@ -24,51 +24,46 @@ public interface ReserverRepository extends JpaRepository<Reserver, Long> {
     List<Reserver> findReserversByExpo(@Param("expoId") Long expoId);
 
     @Query("""
-            SELECT NEW com.myce.reservation.dto.ExpoAdminReservationResponse(
-              rv.id,
-              r.reservationCode,
-              rv.name,
-              CASE
-                WHEN rv.gender = com.myce.member.entity.type.Gender.FEMALE THEN '여'
-                WHEN rv.gender = com.myce.member.entity.type.Gender.MALE THEN '남'
-                ELSE '-'
-              END,
-              rv.phone,
-              rv.email,
-              t.name,
-              qc.usedAt,
-              CASE
-                WHEN qc.status = com.myce.qrcode.entity.code.QrCodeStatus.USED THEN '입장 완료'
-                WHEN qc.id IS NULL
-                     OR qc.status IN (
-                       com.myce.qrcode.entity.code.QrCodeStatus.ACTIVE,
-                       com.myce.qrcode.entity.code.QrCodeStatus.EXPIRED
-                     ) THEN '입장 전'
-                ELSE '입장 전'
-              END
+        SELECT NEW com.myce.reservation.dto.ExpoAdminReservationResponse(
+          rv.id,
+          r.reservationCode,
+          rv.name,
+          CASE
+            WHEN rv.gender = com.myce.member.entity.type.Gender.FEMALE THEN '여'
+            WHEN rv.gender = com.myce.member.entity.type.Gender.MALE THEN '남'
+            ELSE '-'
+          END,
+          rv.phone,
+          rv.email,
+          t.name,
+          qc.usedAt,
+          CASE
+            WHEN qc.status = com.myce.qrcode.entity.code.QrCodeStatus.USED THEN '입장 완료'
+            WHEN qc.status = com.myce.qrcode.entity.code.QrCodeStatus.EXPIRED THEN '티켓 만료'
+            WHEN qc.id IS NULL OR qc.status = com.myce.qrcode.entity.code.QrCodeStatus.ACTIVE THEN '입장 전'
+            ELSE '입장 전'
+          END
+        )
+        FROM Reserver rv
+        JOIN rv.reservation r
+        JOIN r.ticket t
+        LEFT JOIN com.myce.qrcode.entity.QrCode qc ON qc.reserver = rv
+        WHERE r.expo.id = :expoId
+          AND r.status = com.myce.reservation.entity.code.ReservationStatus.CONFIRMED
+          AND (:name IS NULL OR LOWER(rv.name) LIKE LOWER(CONCAT('%', :name, '%')))
+          AND (:phone IS NULL OR rv.phone LIKE CONCAT('%', :phone, '%'))
+          AND (:reservationCode IS NULL OR r.reservationCode LIKE CONCAT('%', :reservationCode, '%'))
+          AND (:ticketName IS NULL OR t.name = :ticketName)
+          AND (
+            :entranceStatus IS NULL OR
+            (
+              (:entranceStatus = '입장 완료' AND qc.status = com.myce.qrcode.entity.code.QrCodeStatus.USED)
+              OR (:entranceStatus = '입장 전' AND (qc.id IS NULL
+                  OR qc.status = com.myce.qrcode.entity.code.QrCodeStatus.ACTIVE))
+              OR (:entranceStatus = '티켓 만료' AND qc.status = com.myce.qrcode.entity.code.QrCodeStatus.EXPIRED)
             )
-            FROM Reserver rv
-            JOIN rv.reservation r
-            JOIN r.ticket t
-            LEFT JOIN com.myce.qrcode.entity.QrCode qc ON qc.reserver = rv
-            WHERE r.expo.id = :expoId
-              AND r.status = com.myce.reservation.entity.code.ReservationStatus.CONFIRMED
-              AND (:name IS NULL OR LOWER(rv.name) LIKE LOWER(CONCAT('%', :name, '%')))
-              AND (:phone IS NULL OR rv.phone LIKE CONCAT('%', :phone, '%'))
-              AND (:reservationCode IS NULL OR r.reservationCode LIKE CONCAT('%',:reservationCode,'%'))
-              AND (:ticketName IS NULL OR t.name = :ticketName)
-              AND (
-                :entranceStatus IS NULL OR
-                (
-                  (:entranceStatus = '입장 완료' AND qc.status = com.myce.qrcode.entity.code.QrCodeStatus.USED)
-                  OR (:entranceStatus = '입장 전' AND (qc.id IS NULL
-                      OR qc.status IN (
-                        com.myce.qrcode.entity.code.QrCodeStatus.ACTIVE,
-                        com.myce.qrcode.entity.code.QrCodeStatus.EXPIRED
-                      )))
-                )
-              )
-            """)
+          )
+    """)
     Page<ExpoAdminReservationResponse> findAllResponsesByExpoIdAndStatus(
             @Param("expoId") Long expoId,
             @Param("entranceStatus") String entranceStatus,

--- a/src/main/java/com/myce/reservation/repository/ReserverRepository.java
+++ b/src/main/java/com/myce/reservation/repository/ReserverRepository.java
@@ -1,7 +1,10 @@
 package com.myce.reservation.repository;
 
+import com.myce.reservation.dto.ExpoAdminReservationResponse;
 import com.myce.reservation.entity.Reservation;
 import com.myce.reservation.entity.Reserver;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -19,4 +22,60 @@ public interface ReserverRepository extends JpaRepository<Reserver, Long> {
            "JOIN r.reservation res " +
            "WHERE res.expo.id = :expoId ")
     List<Reserver> findReserversByExpo(@Param("expoId") Long expoId);
+
+    @Query("""
+            SELECT NEW com.myce.reservation.dto.ExpoAdminReservationResponse(
+              rv.id,
+              r.reservationCode,
+              rv.name,
+              CASE
+                WHEN rv.gender = com.myce.member.entity.type.Gender.FEMALE THEN '여'
+                WHEN rv.gender = com.myce.member.entity.type.Gender.MALE THEN '남'
+                ELSE '-'
+              END,
+              rv.phone,
+              rv.email,
+              t.name,
+              qc.usedAt,
+              CASE
+                WHEN qc.status = com.myce.qrcode.entity.code.QrCodeStatus.USED THEN '입장 완료'
+                WHEN qc.id IS NULL
+                     OR qc.status IN (
+                       com.myce.qrcode.entity.code.QrCodeStatus.ACTIVE,
+                       com.myce.qrcode.entity.code.QrCodeStatus.EXPIRED
+                     ) THEN '입장 전'
+                ELSE '입장 전'
+              END
+            )
+            FROM Reserver rv
+            JOIN rv.reservation r
+            JOIN r.ticket t
+            LEFT JOIN com.myce.qrcode.entity.QrCode qc ON qc.reserver = rv
+            WHERE r.expo.id = :expoId
+              AND r.status = com.myce.reservation.entity.code.ReservationStatus.CONFIRMED
+              AND (:name IS NULL OR LOWER(rv.name) LIKE LOWER(CONCAT('%', :name, '%')))
+              AND (:phone IS NULL OR rv.phone LIKE CONCAT('%', :phone, '%'))
+              AND (:reservationCode IS NULL OR r.reservationCode LIKE CONCAT('%',:reservationCode,'%'))
+              AND (:ticketName IS NULL OR t.name = :ticketName)
+              AND (
+                :entranceStatus IS NULL OR
+                (
+                  (:entranceStatus = '입장 완료' AND qc.status = com.myce.qrcode.entity.code.QrCodeStatus.USED)
+                  OR (:entranceStatus = '입장 전' AND (qc.id IS NULL
+                      OR qc.status IN (
+                        com.myce.qrcode.entity.code.QrCodeStatus.ACTIVE,
+                        com.myce.qrcode.entity.code.QrCodeStatus.EXPIRED
+                      )))
+                )
+              )
+            """)
+    Page<ExpoAdminReservationResponse> findAllResponsesByExpoIdAndStatus(
+            @Param("expoId") Long expoId,
+            @Param("entranceStatus") String entranceStatus,
+            @Param("name") String name,
+            @Param("phone") String phone,
+            @Param("reservationCode") String reservationCode,
+            @Param("ticketName") String ticketName,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/myce/reservation/repository/ReserverRepository.java
+++ b/src/main/java/com/myce/reservation/repository/ReserverRepository.java
@@ -40,6 +40,7 @@ public interface ReserverRepository extends JpaRepository<Reserver, Long> {
           CASE
             WHEN qc.status = com.myce.qrcode.entity.code.QrCodeStatus.USED THEN '입장 완료'
             WHEN qc.status = com.myce.qrcode.entity.code.QrCodeStatus.EXPIRED THEN '티켓 만료'
+            WHEN qc.id IS NULL OR qc.status = com.myce.qrcode.entity.code.QrCodeStatus.APPROVED THEN '입장 전'
             WHEN qc.id IS NULL OR qc.status = com.myce.qrcode.entity.code.QrCodeStatus.ACTIVE THEN '입장 전'
             ELSE '입장 전'
           END
@@ -58,9 +59,10 @@ public interface ReserverRepository extends JpaRepository<Reserver, Long> {
             :entranceStatus IS NULL OR
             (
               (:entranceStatus = '입장 완료' AND qc.status = com.myce.qrcode.entity.code.QrCodeStatus.USED)
-              OR (:entranceStatus = '입장 전' AND (qc.id IS NULL
-                  OR qc.status = com.myce.qrcode.entity.code.QrCodeStatus.ACTIVE))
               OR (:entranceStatus = '티켓 만료' AND qc.status = com.myce.qrcode.entity.code.QrCodeStatus.EXPIRED)
+              OR (:entranceStatus = '입장 전' AND (qc.id IS NULL
+                  OR qc.status IN (com.myce.qrcode.entity.code.QrCodeStatus.ACTIVE,
+                                   com.myce.qrcode.entity.code.QrCodeStatus.APPROVED)))
             )
           )
     """)

--- a/src/main/java/com/myce/reservation/service/ExpoAdminReservationService.java
+++ b/src/main/java/com/myce/reservation/service/ExpoAdminReservationService.java
@@ -1,0 +1,18 @@
+package com.myce.reservation.service;
+
+import com.myce.auth.dto.type.LoginType;
+import com.myce.reservation.dto.ExpoAdminReservationResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ExpoAdminReservationService {
+    Page<ExpoAdminReservationResponse> getMyExpoReservation(Long expoId,
+                                                            Long memberId,
+                                                            LoginType loginType,
+                                                            String entranceStatus,
+                                                            String name,
+                                                            String phone,
+                                                            String reservationCode,
+                                                            String ticketName,
+                                                            Pageable pageable);
+}

--- a/src/main/java/com/myce/reservation/service/ExpoAdminReservationService.java
+++ b/src/main/java/com/myce/reservation/service/ExpoAdminReservationService.java
@@ -4,15 +4,21 @@ import com.myce.auth.dto.type.LoginType;
 import com.myce.reservation.dto.ExpoAdminReservationResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
 
 public interface ExpoAdminReservationService {
-    Page<ExpoAdminReservationResponse> getMyExpoReservation(Long expoId,
-                                                            Long memberId,
-                                                            LoginType loginType,
-                                                            String entranceStatus,
-                                                            String name,
-                                                            String phone,
-                                                            String reservationCode,
-                                                            String ticketName,
-                                                            Pageable pageable);
+    List<String>  getExpoTicketNames(Long expoId,
+                                     Long memberId,
+                                     LoginType loginType);
+    Page<ExpoAdminReservationResponse> getMyExpoReservations(Long expoId,
+                                                             Long memberId,
+                                                             LoginType loginType,
+                                                             String entranceStatus,
+                                                             String name,
+                                                             String phone,
+                                                             String reservationCode,
+                                                             String ticketName,
+                                                             Pageable pageable);
 }

--- a/src/main/java/com/myce/reservation/service/Impl/ExpoAdminReservationServiceImpl.java
+++ b/src/main/java/com/myce/reservation/service/Impl/ExpoAdminReservationServiceImpl.java
@@ -3,8 +3,10 @@ package com.myce.reservation.service.Impl;
 import com.myce.auth.dto.type.LoginType;
 import com.myce.common.exception.CustomErrorCode;
 import com.myce.common.exception.CustomException;
+import com.myce.expo.entity.Ticket;
 import com.myce.expo.repository.AdminPermissionRepository;
 import com.myce.expo.repository.ExpoRepository;
+import com.myce.expo.repository.TicketRepository;
 import com.myce.reservation.dto.ExpoAdminReservationResponse;
 import com.myce.reservation.repository.ReserverRepository;
 import com.myce.reservation.service.ExpoAdminReservationService;
@@ -13,16 +15,29 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 public class ExpoAdminReservationServiceImpl implements ExpoAdminReservationService {
 
     private final ExpoRepository expoRepository;
+    private final TicketRepository ticketRepository;
     private final AdminPermissionRepository adminPermissionRepository;
     private final ReserverRepository reserverRepository;
 
     @Override
-    public Page<ExpoAdminReservationResponse> getMyExpoReservation(
+    public List<String> getExpoTicketNames(Long expoId, Long memberId, LoginType loginType) {
+        validateMyAccess(expoId,memberId,loginType);
+        List<Ticket> tickets = ticketRepository.findByExpoId(expoId);
+
+        return tickets.stream().map(Ticket::getName).toList();
+    }
+
+    @Override
+    public Page<ExpoAdminReservationResponse> getMyExpoReservations(
             Long expoId, Long memberId, LoginType loginType,
             String entranceStatus, String name, String phone, String reservationCode, String ticketName,
             Pageable pageable) {

--- a/src/main/java/com/myce/reservation/service/Impl/ExpoAdminReservationServiceImpl.java
+++ b/src/main/java/com/myce/reservation/service/Impl/ExpoAdminReservationServiceImpl.java
@@ -1,0 +1,55 @@
+package com.myce.reservation.service.Impl;
+
+import com.myce.auth.dto.type.LoginType;
+import com.myce.common.exception.CustomErrorCode;
+import com.myce.common.exception.CustomException;
+import com.myce.expo.repository.AdminPermissionRepository;
+import com.myce.expo.repository.ExpoRepository;
+import com.myce.reservation.dto.ExpoAdminReservationResponse;
+import com.myce.reservation.repository.ReserverRepository;
+import com.myce.reservation.service.ExpoAdminReservationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ExpoAdminReservationServiceImpl implements ExpoAdminReservationService {
+
+    private final ExpoRepository expoRepository;
+    private final AdminPermissionRepository adminPermissionRepository;
+    private final ReserverRepository reserverRepository;
+
+    @Override
+    public Page<ExpoAdminReservationResponse> getMyExpoReservation(
+            Long expoId, Long memberId, LoginType loginType,
+            String entranceStatus, String name, String phone, String reservationCode, String ticketName,
+            Pageable pageable) {
+
+        validateMyAccess(expoId, memberId, loginType);
+
+        return reserverRepository.findAllResponsesByExpoIdAndStatus(
+                expoId, entranceStatus, name, phone, reservationCode, ticketName, pageable);
+    }
+
+    private void validateMyAccess(Long expoId, Long memberId, LoginType loginType) {
+        if(memberId == null || loginType == null){
+            throw new CustomException(CustomErrorCode.MEMBER_NOT_EXIST);
+        }
+
+        switch(loginType){
+            case MEMBER -> {
+                if (!expoRepository.existsByIdAndMemberId(expoId, memberId)) {
+                    throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
+                }
+            }
+            case ADMIN_CODE -> {
+                if(!adminPermissionRepository.existsByAdminCodeIdAndAdminCodeExpoIdAndIsReserverListViewTrue(memberId, expoId)){
+                    throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
+                }
+            }
+            default -> throw new CustomException(CustomErrorCode.INVALID_LOGIN_TYPE);
+        }
+    }
+}


### PR DESCRIPTION
박람회 관리자 예약자 리스트 조회를 구현하였습니다.
reservation 단위가 아닌, reserver 기준으로 **예약자 하나하나**를 조회할 수 있는 기능입니다.

## 구현 기능
### 박람회에 포함된 티켓 목록 반환
- 예약자 필터링에 사용되는 티켓 목록을 드롭다운에 반영하기 위한 기능을 구현하였습니다.

### 예약자 조회/필터링/검색 기능
- 예약 상태값이 **'CONFIRMED(예약 확정)'** 인 예약자들만 조회합니다.
- QR 코드 테이블과 LEFT JOIN을 사용하였습니다.
  - OR 코드가 생성되지 않은 예약자는 '입장 전'으로 표시됩니다.
  - QR 코드가 생성되지 않은 예약자의 입장 일시는 null로 반환됩니다.
  - QR 코드의 상태값이 'APPROVED', 'ACTIVE'인 예약자는 '입장 전'으로 표시됩니다.
  - QR 코드의 상태값이 'USED'인 예약자는 '입장 완료'로 표시됩니다.
  - QR 코드의 상태값이 'EXPIRED'인 예약자는 '티켓 만료'로 표시됩니다.