### PR TITLE
[CRM 145] QR 수기입장 처리

### DIFF
--- a/src/main/java/com/myce/common/exception/CustomErrorCode.java
+++ b/src/main/java/com/myce/common/exception/CustomErrorCode.java
@@ -43,6 +43,7 @@ public enum CustomErrorCode {
     QR_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Q008", "QR 코드 생성 중 오류가 발생했습니다."),
     QR_REISSUE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Q009", "QR 코드 재발급 중 오류가 발생했습니다."),
     QR_APPROVED(HttpStatus.BAD_REQUEST , "Q010" , "QR 코드 발급 기간이 아닙니다."  ),
+    QR_NOT_MANUAL_CHECK_IN(HttpStatus.BAD_REQUEST, "Q011", "ACTIVE 상태의 QR만 수기입장 처리가 가능합니다."),
 
     // S3 S
     S3_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S001", "S3 파일 업로드에 실패했습니다."),

--- a/src/main/java/com/myce/qrcode/controller/ExpoAdminManualCheckInController.java
+++ b/src/main/java/com/myce/qrcode/controller/ExpoAdminManualCheckInController.java
@@ -1,0 +1,32 @@
+package com.myce.qrcode.controller;
+
+import com.myce.auth.dto.CustomUserDetails;
+import com.myce.auth.dto.type.LoginType;
+import com.myce.qrcode.service.ExpoAdminManualCheckInService;
+import com.myce.reservation.dto.ExpoAdminReservationResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/expos/{expoId}/reservers/{reserverId}/manual-checkin")
+@RequiredArgsConstructor
+public class ExpoAdminManualCheckInController {
+
+    private final ExpoAdminManualCheckInService service;
+
+    @PutMapping
+    public ResponseEntity<ExpoAdminReservationResponse> updateReserverQrCodeForManualCheckIn(
+            @PathVariable Long expoId,
+            @PathVariable Long reserverId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails){
+        Long memberId = customUserDetails.getMemberId();
+        LoginType loginType = customUserDetails.getLoginType();
+
+        return ResponseEntity.ok(service.updateReserverQrCodeForManualCheckIn(expoId,memberId,loginType,reserverId));
+    }
+}

--- a/src/main/java/com/myce/qrcode/service/ExpoAdminManualCheckInService.java
+++ b/src/main/java/com/myce/qrcode/service/ExpoAdminManualCheckInService.java
@@ -1,0 +1,11 @@
+package com.myce.qrcode.service;
+
+import com.myce.auth.dto.type.LoginType;
+import com.myce.reservation.dto.ExpoAdminReservationResponse;
+
+public interface ExpoAdminManualCheckInService {
+    ExpoAdminReservationResponse updateReserverQrCodeForManualCheckIn(Long expoId,
+                                                                    Long memberId,
+                                                                    LoginType loginType,
+                                                                    Long reserverId);
+}

--- a/src/main/java/com/myce/qrcode/service/ExpoAdminManualCheckInService.java
+++ b/src/main/java/com/myce/qrcode/service/ExpoAdminManualCheckInService.java
@@ -5,7 +5,7 @@ import com.myce.reservation.dto.ExpoAdminReservationResponse;
 
 public interface ExpoAdminManualCheckInService {
     ExpoAdminReservationResponse updateReserverQrCodeForManualCheckIn(Long expoId,
-                                                                    Long memberId,
-                                                                    LoginType loginType,
-                                                                    Long reserverId);
+                                                                      Long memberId,
+                                                                      LoginType loginType,
+                                                                      Long reserverId);
 }

--- a/src/main/java/com/myce/qrcode/service/impl/ExpoAdminManualCheckInServiceImpl.java
+++ b/src/main/java/com/myce/qrcode/service/impl/ExpoAdminManualCheckInServiceImpl.java
@@ -1,0 +1,61 @@
+package com.myce.qrcode.service.impl;
+
+import com.myce.auth.dto.type.LoginType;
+import com.myce.common.exception.CustomErrorCode;
+import com.myce.common.exception.CustomException;
+import com.myce.expo.repository.AdminPermissionRepository;
+import com.myce.expo.repository.ExpoRepository;
+import com.myce.qrcode.entity.QrCode;
+import com.myce.qrcode.repository.QrCodeRepository;
+import com.myce.qrcode.service.ExpoAdminManualCheckInService;
+import com.myce.reservation.dto.ExpoAdminReservationResponse;
+import com.myce.reservation.repository.ReserverRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ExpoAdminManualCheckInServiceImpl implements ExpoAdminManualCheckInService {
+
+    private final ExpoRepository expoRepository;
+    private final AdminPermissionRepository adminPermissionRepository;
+    private final QrCodeRepository  qrCodeRepository;
+    private final ReserverRepository reserverRepository;
+
+    @Override
+    @Transactional
+    public ExpoAdminReservationResponse updateReserverQrCodeForManualCheckIn(Long expoId,
+                                                                             Long memberId,
+                                                                             LoginType loginType,
+                                                                             Long reserverId) {
+        validateMyAccess(expoId, memberId, loginType);
+
+        QrCode qrCode = qrCodeRepository.findByReserverId(reserverId)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.QR_NOT_FOUND));
+
+        qrCode.markAsUsed();
+
+        return reserverRepository.findOneResponsesByReserverId(reserverId);
+    }
+
+    private void validateMyAccess(Long expoId, Long memberId, LoginType loginType) {
+        if(memberId == null || loginType == null){
+            throw new CustomException(CustomErrorCode.MEMBER_NOT_EXIST);
+        }
+
+        switch(loginType){
+            case MEMBER -> {
+                if (!expoRepository.existsByIdAndMemberId(expoId, memberId)) {
+                    throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
+                }
+            }
+            case ADMIN_CODE -> {
+                if(!adminPermissionRepository.existsByAdminCodeIdAndAdminCodeExpoIdAndIsReserverListViewTrue(memberId, expoId)){
+                    throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
+                }
+            }
+            default -> throw new CustomException(CustomErrorCode.INVALID_LOGIN_TYPE);
+        }
+    }
+}

--- a/src/main/java/com/myce/qrcode/service/impl/ExpoAdminManualCheckInServiceImpl.java
+++ b/src/main/java/com/myce/qrcode/service/impl/ExpoAdminManualCheckInServiceImpl.java
@@ -6,6 +6,7 @@ import com.myce.common.exception.CustomException;
 import com.myce.expo.repository.AdminPermissionRepository;
 import com.myce.expo.repository.ExpoRepository;
 import com.myce.qrcode.entity.QrCode;
+import com.myce.qrcode.entity.code.QrCodeStatus;
 import com.myce.qrcode.repository.QrCodeRepository;
 import com.myce.qrcode.service.ExpoAdminManualCheckInService;
 import com.myce.reservation.dto.ExpoAdminReservationResponse;
@@ -34,9 +35,13 @@ public class ExpoAdminManualCheckInServiceImpl implements ExpoAdminManualCheckIn
         QrCode qrCode = qrCodeRepository.findByReserverId(reserverId)
                 .orElseThrow(() -> new CustomException(CustomErrorCode.QR_NOT_FOUND));
 
+        if(qrCode.getStatus() != QrCodeStatus.ACTIVE){
+            throw new CustomException(CustomErrorCode.QR_NOT_MANUAL_CHECK_IN);
+        }
+
         qrCode.markAsUsed();
 
-        return reserverRepository.findOneResponsesByReserverId(reserverId);
+        return reserverRepository.findOneResponsesByReserverId(reserverId,expoId);
     }
 
     private void validateMyAccess(Long expoId, Long memberId, LoginType loginType) {

--- a/src/main/java/com/myce/reservation/controller/ExpoAdminReservationController.java
+++ b/src/main/java/com/myce/reservation/controller/ExpoAdminReservationController.java
@@ -47,7 +47,7 @@ public class ExpoAdminReservationController {
         Long memberId = customUserDetails.getMemberId();
         LoginType loginType = customUserDetails.getLoginType();
 
-        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.ASC, "createdAt"));
+        Pageable pageable = PageRequest.of(page, size);
         Page<ExpoAdminReservationResponse> result = service.getMyExpoReservations(
                 expoId, memberId, loginType,
                 entranceStatus, name, phone, reservationCode, ticketName,

--- a/src/main/java/com/myce/reservation/controller/ExpoAdminReservationController.java
+++ b/src/main/java/com/myce/reservation/controller/ExpoAdminReservationController.java
@@ -17,13 +17,13 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/expos/{expoId}")
+@RequestMapping("/api/expos/{expoId}/reservations")
 @RequiredArgsConstructor
 public class ExpoAdminReservationController {
 
     private final ExpoAdminReservationService service;
 
-    @GetMapping("/reservations/ticket-name")
+    @GetMapping("/ticket-name")
     public ResponseEntity<List<String>> getExpoTicketNames(
             @PathVariable Long expoId,
             @AuthenticationPrincipal CustomUserDetails customUserDetails) {
@@ -33,7 +33,7 @@ public class ExpoAdminReservationController {
         return ResponseEntity.ok(service.getExpoTicketNames(expoId,memberId,loginType));
     }
 
-    @GetMapping("/reservations")
+    @GetMapping
     public ResponseEntity<PagedModel<ExpoAdminReservationResponse>> getMyExpoReservations(
             @PathVariable Long expoId,
             @RequestParam(defaultValue = "0") int page,

--- a/src/main/java/com/myce/reservation/repository/ReserverRepository.java
+++ b/src/main/java/com/myce/reservation/repository/ReserverRepository.java
@@ -75,4 +75,37 @@ public interface ReserverRepository extends JpaRepository<Reserver, Long> {
             @Param("ticketName") String ticketName,
             Pageable pageable
     );
+
+    @Query("""
+      SELECT NEW com.myce.reservation.dto.ExpoAdminReservationResponse(
+        rv.id,
+        r.reservationCode,
+        rv.name,
+        CASE
+          WHEN rv.gender = com.myce.member.entity.type.Gender.FEMALE THEN '여'
+          WHEN rv.gender = com.myce.member.entity.type.Gender.MALE   THEN '남'
+          ELSE '-'
+        END,
+        rv.phone,
+        rv.email,
+        t.name,
+        qc.usedAt,
+        CASE
+          WHEN qc.status = com.myce.qrcode.entity.code.QrCodeStatus.USED    THEN '입장 완료'
+          WHEN qc.status = com.myce.qrcode.entity.code.QrCodeStatus.EXPIRED THEN '티켓 만료'
+          WHEN qc.id IS NULL
+            OR qc.status IN (
+              com.myce.qrcode.entity.code.QrCodeStatus.APPROVED,
+              com.myce.qrcode.entity.code.QrCodeStatus.ACTIVE
+            ) THEN '입장 전'
+          ELSE '입장 전'
+        END
+      )
+      FROM Reserver rv
+      JOIN rv.reservation r
+      JOIN r.ticket t
+      LEFT JOIN com.myce.qrcode.entity.QrCode qc ON qc.reserver = rv
+      WHERE rv.id = :reserverId
+    """)
+    ExpoAdminReservationResponse findOneResponsesByReserverId(@Param("reserverId") Long reserverId);
 }

--- a/src/main/java/com/myce/reservation/repository/ReserverRepository.java
+++ b/src/main/java/com/myce/reservation/repository/ReserverRepository.java
@@ -24,47 +24,55 @@ public interface ReserverRepository extends JpaRepository<Reserver, Long> {
     List<Reserver> findReserversByExpo(@Param("expoId") Long expoId);
 
     @Query("""
-        SELECT NEW com.myce.reservation.dto.ExpoAdminReservationResponse(
-          rv.id,
-          r.reservationCode,
-          rv.name,
-          CASE
-            WHEN rv.gender = com.myce.member.entity.type.Gender.FEMALE THEN '여'
-            WHEN rv.gender = com.myce.member.entity.type.Gender.MALE THEN '남'
-            ELSE '-'
-          END,
-          rv.phone,
-          rv.email,
-          t.name,
-          qc.usedAt,
-          CASE
-            WHEN qc.status = com.myce.qrcode.entity.code.QrCodeStatus.USED THEN '입장 완료'
-            WHEN qc.status = com.myce.qrcode.entity.code.QrCodeStatus.EXPIRED THEN '티켓 만료'
-            WHEN qc.id IS NULL OR qc.status = com.myce.qrcode.entity.code.QrCodeStatus.APPROVED THEN '입장 전'
-            WHEN qc.id IS NULL OR qc.status = com.myce.qrcode.entity.code.QrCodeStatus.ACTIVE THEN '입장 전'
-            ELSE '입장 전'
-          END
-        )
-        FROM Reserver rv
-        JOIN rv.reservation r
-        JOIN r.ticket t
-        LEFT JOIN com.myce.qrcode.entity.QrCode qc ON qc.reserver = rv
-        WHERE r.expo.id = :expoId
-          AND r.status = com.myce.reservation.entity.code.ReservationStatus.CONFIRMED
-          AND (:name IS NULL OR LOWER(rv.name) LIKE LOWER(CONCAT('%', :name, '%')))
-          AND (:phone IS NULL OR rv.phone LIKE CONCAT('%', :phone, '%'))
-          AND (:reservationCode IS NULL OR r.reservationCode LIKE CONCAT('%', :reservationCode, '%'))
-          AND (:ticketName IS NULL OR t.name = :ticketName)
-          AND (
-            :entranceStatus IS NULL OR
-            (
-              (:entranceStatus = '입장 완료' AND qc.status = com.myce.qrcode.entity.code.QrCodeStatus.USED)
-              OR (:entranceStatus = '티켓 만료' AND qc.status = com.myce.qrcode.entity.code.QrCodeStatus.EXPIRED)
-              OR (:entranceStatus = '입장 전' AND (qc.id IS NULL
-                  OR qc.status IN (com.myce.qrcode.entity.code.QrCodeStatus.ACTIVE,
-                                   com.myce.qrcode.entity.code.QrCodeStatus.APPROVED)))
-            )
+          SELECT NEW com.myce.reservation.dto.ExpoAdminReservationResponse(
+            rv.id,
+            r.reservationCode,
+            rv.name,
+            CASE
+              WHEN rv.gender = com.myce.member.entity.type.Gender.FEMALE THEN '여'
+              WHEN rv.gender = com.myce.member.entity.type.Gender.MALE   THEN '남'
+              ELSE '-'
+            END,
+            rv.phone,
+            rv.email,
+            t.name,
+            qc.usedAt,
+            CASE
+              WHEN qc.status = com.myce.qrcode.entity.code.QrCodeStatus.USED    THEN '입장 완료'
+              WHEN qc.status = com.myce.qrcode.entity.code.QrCodeStatus.EXPIRED THEN '티켓 만료'
+              WHEN qc.status IN (com.myce.qrcode.entity.code.QrCodeStatus.APPROVED,
+                                 com.myce.qrcode.entity.code.QrCodeStatus.ACTIVE) THEN '입장 전'
+              WHEN qc.id IS NULL                                                THEN '발급 대기'
+              ELSE '발급 실패'
+            END
           )
+          FROM Reserver rv
+          JOIN rv.reservation r
+          JOIN r.ticket t
+          LEFT JOIN com.myce.qrcode.entity.QrCode qc ON qc.reserver = rv
+          WHERE r.expo.id = :expoId
+            AND r.status = com.myce.reservation.entity.code.ReservationStatus.CONFIRMED
+            AND (:name IS NULL OR LOWER(rv.name) LIKE LOWER(CONCAT('%', :name, '%')))
+            AND (:phone IS NULL OR rv.phone LIKE CONCAT('%', :phone, '%'))
+            AND (:reservationCode IS NULL OR r.reservationCode LIKE CONCAT('%', :reservationCode, '%'))
+            AND (:ticketName IS NULL OR t.name = :ticketName)
+            AND (
+              :entranceStatus IS NULL OR
+              (
+                (:entranceStatus = '입장 완료' AND qc.status = com.myce.qrcode.entity.code.QrCodeStatus.USED)
+                OR (:entranceStatus = '티켓 만료' AND qc.status = com.myce.qrcode.entity.code.QrCodeStatus.EXPIRED)
+                OR (:entranceStatus = '발급 대기' AND qc.id IS NULL)
+                OR (:entranceStatus = '입장 전' AND qc.status IN (
+                      com.myce.qrcode.entity.code.QrCodeStatus.APPROVED,
+                      com.myce.qrcode.entity.code.QrCodeStatus.ACTIVE
+                    ))
+              )
+            )
+          ORDER BY
+              CASE WHEN qc.usedAt IS NULL THEN 1 ELSE 0 END,
+              qc.usedAt DESC,
+              rv.createdAt ASC,
+              rv.id ASC
     """)
     Page<ExpoAdminReservationResponse> findAllResponsesByExpoIdAndStatus(
             @Param("expoId") Long expoId,
@@ -93,19 +101,19 @@ public interface ReserverRepository extends JpaRepository<Reserver, Long> {
         CASE
           WHEN qc.status = com.myce.qrcode.entity.code.QrCodeStatus.USED    THEN '입장 완료'
           WHEN qc.status = com.myce.qrcode.entity.code.QrCodeStatus.EXPIRED THEN '티켓 만료'
-          WHEN qc.id IS NULL
-            OR qc.status IN (
-              com.myce.qrcode.entity.code.QrCodeStatus.APPROVED,
-              com.myce.qrcode.entity.code.QrCodeStatus.ACTIVE
-            ) THEN '입장 전'
-          ELSE '입장 전'
+          WHEN qc.id IS NULL                                                  THEN '발급 대기'
+          WHEN qc.status IN (com.myce.qrcode.entity.code.QrCodeStatus.APPROVED,
+                             com.myce.qrcode.entity.code.QrCodeStatus.ACTIVE) THEN '입장 전'
+          ELSE '발급 실패'
         END
       )
       FROM Reserver rv
       JOIN rv.reservation r
       JOIN r.ticket t
       LEFT JOIN com.myce.qrcode.entity.QrCode qc ON qc.reserver = rv
-      WHERE rv.id = :reserverId
+      WHERE rv.id = :reserverId AND r.expo.id = :expoId
     """)
-    ExpoAdminReservationResponse findOneResponsesByReserverId(@Param("reserverId") Long reserverId);
+    ExpoAdminReservationResponse findOneResponsesByReserverId(
+            @Param("reserverId") Long reserverId,
+            @Param("expoId") Long expoId);
 }


### PR DESCRIPTION
## 구현 내용
@bonyubking  QR 담당자 본엽님 읽어주세요!

### QR 수기 입장 처리
- QR status가 **ACTIVE인 (프론트 : 입장 전)** QR들만 수기 입장 처리 가능하도록 로직을 구현하였습니다.
- 서버 이슈로 APPROVED 전환 실패, APPROVED → ACTIVE 전환 실패, 혹은 이미 EXPIRED 된 경우에는 **QR 재발급을 먼저 진행**한 뒤, ACTIVE 된 상태에서 수기 입장처리를 해야할 것 같습니다. (@bonyubking 본엽님 참고)
<img width="146" height="184" alt="image" src="https://github.com/user-attachments/assets/4bf9a6e2-0bea-4d96-881a-41977c151bee" />


### 예약자 내역 정렬 기준 변경
- QR 사용 완료 시간(usedAt)이 있는 항목은 최신순으로 먼저 정렬해, 체크인 담당자가 실시간 입장 현황을 빠르게 파악할 수 있게 했습니다.
- 사용 완료 시간이 없는 항목은 예약자 등록 시간(createdAt) 오름차순으로 정렬했습니다.
<img width="1608" height="696" alt="image" src="https://github.com/user-attachments/assets/d47109fe-301c-4ee0-9922-1a3b757c6bf3" />


### 예약자 내역 상태 라벨링 추가
- 기존에 QR status가 APPROVE인 상태들을 프론트에서 **입장 전 -> 발급 대기** 상태로 변경하였습니다.
<img width="1628" height="488" alt="image" src="https://github.com/user-attachments/assets/5c993451-0866-4f55-84f1-49c014d2c8e8" />
