### PR TITLE
[CRM-260] 예약자 수기 입장 처리 로직 개선 및 QR 코드 미발급 케이스 처리

### DIFF
--- a/src/main/java/com/myce/qrcode/service/impl/ExpoAdminManualCheckInServiceImpl.java
+++ b/src/main/java/com/myce/qrcode/service/impl/ExpoAdminManualCheckInServiceImpl.java
@@ -9,6 +9,7 @@ import com.myce.qrcode.entity.QrCode;
 import com.myce.qrcode.entity.code.QrCodeStatus;
 import com.myce.qrcode.repository.QrCodeRepository;
 import com.myce.qrcode.service.ExpoAdminManualCheckInService;
+import com.myce.qrcode.service.QrCodeService;
 import com.myce.reservation.dto.ExpoAdminReservationResponse;
 import com.myce.reservation.repository.ReserverRepository;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +24,7 @@ public class ExpoAdminManualCheckInServiceImpl implements ExpoAdminManualCheckIn
     private final AdminPermissionRepository adminPermissionRepository;
     private final QrCodeRepository  qrCodeRepository;
     private final ReserverRepository reserverRepository;
+    private final QrCodeService qrCodeService;
 
     @Override
     @Transactional
@@ -32,15 +34,20 @@ public class ExpoAdminManualCheckInServiceImpl implements ExpoAdminManualCheckIn
                                                                              Long reserverId) {
         validateMyAccess(expoId, memberId, loginType);
 
-        QrCode qrCode = qrCodeRepository.findByReserverId(reserverId)
-                .orElseThrow(() -> new CustomException(CustomErrorCode.QR_NOT_FOUND));
+        QrCode qrCode = qrCodeRepository.findByReserverId(reserverId).orElse(null);
 
-        if(qrCode.getStatus() != QrCodeStatus.ACTIVE){
-            throw new CustomException(CustomErrorCode.QR_NOT_MANUAL_CHECK_IN);
+        if(qrCode != null){
+            if (qrCode.getStatus() == QrCodeStatus.ACTIVE || qrCode.getStatus() == QrCodeStatus.APPROVED) {
+                qrCode.markAsUsed();
+            }else{
+                throw new CustomException(CustomErrorCode.QR_NOT_MANUAL_CHECK_IN);
+            }
+        }else{
+            qrCodeService.issueQr(reserverId);
+            QrCode newQrCode = qrCodeRepository.findByReserverId(reserverId)
+                    .orElseThrow(() -> new CustomException(CustomErrorCode.QR_NOT_FOUND));
+            newQrCode.markAsUsed();
         }
-
-        qrCode.markAsUsed();
-
         return reserverRepository.findOneResponsesByReserverId(reserverId,expoId);
     }
 


### PR DESCRIPTION
기존 예약자 수기 입장 처리 로직을 개선하여, QR 코드가 아직 발급되지 않은 예약 건도 현장에서 즉시 발급 및 입장 처리가 가능하도록 기능을 확장했습니다. 입장 처리 가능한 QR 코드 상태도 명확히 정의하여 예외 처리 로직을 강화했습니다.


#### 1. QR 코드 미발급 시 자동 발급 로직 추가
서버 이슈로 인해 reserver 테이블에는 존재하지만 QR 코드가 없을 경우(발급 대기 상태) `qrCodeService.issueQr()`를 호출하여 QR 코드를 자동 발급한 후, 바로 입장 처리 로직을 진행하도록 변경했습니다. 이를 통해 관리자가 현장에서 QR 코드 발급 및 입장을 한 번에 처리할 수 있습니다.

#### 2. 입장 처리 가능 상태 확장 및 명확화
- 기존에는 `ACTIVE` 상태의 QR 코드만 입장 처리할 수 있었으나, 입장 전 상태로 간주하는것이  `ACTIVE`와 `APPROVED` 상태 모두이므로 두 상태 모두 수기 입장이 가능하도록 허용했습니다. `APPROVED` 상태는 발급은 되었지만 아직 사용 기간이 아닌 경우를 의미하며 서버 이슈나 현장 상황에 따라 유연하게 대처하기 위하여 로직을 추가하였습니다.