### PR TITLE
[CRM-140] 박람회 관리자 예약자 내역 엑셀 다운로드 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,8 @@ dependencies {
 	implementation platform("software.amazon.awssdk:bom:2.25.23")
 	implementation "software.amazon.awssdk:s3"
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.0'
+	implementation 'org.apache.poi:poi:5.4.1' //엑셀 추출 라이브러리
+	implementation 'org.apache.poi:poi-ooxml:5.4.1' //.xlsx API 포함
 
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/com/myce/common/exception/CustomErrorCode.java
+++ b/src/main/java/com/myce/common/exception/CustomErrorCode.java
@@ -121,8 +121,10 @@ public enum CustomErrorCode {
     REFUND_NOT_FOUND(HttpStatus.NOT_FOUND, "RF001", "환불 정보가 존재하지 않습니다."),
 
     // 시스템 설정 에러
-    NOT_EXIST_MESSAGE_TEMPLATE(HttpStatus.NOT_FOUND, "SY001", "메시지 템플릿이 존재하지 않습니다.");
+    NOT_EXIST_MESSAGE_TEMPLATE(HttpStatus.NOT_FOUND, "SY001", "메시지 템플릿이 존재하지 않습니다."),
 
+    // 엑셀 EX
+    EXCEL_EXPORT_FAILED(HttpStatus.NOT_FOUND, "EX001", "엑셀 추출에 실패하였습니다.");
 
     private final HttpStatus status;
     private final String errorCode;

--- a/src/main/java/com/myce/expo/repository/AdminPermissionRepository.java
+++ b/src/main/java/com/myce/expo/repository/AdminPermissionRepository.java
@@ -4,8 +4,6 @@ import com.myce.expo.entity.AdminPermission;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
-
 @Repository
 public interface AdminPermissionRepository extends JpaRepository<AdminPermission, Long> {
     boolean existsByAdminCodeIdAndAdminCodeExpoIdAndIsExpoDetailUpdateTrue(Long adminCodeId, Long expoId);

--- a/src/main/java/com/myce/reservation/controller/ExpoAdminExcelDownloadController.java
+++ b/src/main/java/com/myce/reservation/controller/ExpoAdminExcelDownloadController.java
@@ -1,0 +1,43 @@
+package com.myce.reservation.controller;
+
+import com.myce.auth.dto.CustomUserDetails;
+import com.myce.auth.dto.type.LoginType;
+import com.myce.reservation.service.ExpoAdminExcelDownloadService;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+
+@RestController
+@RequestMapping("/api/expos/{expoId}/reservations/excel-download")
+@RequiredArgsConstructor
+public class ExpoAdminExcelDownloadController {
+
+    private final ExpoAdminExcelDownloadService service;
+
+    @GetMapping
+    public void downloadMyReservationExcelFile (
+            @PathVariable Long expoId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            HttpServletResponse httpResponse) throws IOException {
+
+        Long memberId = customUserDetails.getMemberId();
+        LoginType loginType = customUserDetails.getLoginType();
+
+        String fileName = "예약자_명단.xlsx";
+
+        httpResponse.setContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+        httpResponse.setHeader("Content-Disposition", "attachment; filename=\"" + fileName + "\"");
+
+        service.downloadMyReservationExcelFile(
+                expoId,
+                memberId,
+                loginType,
+                httpResponse.getOutputStream());
+    }
+}

--- a/src/main/java/com/myce/reservation/dto/ExpoAdminExcelDownloadResponse.java
+++ b/src/main/java/com/myce/reservation/dto/ExpoAdminExcelDownloadResponse.java
@@ -1,0 +1,18 @@
+package com.myce.reservation.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class ExpoAdminExcelDownloadResponse {
+    private String reservationCode;
+    private String name;
+    private String gender;
+    private LocalDate birthday;
+    private String phone;
+    private String email;
+    private String ticketName;
+}

--- a/src/main/java/com/myce/reservation/repository/ReserverRepository.java
+++ b/src/main/java/com/myce/reservation/repository/ReserverRepository.java
@@ -1,16 +1,21 @@
 package com.myce.reservation.repository;
 
+import com.myce.reservation.dto.ExpoAdminExcelDownloadResponse;
 import com.myce.reservation.dto.ExpoAdminReservationResponse;
 import com.myce.reservation.entity.Reservation;
 import com.myce.reservation.entity.Reserver;
+import jakarta.persistence.QueryHint;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Stream;
 
 @Repository
 public interface ReserverRepository extends JpaRepository<Reserver, Long> {
@@ -116,4 +121,31 @@ public interface ReserverRepository extends JpaRepository<Reserver, Long> {
     ExpoAdminReservationResponse findOneResponsesByReserverId(
             @Param("reserverId") Long reserverId,
             @Param("expoId") Long expoId);
+
+    @Transactional(readOnly = true)
+    @QueryHints(value = @QueryHint(name = "org.hibernate.fetchSize", value = "1000"))
+    @Query("""
+          SELECT NEW com.myce.reservation.dto.ExpoAdminExcelDownloadResponse(
+            r.reservationCode,
+            rv.name,
+            CASE
+              WHEN rv.gender = com.myce.member.entity.type.Gender.FEMALE THEN '여'
+              WHEN rv.gender = com.myce.member.entity.type.Gender.MALE   THEN '남'
+              ELSE '-'
+            END,
+            rv.birth,
+            rv.phone,
+            rv.email,
+            t.name
+          )
+          FROM Reserver rv
+          JOIN rv.reservation r
+          JOIN r.ticket t
+          WHERE r.expo.id = :expoId
+            AND r.status = com.myce.reservation.entity.code.ReservationStatus.CONFIRMED
+          ORDER BY
+              rv.createdAt ASC,
+              rv.id ASC
+    """)
+    Stream<ExpoAdminExcelDownloadResponse> streamAllForExcel(@Param("expoId") Long expoId);
 }

--- a/src/main/java/com/myce/reservation/service/ExpoAdminExcelDownloadService.java
+++ b/src/main/java/com/myce/reservation/service/ExpoAdminExcelDownloadService.java
@@ -1,0 +1,9 @@
+package com.myce.reservation.service;
+
+import com.myce.auth.dto.type.LoginType;
+
+import java.io.OutputStream;
+
+public interface ExpoAdminExcelDownloadService {
+    void downloadMyReservationExcelFile(Long expoId, Long memberId, LoginType loginType, OutputStream outputStream);
+}

--- a/src/main/java/com/myce/reservation/service/Impl/ExpoAdminExcelDownloadServiceImpl.java
+++ b/src/main/java/com/myce/reservation/service/Impl/ExpoAdminExcelDownloadServiceImpl.java
@@ -1,0 +1,195 @@
+package com.myce.reservation.service.Impl;
+
+import com.myce.auth.dto.type.LoginType;
+import com.myce.common.exception.CustomErrorCode;
+import com.myce.common.exception.CustomException;
+import com.myce.expo.repository.AdminPermissionRepository;
+import com.myce.expo.repository.ExpoRepository;
+import com.myce.reservation.dto.ExpoAdminExcelDownloadResponse;
+import com.myce.reservation.repository.ReserverRepository;
+import com.myce.reservation.service.ExpoAdminExcelDownloadService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.poi.ss.usermodel.*;
+import org.apache.poi.xssf.streaming.SXSSFSheet;
+import org.apache.poi.xssf.streaming.SXSSFWorkbook;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.time.LocalDate;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ExpoAdminExcelDownloadServiceImpl implements ExpoAdminExcelDownloadService {
+
+    private final ExpoRepository expoRepository;
+    private final AdminPermissionRepository adminPermissionRepository;
+    private final ReserverRepository reserverRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public void downloadMyReservationExcelFile(Long expoId, Long memberId, LoginType loginType, OutputStream outputStream) {
+
+        validateMyAccess(expoId, memberId, loginType);
+
+        SXSSFWorkbook workbook = new SXSSFWorkbook(100);
+
+        try {
+            // 1) 시트 생성
+            SXSSFSheet sheet = workbook.createSheet("예약자_명단");
+            sheet.trackAllColumnsForAutoSizing();
+
+            // 2) 스타일 생성
+            CellStyle headerStyle = createHeaderStyle(workbook);
+            CellStyle bodyStyle = createBodyCellStyle(workbook);
+            CellStyle dateCellStyle = createDateCellStyle(workbook);
+
+            // 3) 헤더 생성
+            String[] headers = {"번호", "예약 코드", "이름", "성별", "생년월일", "전화번호", "이메일", "티켓 이름"};
+            createHeaderRow(sheet, headers, headerStyle);
+
+            // 4) 헤더 고정 및 필터
+            sheet.createFreezePane(0, 1);
+            sheet.setAutoFilter(new org.apache.poi.ss.util.CellRangeAddress(0, 0, 0, headers.length - 1));
+
+            // 5) DB 스트림으로 데이터 채우기
+            try (Stream<ExpoAdminExcelDownloadResponse> data = reserverRepository.streamAllForExcel(expoId)) {
+                AtomicInteger rowNum = new AtomicInteger(1);
+                data.forEach(dto -> {
+                    Row row = sheet.createRow(rowNum.get());
+                    fillDataRow(dto, row, rowNum.getAndIncrement(), bodyStyle, dateCellStyle);
+                });
+            }
+
+            // 6) 고정 컬럼 폭 적용
+            applyFixedWidths(sheet);
+
+            // 7) OutputStream에 쓰기
+            workbook.write(outputStream);
+            log.info("[ExcelDownload] Excel file written successfully for expoId={}", expoId);
+
+        } catch (IOException e) {
+            log.error("[ExcelDownload] Failed to write Excel file for expoId={}", expoId, e);
+            throw new CustomException(CustomErrorCode.EXCEL_EXPORT_FAILED);
+        } finally {
+            workbook.dispose();
+        }
+    }
+
+    // 헤더 스타일 생성
+    private CellStyle createHeaderStyle(Workbook workbook) {
+        CellStyle style = workbook.createCellStyle();
+        style.setFillForegroundColor(IndexedColors.GREY_25_PERCENT.getIndex());
+        style.setFillPattern(FillPatternType.SOLID_FOREGROUND);
+        style.setAlignment(HorizontalAlignment.CENTER);
+
+        Font font = workbook.createFont();
+        font.setBold(true);
+        style.setFont(font);
+
+        return style;
+    }
+
+    // 본문 스타일 생성
+    private CellStyle createBodyCellStyle(Workbook workbook) {
+        CellStyle style = workbook.createCellStyle();
+        style.setAlignment(HorizontalAlignment.CENTER);
+
+        return style;
+    }
+
+    // 날짜 스타일 생성
+    private CellStyle createDateCellStyle(Workbook workbook) {
+        CellStyle style = workbook.createCellStyle();
+        CreationHelper createHelper = workbook.getCreationHelper();
+        style.setDataFormat(createHelper.createDataFormat().getFormat("yyyy-mm-dd"));
+        style.setAlignment(HorizontalAlignment.CENTER);
+
+        return style;
+    }
+
+    // 헤더 생성
+    private void createHeaderRow(Sheet sheet, String[] headers, CellStyle headerStyle) {
+        Row headerRow = sheet.createRow(0);
+        for (int i = 0; i < headers.length; i++) {
+            Cell headerCell = headerRow.createCell(i);
+            headerCell.setCellValue(headers[i]);
+            headerCell.setCellStyle(headerStyle);
+        }
+    }
+    
+    // 행 생성
+    private void fillDataRow(ExpoAdminExcelDownloadResponse dto,
+                             Row row,
+                             int rowNum,
+                             CellStyle bodyStyle,
+                             CellStyle dateCellStyle) {
+        Cell cell0 = row.createCell(0);
+        cell0.setCellValue(rowNum);
+        cell0.setCellStyle(bodyStyle);
+
+        Cell cell1 = row.createCell(1);
+        cell1.setCellValue(dto.getReservationCode());
+        cell1.setCellStyle(bodyStyle);
+
+        Cell cell2 = row.createCell(2);
+        cell2.setCellValue(dto.getName());
+        cell2.setCellStyle(bodyStyle);
+
+        Cell cell3 = row.createCell(3);
+        cell3.setCellValue(dto.getGender());
+        cell3.setCellStyle(bodyStyle);
+
+        // 생년월일
+        Cell cell4 = row.createCell(4);
+        LocalDate birthDate = dto.getBirthday();
+        cell4.setCellValue(birthDate);
+        cell4.setCellStyle(dateCellStyle);
+
+        Cell cell5 = row.createCell(5);
+        cell5.setCellValue(dto.getPhone());
+        cell5.setCellStyle(bodyStyle);
+
+        Cell cell6 = row.createCell(6);
+        cell6.setCellValue(dto.getEmail());
+        cell6.setCellStyle(bodyStyle);
+
+        Cell cell7 = row.createCell(7);
+        cell7.setCellValue(dto.getTicketName());
+        cell7.setCellStyle(bodyStyle);
+    }
+
+    // 고정 컬럼 폭 적용
+    private void applyFixedWidths(Sheet sheet) {
+        int[] widths = {5, 20, 12, 6, 12, 16, 28, 50};
+        for (int i = 0; i < widths.length; i++) {
+            int width = Math.min((widths[i] + 2) * 256, 255 * 256);
+            sheet.setColumnWidth(i, width);
+        }
+    }
+    
+    //권한 설정
+    private void validateMyAccess(Long expoId, Long memberId, LoginType loginType) {
+        if (memberId == null || loginType == null) {
+            throw new CustomException(CustomErrorCode.MEMBER_NOT_EXIST);
+        }
+        switch (loginType) {
+            case MEMBER -> {
+                if (!expoRepository.existsByIdAndMemberId(expoId, memberId)) {
+                    throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
+                }
+            }
+            case ADMIN_CODE -> {
+                if (!adminPermissionRepository.existsByAdminCodeIdAndAdminCodeExpoIdAndIsReserverListViewTrue(memberId, expoId)) {
+                    throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
+                }
+            }
+            default -> throw new CustomException(CustomErrorCode.INVALID_LOGIN_TYPE);
+        }
+    }
+}


### PR DESCRIPTION
엑셀 추출 기능 구현을 위해 두 가지 방식을 검토했습니다. 
예약자 데이터가 수천 건 이상일 때 발생할 수 있는 잠재적인 문제점을 고려하여, **백엔드에서 처리하는 방식**으로 구현하였습니다.
@choi2h 변동 내역 확인 부탁드립니다!!

### 프론트엔드 처리 방식 (xlsx-js-style) - 기존 계획
1. 프론트에서 백엔드 API를 호출해 전체 예약자 리스트를 모두 받는다. (페이징 해제)
2. xlsx-js-style 라이브러리를 사용하여 클라이언트에서 데이터를 가공하고 엑셀 파일을 생성한다.

* 문제점 : 네트워크 부하 , 클라이언트 PC 성능에 따른 엑셀 생성 속도 저하

### 백엔드 처리 방식 (Apache POI) - 현재 구현 내용
1. 클라이언트가 엑셀 다운로드 API를 호출한다.
2. 백엔드 서버에서 Apache POI 라이브러리를 사용해 DB에서 전체 데이터를 조회하고 엑셀 파일을 생성한다.
3. 생성된 엑셀 파일을 클라이언트에게 바로 반환하여 다운로드 하도록 한다.

* 장점 : 클라이언트는 최종 엑셀 파일만 다운로드 하면 되기 때문에 네트워크 부하 적음

이에 따라 예약자 데이터가 많아질 경우를 대비해 백엔드에서 **Apache POI**를 사용하여 엑셀 파일을 생성하고 제공하는 방식을 채택하는것이 훨씬 더 효율적이고 안정적이라고 판단됩니다. 실무에서 채택하는 방법이기도 한 것 같습니다. 

### 요약
- 프론트엔드 처리 : 소규모 데이터에 적합, 대량 처리시 성능 및 안정성 문제 발생 가능
- 백엔드 처리 : 대규모 데이터에 적합, 안정적이고 효율적

---
### 의존성 추가
build.gradle에 다음 의존성을 추가합니다.
@juanpark  배포에 문제 없는지 확인 부탁드립니다.

<img width="521" height="46" alt="image" src="https://github.com/user-attachments/assets/55594c89-b538-4f1e-b2ae-cba562134a94" />

- Apache POI : 엑셀 생성 라이브러리
  - implementation 'org.apache.poi:poi:5.4.1' // .xls 포맷 지원
  - implementation 'org.apache.poi:poi-ooxml:5.4.1' // .xlsx 포맷 지원
---
### 동작 흐름
- 프론트 → 엑셀 다운로드 API 호출 (responseType: 'blob')
- 백엔드 → DB 조회 후 SXSSFWorkbook으로 엑셀 생성
- 생성된 파일을 HTTP 응답으로 전송
- 프론트 → Blob URL로 다운로드 실행