### PR TITLE
[CRM-192] feat: SSE 알림 기능

### DIFF
--- a/src/main/java/com/myce/auth/security/config/SecurityConfig.java
+++ b/src/main/java/com/myce/auth/security/config/SecurityConfig.java
@@ -64,7 +64,7 @@ public class SecurityConfig {
         http.authorizeHttpRequests(auth ->
                 auth.requestMatchers(HttpMethod.POST, "/api/auth/**")
                         .permitAll()
-                        .requestMatchers(HttpMethod.GET, "/api/ads")
+                        .requestMatchers(HttpMethod.GET, "/api/ads", "/api/auth/**", "/api/sse/subscribe")
                         .permitAll()
                         .requestMatchers(
                                 "/swagger-ui/**",

--- a/src/main/java/com/myce/auth/security/config/SecurityConfig.java
+++ b/src/main/java/com/myce/auth/security/config/SecurityConfig.java
@@ -64,7 +64,7 @@ public class SecurityConfig {
         http.authorizeHttpRequests(auth ->
                 auth.requestMatchers(HttpMethod.POST, "/api/auth/**")
                         .permitAll()
-                        .requestMatchers(HttpMethod.GET, "/api/ads", "/api/auth/**", "/api/sse/subscribe")
+                        .requestMatchers(HttpMethod.GET, "/api/ads", "/api/auth/**")
                         .permitAll()
                         .requestMatchers(
                                 "/swagger-ui/**",

--- a/src/main/java/com/myce/auth/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/myce/auth/security/filter/JwtAuthenticationFilter.java
@@ -98,6 +98,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         return true;
     }
 
+    // ASYNC 디스패치는 필터 비활성화
+    @Override
+    protected boolean shouldNotFilterAsyncDispatch() {
+        return false;
+    }
+
     private void setErrorResponse(HttpServletResponse response, String code) throws IOException {
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         response.setContentType("application/json;charset=UTF-8");

--- a/src/main/java/com/myce/notification/controller/SseController.java
+++ b/src/main/java/com/myce/notification/controller/SseController.java
@@ -1,0 +1,29 @@
+package com.myce.notification.controller;
+
+import com.myce.auth.dto.CustomUserDetails;
+import com.myce.notification.service.SseService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class SseController {
+    private final SseService sseService;
+
+    @GetMapping(value = "/api/sse/subscribe", produces = "text/event-stream")
+    public ResponseEntity<SseEmitter> subscribe(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        Long memberId = customUserDetails.getMemberId();
+
+        log.trace("initialize Sse Connection for MemberId:" + memberId);
+
+        return ResponseEntity.ok(sseService.subscribe(memberId));
+    }
+
+}

--- a/src/main/java/com/myce/notification/repository/EmitterRepository.java
+++ b/src/main/java/com/myce/notification/repository/EmitterRepository.java
@@ -1,0 +1,12 @@
+package com.myce.notification.repository;
+
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.List;
+
+public interface EmitterRepository {
+    SseEmitter save(String emitterId, SseEmitter sseEmitter);
+    void removeSseEmitter(String memberId);
+    List<SseEmitter> findAllSseEmitterByMemberId(String memberId);
+}

--- a/src/main/java/com/myce/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/myce/notification/repository/NotificationRepository.java
@@ -1,0 +1,7 @@
+package com.myce.notification.repository;
+
+import com.myce.notification.document.Notification;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface NotificationRepository extends MongoRepository<Notification, String> {
+}

--- a/src/main/java/com/myce/notification/repository/impl/EmitterRepositoryImpl.java
+++ b/src/main/java/com/myce/notification/repository/impl/EmitterRepositoryImpl.java
@@ -1,0 +1,32 @@
+package com.myce.notification.repository.impl;
+
+import com.myce.notification.repository.EmitterRepository;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Repository
+public class EmitterRepositoryImpl implements EmitterRepository {
+    private final Map<String, SseEmitter> sseEmitters = new ConcurrentHashMap<>();
+
+    public SseEmitter save(String emitterId, SseEmitter sseEmitter) {
+        sseEmitters.put(emitterId, sseEmitter);
+        return sseEmitter;
+    }
+
+    public void removeSseEmitter(String memberId) {
+        sseEmitters.remove(memberId);
+    }
+
+    public List<SseEmitter> findAllSseEmitterByMemberId(String memberId) {
+        System.out.println("sseEmitters.keySet(): " + sseEmitters.keySet());
+        return sseEmitters.keySet().stream()
+                .filter((key)
+                        -> key.startsWith(memberId + "_"))
+                .map(sseEmitters::get)
+                .toList();
+    }
+}

--- a/src/main/java/com/myce/notification/repository/impl/EmitterRepositoryImpl.java
+++ b/src/main/java/com/myce/notification/repository/impl/EmitterRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.myce.notification.repository.impl;
 
 import com.myce.notification.repository.EmitterRepository;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -9,11 +10,13 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Repository
+@Slf4j
 public class EmitterRepositoryImpl implements EmitterRepository {
     private final Map<String, SseEmitter> sseEmitters = new ConcurrentHashMap<>();
 
     public SseEmitter save(String emitterId, SseEmitter sseEmitter) {
         sseEmitters.put(emitterId, sseEmitter);
+        log.info("Emitters now: {}", sseEmitters.keySet());
         return sseEmitter;
     }
 
@@ -22,7 +25,6 @@ public class EmitterRepositoryImpl implements EmitterRepository {
     }
 
     public List<SseEmitter> findAllSseEmitterByMemberId(String memberId) {
-        System.out.println("sseEmitters.keySet(): " + sseEmitters.keySet());
         return sseEmitters.keySet().stream()
                 .filter((key)
                         -> key.startsWith(memberId + "_"))

--- a/src/main/java/com/myce/notification/service/SseService.java
+++ b/src/main/java/com/myce/notification/service/SseService.java
@@ -1,0 +1,8 @@
+package com.myce.notification.service;
+
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+public interface SseService {
+    SseEmitter subscribe(Long memberId);
+    void notifyToExpoClient(Long expoId, String content);
+}

--- a/src/main/java/com/myce/notification/service/impl/SseServiceImpl.java
+++ b/src/main/java/com/myce/notification/service/impl/SseServiceImpl.java
@@ -19,7 +19,7 @@ import java.util.List;
 public class SseServiceImpl implements SseService {
     private final EmitterRepository emitterRepository;
     private final ReservationRepository reservationRepository;
-    private static final Long DEFAULT_TIMEOUT = 10L * 1000;
+    private static final Long DEFAULT_TIMEOUT = 60L * 1000 * 3;
 
     public SseEmitter subscribe(Long memberId) {
         String emitterId = memberId + "_" + System.currentTimeMillis();

--- a/src/main/java/com/myce/notification/service/impl/SseServiceImpl.java
+++ b/src/main/java/com/myce/notification/service/impl/SseServiceImpl.java
@@ -26,12 +26,15 @@ public class SseServiceImpl implements SseService {
         SseEmitter sseEmitter = new SseEmitter(DEFAULT_TIMEOUT);
         emitterRepository.save(emitterId, sseEmitter);
 
+        sseEmitter.onCompletion(() -> {
+            log.info("sseEmitter completion, emitterId: {}", emitterId);
+            emitterRepository.removeSseEmitter(emitterId);
+        });
+
         sseEmitter.onTimeout(() -> {
             log.info("sseEmitter timeout, emitterId: {}", emitterId);
-            sseEmitter.complete();
+            emitterRepository.removeSseEmitter(emitterId);
         });
-        sseEmitter.onCompletion(() ->
-            emitterRepository.removeSseEmitter(emitterId));
 
         sendMessage(sseEmitter, "SSE connected, emitterId: " + emitterId);
 
@@ -41,8 +44,8 @@ public class SseServiceImpl implements SseService {
     public void notifyToExpoClient(Long expoId, String content) {
         List<Long> allReservationMemberId = reservationRepository
                 .findAllMemberIdByExpoIdAndStatusAndUserType(
-                expoId, ReservationStatus.CONFIRMED, UserType.MEMBER
-        );
+                        expoId, ReservationStatus.CONFIRMED, UserType.MEMBER
+                );
         log.info("send notice to Expo Client: {}", allReservationMemberId);
         for (Long id : allReservationMemberId) {
             notifyMemberViaSseEmitters(id, content);
@@ -57,12 +60,13 @@ public class SseServiceImpl implements SseService {
         });
     }
 
-    private static void sendMessage(SseEmitter sseEmitter, String content) {
+    private void sendMessage(SseEmitter sseEmitter, String content) {
         try {
             sseEmitter.send(SseEmitter.event()
                     .data(content));
         } catch (IOException e) {
-            sseEmitter.complete();
+            log.error("Failed to send SSE message, sseEmitter complete with error.", e);
+            sseEmitter.completeWithError(e);
         }
     }
 

--- a/src/main/java/com/myce/notification/service/impl/SseServiceImpl.java
+++ b/src/main/java/com/myce/notification/service/impl/SseServiceImpl.java
@@ -28,7 +28,6 @@ public class SseServiceImpl implements SseService {
 
         sseEmitter.onTimeout(() -> {
             log.info("sseEmitter timeout, emitterId: {}", emitterId);
-            sendMessage(sseEmitter, "connectionTimeout");
             sseEmitter.complete();
         });
         sseEmitter.onCompletion(() ->

--- a/src/main/java/com/myce/notification/service/impl/SseServiceImpl.java
+++ b/src/main/java/com/myce/notification/service/impl/SseServiceImpl.java
@@ -1,0 +1,70 @@
+package com.myce.notification.service.impl;
+
+import com.myce.notification.repository.EmitterRepository;
+import com.myce.notification.service.SseService;
+import com.myce.reservation.entity.code.ReservationStatus;
+import com.myce.reservation.entity.code.UserType;
+import com.myce.reservation.repository.ReservationRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SseServiceImpl implements SseService {
+    private final EmitterRepository emitterRepository;
+    private final ReservationRepository reservationRepository;
+    private static final Long DEFAULT_TIMEOUT = 10L * 1000;
+
+    public SseEmitter subscribe(Long memberId) {
+        String emitterId = memberId + "_" + System.currentTimeMillis();
+        SseEmitter sseEmitter = new SseEmitter(DEFAULT_TIMEOUT);
+        emitterRepository.save(emitterId, sseEmitter);
+
+        sseEmitter.onTimeout(() -> {
+            log.info("sseEmitter timeout, emitterId: {}", emitterId);
+            sendMessage(sseEmitter, "connectionTimeout");
+            sseEmitter.complete();
+        });
+        sseEmitter.onCompletion(() ->
+            emitterRepository.removeSseEmitter(emitterId));
+
+        sendMessage(sseEmitter, "SSE connected, emitterId: " + emitterId);
+
+        return sseEmitter;
+    }
+
+    public void notifyToExpoClient(Long expoId, String content) {
+        List<Long> allReservationMemberId = reservationRepository
+                .findAllMemberIdByExpoIdAndStatusAndUserType(
+                expoId, ReservationStatus.CONFIRMED, UserType.MEMBER
+        );
+        log.info("send notice to Expo Client: {}", allReservationMemberId);
+        for (Long id : allReservationMemberId) {
+            notifyMemberViaSseEmitters(id, content);
+        }
+    }
+
+    private void notifyMemberViaSseEmitters(Long memberId, String content) {
+        List<SseEmitter> emitters = emitterRepository
+                .findAllSseEmitterByMemberId(String.valueOf(memberId));
+        emitters.forEach(sseEmitter -> {
+            sendMessage(sseEmitter, content);
+        });
+    }
+
+    private static void sendMessage(SseEmitter sseEmitter, String content) {
+        try {
+            sseEmitter.send(SseEmitter.event()
+                    .data(content));
+        } catch (IOException e) {
+            sseEmitter.complete();
+        }
+    }
+
+}

--- a/src/main/java/com/myce/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/myce/reservation/repository/ReservationRepository.java
@@ -4,14 +4,15 @@ import com.myce.reservation.dto.ExpoAdminPaymentBasicResponse;
 import com.myce.reservation.entity.Reservation;
 import com.myce.reservation.entity.code.ReservationStatus;
 import com.myce.reservation.entity.code.UserType;
-import java.util.List;
-import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
@@ -80,4 +81,18 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
             @Param("phone") String phone,
             Pageable pageable
     );
+
+    @Query("""
+           select distinct r.userId
+           from Reservation r
+           where r.expo.id = :expoId
+             and r.status = :status
+             and r.userType = :userType
+           """)
+    List<Long> findAllMemberIdByExpoIdAndStatusAndUserType(
+            @Param("expoId") Long expoId,
+            @Param("status") ReservationStatus status,
+            @Param("userType") UserType userType
+    );
+
 }


### PR DESCRIPTION
### 구현 기능
* SSE 알림 연결 기능
 : CustomUserDetail의 memberId를 기준으로 repository에 SseEmitter를 저장합니다. 여러 창 접속을 고려하여 중복 id 등록이 가능하도록 설계했습니다
* expoId를 조회하고 content를 통해 notice 전달

> 공지 메세지 템플릿 조회는 공지 타입에 대응하는 과정에서 현재 DB 테이블로는 구현 전 추가적인 논의가 필요할 것 같아 보류하였습니다.