### PR TITLE
[CRM-171] feat : 박람회&광고 요금제 추가 API 개발

### DIFF
--- a/src/main/java/com/myce/system/controller/AdFeeController.java
+++ b/src/main/java/com/myce/system/controller/AdFeeController.java
@@ -1,0 +1,25 @@
+package com.myce.system.controller;
+
+import com.myce.system.dto.fee.AdFeeRequest;
+import com.myce.system.service.fee.AdFeeService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/settings/ad-fee")
+public class AdFeeController {
+
+    private final AdFeeService adFeeService;
+
+    @PostMapping()
+    public ResponseEntity<Void> save(@RequestBody @Valid AdFeeRequest request) {
+        adFeeService.saveAdFee(request);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/myce/system/controller/ExpoFeeController.java
+++ b/src/main/java/com/myce/system/controller/ExpoFeeController.java
@@ -21,6 +21,6 @@ public class ExpoFeeController {
     @PostMapping
     public ResponseEntity<Void> save (@RequestBody @Valid ExpoFeeRequest request) {
         expoFeeService.saveExpoFee(request);
-        return ResponseEntity.status(HttpStatus.CREATED).build();
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/myce/system/controller/ExpoFeeController.java
+++ b/src/main/java/com/myce/system/controller/ExpoFeeController.java
@@ -1,0 +1,26 @@
+package com.myce.system.controller;
+
+import com.myce.system.dto.fee.ExpoFeeRequest;
+import com.myce.system.service.fee.ExpoFeeService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/settings/expo-fee")
+public class ExpoFeeController {
+
+    private final ExpoFeeService expoFeeService;
+
+    @PostMapping
+    public ResponseEntity<Void> save (@RequestBody @Valid ExpoFeeRequest request) {
+        expoFeeService.saveExpoFee(request);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+}

--- a/src/main/java/com/myce/system/dto/fee/AdFeeRequest.java
+++ b/src/main/java/com/myce/system/dto/fee/AdFeeRequest.java
@@ -1,0 +1,18 @@
+package com.myce.system.dto.fee;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AdFeeRequest {
+    @NotNull(message = "광고 위치를 입력해주세요.")
+    private Long positionId;
+    @NotNull(message = "이용료를 입력해주세요.")
+    @Min(value = 0, message = "이용료는 0원 이상 입력되어야 합니다.")
+    private Integer feePerDay;
+    @NotNull(message = "활성화 여부를 입력해주세요.")
+    private Boolean isActive;
+}

--- a/src/main/java/com/myce/system/dto/fee/ExpoFeeRequest.java
+++ b/src/main/java/com/myce/system/dto/fee/ExpoFeeRequest.java
@@ -1,0 +1,32 @@
+package com.myce.system.dto.fee;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@ToString
+@Getter
+@NoArgsConstructor
+public class ExpoFeeRequest {
+    @NotNull(message = "등록금을 입력해주세요.")
+    @Min(value = 0, message = "등록금은 0원 이상 입력되어야 합니다.")
+    private Integer deposit;
+
+    @NotNull(message = "프리미엄 서비스 요금을 입력해주세요.")
+    @Min(value = 0, message = "프리미엄 서비스 요금은 0원 이상 입력되어야 합니다. ")
+    private Integer premiumDeposit;
+
+    @NotNull(message = "정산 수수료를 입력해주세요.")
+    @Min(value = 0, message = "정산 수수료는 0 이상 입력되어야 합니다. ")
+    private BigDecimal settlementCommission;
+
+    @NotNull(message = "일일 사용료를 입력해주세요.")
+    @Min(value = 0, message = "일일 사용료는 0 이상 입력되어야 합니다. ")
+    private Integer dailyUsageFee;
+
+    @NotNull(message = "활성화 여부를 입력해주세요.")
+    private Boolean isActive;
+}

--- a/src/main/java/com/myce/system/entity/AdFeeSetting.java
+++ b/src/main/java/com/myce/system/entity/AdFeeSetting.java
@@ -59,4 +59,12 @@ public class AdFeeSetting {
         this.feePerDay = feePerDay;
         this.isActive = isActive;
     }
+
+    public void active() {
+        this.isActive = true;
+    }
+
+    public void inactive() {
+        this.isActive = false;
+    }
 }

--- a/src/main/java/com/myce/system/entity/ExpoFeeSetting.java
+++ b/src/main/java/com/myce/system/entity/ExpoFeeSetting.java
@@ -52,4 +52,12 @@ public class ExpoFeeSetting {
         this.dailyUsageFee = dailyUsageFee;
         this.isActive = isActive;
     }
+
+    public void inactive() {
+        this.isActive = false;
+    }
+
+    public void active() {
+        this.isActive = true;
+    }
 }

--- a/src/main/java/com/myce/system/service/fee/AdFeeService.java
+++ b/src/main/java/com/myce/system/service/fee/AdFeeService.java
@@ -1,0 +1,9 @@
+package com.myce.system.service.fee;
+
+import com.myce.system.dto.fee.AdFeeRequest;
+
+public interface AdFeeService {
+
+    void saveAdFee(AdFeeRequest request);
+
+}

--- a/src/main/java/com/myce/system/service/fee/ExpoFeeService.java
+++ b/src/main/java/com/myce/system/service/fee/ExpoFeeService.java
@@ -1,0 +1,7 @@
+package com.myce.system.service.fee;
+
+import com.myce.system.dto.fee.ExpoFeeRequest;
+
+public interface ExpoFeeService {
+    void saveExpoFee(ExpoFeeRequest request);
+}

--- a/src/main/java/com/myce/system/service/fee/impl/AdFeeServiceImpl.java
+++ b/src/main/java/com/myce/system/service/fee/impl/AdFeeServiceImpl.java
@@ -1,0 +1,54 @@
+package com.myce.system.service.fee.impl;
+
+import com.myce.advertisement.entity.AdPosition;
+import com.myce.advertisement.repository.AdPositionRepository;
+import com.myce.common.exception.CustomErrorCode;
+import com.myce.common.exception.CustomException;
+import com.myce.system.dto.fee.AdFeeRequest;
+import com.myce.system.entity.AdFeeSetting;
+import com.myce.system.repository.AdFeeSettingRepository;
+import com.myce.system.service.fee.AdFeeService;
+import com.myce.system.service.mapper.AdFeeMapper;
+import jakarta.transaction.Transactional;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AdFeeServiceImpl implements AdFeeService {
+
+    private final AdPositionRepository adPositionRepository;
+    private final AdFeeSettingRepository adFeeSettingRepository;
+    private final AdFeeMapper adFeeMapper;
+
+    @Override
+    @Transactional
+    public void saveAdFee(AdFeeRequest request) {
+        Long adPositionId = request.getPositionId();
+        AdPosition adPosition = adPositionRepository.findById(adPositionId)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.AD_POSITION_NOT_EXIST));
+
+        if(request.getIsActive()) {
+            updateAlreadyActiveSetting(adPositionId);
+        }
+
+        AdFeeSetting adFeeSetting = adFeeMapper.getAdFeeSetting(request, adPosition);
+        adFeeSettingRepository.save(adFeeSetting);
+    }
+
+    private void updateAlreadyActiveSetting(Long adPositionId) {
+        Optional<AdFeeSetting> optionalAdFeeSetting =
+                adFeeSettingRepository.findByAdPositionIdAndIsActiveTrue(adPositionId);
+        if(optionalAdFeeSetting.isEmpty()) return;
+
+        AdFeeSetting adFeeSetting = optionalAdFeeSetting.get();
+        log.debug("Change ad fee active status to inactive. adFeeId={}", adFeeSetting.getId());
+        adFeeSetting.inactive();
+        adFeeSettingRepository.save(adFeeSetting);
+        adFeeSettingRepository.flush();
+    }
+}

--- a/src/main/java/com/myce/system/service/fee/impl/ExpoFeeServiceImpl.java
+++ b/src/main/java/com/myce/system/service/fee/impl/ExpoFeeServiceImpl.java
@@ -1,0 +1,41 @@
+package com.myce.system.service.fee.impl;
+
+import com.myce.system.dto.fee.ExpoFeeRequest;
+import com.myce.system.entity.ExpoFeeSetting;
+import com.myce.system.repository.ExpoFeeSettingRepository;
+import com.myce.system.service.fee.ExpoFeeService;
+import com.myce.system.service.mapper.ExpoFeeMapper;
+import jakarta.transaction.Transactional;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ExpoFeeServiceImpl implements ExpoFeeService {
+
+    private final ExpoFeeMapper expoFeeMapper;
+    private final ExpoFeeSettingRepository expoFeeSettingRepository;
+
+    @Override
+    @Transactional
+    public void saveExpoFee(ExpoFeeRequest request) {
+        if(request.getIsActive()) {
+            updateInactiveExpoFee();
+        }
+
+        ExpoFeeSetting expoFeeSetting = expoFeeMapper.toExpoFeeSetting(request);
+        expoFeeSettingRepository.save(expoFeeSetting);
+    }
+
+    private void updateInactiveExpoFee() {
+        Optional<ExpoFeeSetting> expoFeeSettingOptional = expoFeeSettingRepository.findByIsActiveTrue();
+        if(expoFeeSettingOptional.isEmpty()) return;
+
+        ExpoFeeSetting expoFeeSetting = expoFeeSettingOptional.get();
+        log.debug("Change expo fee active status to inactive. expoFeeId={}", expoFeeSetting.getId());
+        expoFeeSetting.inactive();
+    }
+}

--- a/src/main/java/com/myce/system/service/mapper/AdFeeMapper.java
+++ b/src/main/java/com/myce/system/service/mapper/AdFeeMapper.java
@@ -1,0 +1,18 @@
+package com.myce.system.service.mapper;
+
+import com.myce.advertisement.entity.AdPosition;
+import com.myce.system.dto.fee.AdFeeRequest;
+import com.myce.system.entity.AdFeeSetting;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AdFeeMapper {
+
+    public AdFeeSetting getAdFeeSetting(AdFeeRequest request, AdPosition adPosition) {
+        return AdFeeSetting.builder()
+                .adPosition(adPosition)
+                .feePerDay(request.getFeePerDay())
+                .isActive(request.getIsActive())
+                .build();
+    }
+}

--- a/src/main/java/com/myce/system/service/mapper/ExpoFeeMapper.java
+++ b/src/main/java/com/myce/system/service/mapper/ExpoFeeMapper.java
@@ -1,0 +1,20 @@
+package com.myce.system.service.mapper;
+
+import com.myce.system.dto.fee.ExpoFeeRequest;
+import com.myce.system.entity.ExpoFeeSetting;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ExpoFeeMapper {
+
+    public ExpoFeeSetting toExpoFeeSetting(ExpoFeeRequest request) {
+        return ExpoFeeSetting.builder()
+                .deposit(request.getDeposit())
+                .premiumDeposit(request.getPremiumDeposit())
+                .settlementCommission(request.getSettlementCommission())
+                .dailyUsageFee(request.getDailyUsageFee())
+                .isActive(request.getIsActive())
+                .build();
+    }
+
+}

--- a/src/main/java/com/myce/system/service/message/impl/GenerateMessageServiceImpl.java
+++ b/src/main/java/com/myce/system/service/message/impl/GenerateMessageServiceImpl.java
@@ -1,4 +1,4 @@
-package com.myce.system.service.impl.message;
+package com.myce.system.service.message.impl;
 
 import com.myce.common.exception.CustomErrorCode;
 import com.myce.common.exception.CustomException;

--- a/src/main/java/com/myce/system/service/message/impl/MessageTemplateServiceImpl.java
+++ b/src/main/java/com/myce/system/service/message/impl/MessageTemplateServiceImpl.java
@@ -1,4 +1,4 @@
-package com.myce.system.service.impl.message;
+package com.myce.system.service.message.impl;
 
 import com.myce.common.exception.CustomErrorCode;
 import com.myce.common.exception.CustomException;


### PR DESCRIPTION
## 개발 내용
- 박람회 요금제 추가 API 개발 -> `/api/settings/expo-fee`
- 광고 요금제 추가 API 개발 -> `/api/settings/ad-fee`

> 추가 요금제가 Active로 들어갈 시 기존 요금제에 대해서는 Inactive 처리