### PR TITLE
[CRM-172] feat : 박람회 요금제&광고 요금제 목록 조회

### DIFF
--- a/src/main/java/com/myce/system/controller/AdFeeController.java
+++ b/src/main/java/com/myce/system/controller/AdFeeController.java
@@ -27,9 +27,9 @@ public class AdFeeController {
     }
 
     @GetMapping
-    public ResponseEntity<AdFeeListResponse> findAll(
-            @RequestParam(defaultValue = "0", required = false, name = "page")int page,
-            @RequestParam(required = false, value = "position") Long positionId) {
+    public ResponseEntity<AdFeeListResponse> getAdFeeSettings(
+            @RequestParam(name = "page", defaultValue = "0", required = false)int page,
+            @RequestParam(value = "position", required = false) Long positionId) {
         AdFeeListResponse response = adFeeService.getAdFeeList(page, positionId);
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/myce/system/controller/AdFeeController.java
+++ b/src/main/java/com/myce/system/controller/AdFeeController.java
@@ -1,13 +1,16 @@
 package com.myce.system.controller;
 
+import com.myce.system.dto.fee.AdFeeListResponse;
 import com.myce.system.dto.fee.AdFeeRequest;
 import com.myce.system.service.fee.AdFeeService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -21,5 +24,13 @@ public class AdFeeController {
     public ResponseEntity<Void> save(@RequestBody @Valid AdFeeRequest request) {
         adFeeService.saveAdFee(request);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping
+    public ResponseEntity<AdFeeListResponse> findAll(
+            @RequestParam(defaultValue = "0", required = false, name = "page")int page,
+            @RequestParam(required = false, value = "position") Long positionId) {
+        AdFeeListResponse response = adFeeService.getAdFeeList(page, positionId);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/myce/system/controller/AdFeeController.java
+++ b/src/main/java/com/myce/system/controller/AdFeeController.java
@@ -29,8 +29,9 @@ public class AdFeeController {
     @GetMapping
     public ResponseEntity<AdFeeListResponse> getAdFeeSettings(
             @RequestParam(name = "page", defaultValue = "0", required = false)int page,
-            @RequestParam(value = "position", required = false) Long positionId) {
-        AdFeeListResponse response = adFeeService.getAdFeeList(page, positionId);
+            @RequestParam(value = "position", required = false) Long positionId,
+            @RequestParam(value = "name", required = false) String name) {
+        AdFeeListResponse response = adFeeService.getAdFeeList(page, positionId, name);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/myce/system/controller/ExpoFeeController.java
+++ b/src/main/java/com/myce/system/controller/ExpoFeeController.java
@@ -1,14 +1,17 @@
 package com.myce.system.controller;
 
+import com.myce.system.dto.fee.ExpoFeeListResponse;
 import com.myce.system.dto.fee.ExpoFeeRequest;
 import com.myce.system.service.fee.ExpoFeeService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -22,5 +25,14 @@ public class ExpoFeeController {
     public ResponseEntity<Void> save (@RequestBody @Valid ExpoFeeRequest request) {
         expoFeeService.saveExpoFee(request);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping
+    public ResponseEntity<ExpoFeeListResponse> getExpoFeeSettings(
+            @RequestParam(value = "page", defaultValue = "0", required = false) int page,
+            @RequestParam(value = "name", required = false) String name
+    ) {
+        ExpoFeeListResponse response = expoFeeService.getExpoFeeList(page, name);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/myce/system/dto/fee/AdFeeListResponse.java
+++ b/src/main/java/com/myce/system/dto/fee/AdFeeListResponse.java
@@ -1,0 +1,22 @@
+package com.myce.system.dto.fee;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class AdFeeListResponse {
+    private final int currentPage;
+    private final int totalPage;
+    private final List<AdFeeResponse> adFeeList;
+
+    public AdFeeListResponse(int currentPage, int totalPage) {
+        this.currentPage = currentPage;
+        this.totalPage = totalPage;
+        this.adFeeList = new ArrayList<>();
+    }
+
+    public void addAdFee(AdFeeResponse adFeeResponse) {
+        this.adFeeList.add(adFeeResponse);
+    }
+}

--- a/src/main/java/com/myce/system/dto/fee/AdFeeRequest.java
+++ b/src/main/java/com/myce/system/dto/fee/AdFeeRequest.java
@@ -1,6 +1,7 @@
 package com.myce.system.dto.fee;
 
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,6 +11,8 @@ import lombok.NoArgsConstructor;
 public class AdFeeRequest {
     @NotNull(message = "광고 위치를 입력해주세요.")
     private Long positionId;
+    @NotBlank(message = "요금설정명을 입력해주세요.")
+    private String name;
     @NotNull(message = "이용료를 입력해주세요.")
     @Min(value = 0, message = "이용료는 0원 이상 입력되어야 합니다.")
     private Integer feePerDay;

--- a/src/main/java/com/myce/system/dto/fee/AdFeeResponse.java
+++ b/src/main/java/com/myce/system/dto/fee/AdFeeResponse.java
@@ -7,11 +7,11 @@ import lombok.Getter;
 @Getter
 @Builder
 public class AdFeeResponse {
-    private Long id;
-    private String position;
-    private String name;
-    private int feePerDay;
-    private boolean isActive;
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
+    private final Long id;
+    private final String position;
+    private final String name;
+    private final int feePerDay;
+    private final boolean isActive;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
 }

--- a/src/main/java/com/myce/system/dto/fee/AdFeeResponse.java
+++ b/src/main/java/com/myce/system/dto/fee/AdFeeResponse.java
@@ -1,0 +1,17 @@
+package com.myce.system.dto.fee;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AdFeeResponse {
+    private Long id;
+    private String position;
+    private String name;
+    private int feePerDay;
+    private boolean isActive;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/myce/system/dto/fee/ExpoFeeListResponse.java
+++ b/src/main/java/com/myce/system/dto/fee/ExpoFeeListResponse.java
@@ -1,0 +1,22 @@
+package com.myce.system.dto.fee;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class ExpoFeeListResponse {
+    private final int currentPage;
+    private final int totalPage;
+    private final List<ExpoFeeResponse> expoFeeList;
+
+    public ExpoFeeListResponse(int currentPage, int totalPage) {
+        this.currentPage = currentPage;
+        this.totalPage = totalPage;
+        this.expoFeeList = new ArrayList<>();
+    }
+
+    public void addExpoFee(ExpoFeeResponse expoFeeResponse) {
+        this.expoFeeList.add(expoFeeResponse);
+    }
+}

--- a/src/main/java/com/myce/system/dto/fee/ExpoFeeResponse.java
+++ b/src/main/java/com/myce/system/dto/fee/ExpoFeeResponse.java
@@ -1,0 +1,20 @@
+package com.myce.system.dto.fee;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ExpoFeeResponse {
+    private final Long id;
+    private final String name;
+    private final int deposit;
+    private final int premiumDeposit;
+    private final BigDecimal settlementCommission;
+    private final int dailyUsageFee;
+    private final boolean isActive;
+    private final LocalDateTime createTime;
+    private final LocalDateTime updateTime;
+}

--- a/src/main/java/com/myce/system/entity/AdFeeSetting.java
+++ b/src/main/java/com/myce/system/entity/AdFeeSetting.java
@@ -39,6 +39,9 @@ public class AdFeeSetting {
     @JoinColumn(name = "ad_position_id", referencedColumnName = "ad_position_id", nullable = false)
     private AdPosition adPosition;
 
+    @Column(name="name", nullable = false, length = 30)
+    private String name;
+
     @Column(name = "fee_per_day", nullable = false)
     private Integer feePerDay;
 
@@ -54,8 +57,9 @@ public class AdFeeSetting {
     private LocalDateTime updatedAt;
 
     @Builder
-    public AdFeeSetting(AdPosition adPosition, Integer feePerDay, Boolean isActive) {
+    public AdFeeSetting(AdPosition adPosition, String name, Integer feePerDay, Boolean isActive) {
         this.adPosition = adPosition;
+        this.name = name;
         this.feePerDay = feePerDay;
         this.isActive = isActive;
     }

--- a/src/main/java/com/myce/system/entity/ExpoFeeSetting.java
+++ b/src/main/java/com/myce/system/entity/ExpoFeeSetting.java
@@ -20,6 +20,9 @@ public class ExpoFeeSetting {
     @Column(name = "expo_fee_setting_id")
     private Long id;
 
+    @Column(name="name", nullable = false, length = 30)
+    private String name;
+
     @Column(name = "deposit", nullable = false)
     private Integer deposit;
 
@@ -44,8 +47,9 @@ public class ExpoFeeSetting {
     private LocalDateTime updatedAt;
 
     @Builder
-    public ExpoFeeSetting(Integer deposit, Integer premiumDeposit, BigDecimal settlementCommission,
+    public ExpoFeeSetting(String name, Integer deposit, Integer premiumDeposit, BigDecimal settlementCommission,
                           Integer dailyUsageFee, Boolean isActive) {
+        this.name = name;
         this.deposit = deposit;
         this.premiumDeposit = premiumDeposit;
         this.settlementCommission = settlementCommission;

--- a/src/main/java/com/myce/system/repository/AdFeeSettingRepository.java
+++ b/src/main/java/com/myce/system/repository/AdFeeSettingRepository.java
@@ -1,11 +1,15 @@
 package com.myce.system.repository;
 
 import com.myce.system.entity.AdFeeSetting;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface AdFeeSettingRepository extends JpaRepository<AdFeeSetting, Long> {
+    Page<AdFeeSetting> findAll(Pageable pageable);
+    Page<AdFeeSetting> findAllByAdPosition_Id(Long positionId, Pageable pageable);
     Optional<AdFeeSetting> findByAdPositionIdAndIsActiveTrue(Long adPositionId);
     Optional<AdFeeSetting> findByAdPositionId(Long adPositionId);
 }

--- a/src/main/java/com/myce/system/repository/AdFeeSettingRepository.java
+++ b/src/main/java/com/myce/system/repository/AdFeeSettingRepository.java
@@ -3,13 +3,25 @@ package com.myce.system.repository;
 import com.myce.system.entity.AdFeeSetting;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface AdFeeSettingRepository extends JpaRepository<AdFeeSetting, Long> {
+    @EntityGraph(attributePaths = {"adPosition"}, type = EntityGraph.EntityGraphType.FETCH)
     Page<AdFeeSetting> findAll(Pageable pageable);
+
+    @EntityGraph(attributePaths = {"adPosition"}, type = EntityGraph.EntityGraphType.FETCH)
     Page<AdFeeSetting> findAllByAdPosition_Id(Long positionId, Pageable pageable);
+
+    @EntityGraph(attributePaths = {"adPosition"}, type = EntityGraph.EntityGraphType.FETCH)
+    Page<AdFeeSetting> findAllByNameContains(String name, Pageable pageable);
+
+    @EntityGraph(attributePaths = {"adPosition"}, type = EntityGraph.EntityGraphType.FETCH)
+    Page<AdFeeSetting> findAllByAdPosition_IdAndNameContaining(Long positionId, String name, Pageable pageable);
+
     Optional<AdFeeSetting> findByAdPositionIdAndIsActiveTrue(Long adPositionId);
+
     Optional<AdFeeSetting> findByAdPositionId(Long adPositionId);
 }

--- a/src/main/java/com/myce/system/repository/ExpoFeeSettingRepository.java
+++ b/src/main/java/com/myce/system/repository/ExpoFeeSettingRepository.java
@@ -1,6 +1,8 @@
 package com.myce.system.repository;
 
 import com.myce.system.entity.ExpoFeeSetting;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,4 +11,8 @@ import java.util.Optional;
 @Repository
 public interface ExpoFeeSettingRepository extends JpaRepository<ExpoFeeSetting, Long> {
     Optional<ExpoFeeSetting> findByIsActiveTrue();
+
+    Page<ExpoFeeSetting> findAll(Pageable pageable);
+
+    Page<ExpoFeeSetting> findAllByNameContaining(String name, Pageable pageable);
 }

--- a/src/main/java/com/myce/system/service/fee/AdFeeService.java
+++ b/src/main/java/com/myce/system/service/fee/AdFeeService.java
@@ -1,9 +1,11 @@
 package com.myce.system.service.fee;
 
+import com.myce.system.dto.fee.AdFeeListResponse;
 import com.myce.system.dto.fee.AdFeeRequest;
 
 public interface AdFeeService {
 
     void saveAdFee(AdFeeRequest request);
 
+    AdFeeListResponse getAdFeeList(int page, Long positionId);
 }

--- a/src/main/java/com/myce/system/service/fee/AdFeeService.java
+++ b/src/main/java/com/myce/system/service/fee/AdFeeService.java
@@ -7,5 +7,5 @@ public interface AdFeeService {
 
     void saveAdFee(AdFeeRequest request);
 
-    AdFeeListResponse getAdFeeList(int page, Long positionId);
+    AdFeeListResponse getAdFeeList(int page, Long positionId, String name);
 }

--- a/src/main/java/com/myce/system/service/fee/ExpoFeeService.java
+++ b/src/main/java/com/myce/system/service/fee/ExpoFeeService.java
@@ -1,7 +1,10 @@
 package com.myce.system.service.fee;
 
+import com.myce.system.dto.fee.ExpoFeeListResponse;
 import com.myce.system.dto.fee.ExpoFeeRequest;
 
 public interface ExpoFeeService {
     void saveExpoFee(ExpoFeeRequest request);
+
+    ExpoFeeListResponse getExpoFeeList(int page, String name);
 }

--- a/src/main/java/com/myce/system/service/fee/impl/AdFeeServiceImpl.java
+++ b/src/main/java/com/myce/system/service/fee/impl/AdFeeServiceImpl.java
@@ -4,15 +4,21 @@ import com.myce.advertisement.entity.AdPosition;
 import com.myce.advertisement.repository.AdPositionRepository;
 import com.myce.common.exception.CustomErrorCode;
 import com.myce.common.exception.CustomException;
+import com.myce.system.dto.fee.AdFeeListResponse;
 import com.myce.system.dto.fee.AdFeeRequest;
 import com.myce.system.entity.AdFeeSetting;
 import com.myce.system.repository.AdFeeSettingRepository;
 import com.myce.system.service.fee.AdFeeService;
 import com.myce.system.service.mapper.AdFeeMapper;
 import jakarta.transaction.Transactional;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 
@@ -38,6 +44,19 @@ public class AdFeeServiceImpl implements AdFeeService {
 
         AdFeeSetting adFeeSetting = adFeeMapper.getAdFeeSetting(request, adPosition);
         adFeeSettingRepository.save(adFeeSetting);
+    }
+
+    @Override
+    public AdFeeListResponse getAdFeeList(int page, Long positionId) {
+        Sort sort = Sort.by("createdAt").descending();
+        Pageable pageable = PageRequest.of(page, 10, sort);
+        Page<AdFeeSetting> adFeeSettings;
+
+        if(positionId != null) adFeeSettings =
+                adFeeSettingRepository.findAllByAdPosition_Id(positionId, pageable);
+        else adFeeSettings= adFeeSettingRepository.findAll(pageable);
+
+        return adFeeMapper.toListResponse(adFeeSettings);
     }
 
     private void updateAlreadyActiveSetting(Long adPositionId) {

--- a/src/main/java/com/myce/system/service/fee/impl/AdFeeServiceImpl.java
+++ b/src/main/java/com/myce/system/service/fee/impl/AdFeeServiceImpl.java
@@ -47,14 +47,19 @@ public class AdFeeServiceImpl implements AdFeeService {
     }
 
     @Override
-    public AdFeeListResponse getAdFeeList(int page, Long positionId) {
+    public AdFeeListResponse getAdFeeList(int page, Long positionId, String name) {
         Sort sort = Sort.by("createdAt").descending();
         Pageable pageable = PageRequest.of(page, 10, sort);
         Page<AdFeeSetting> adFeeSettings;
 
-        if(positionId != null) adFeeSettings =
-                adFeeSettingRepository.findAllByAdPosition_Id(positionId, pageable);
-        else adFeeSettings= adFeeSettingRepository.findAll(pageable);
+        if(positionId != null && name != null)
+            adFeeSettings = adFeeSettingRepository.findAllByAdPosition_IdAndNameContaining(positionId, name, pageable);
+        else if(positionId != null)
+            adFeeSettings = adFeeSettingRepository.findAllByAdPosition_Id(positionId, pageable);
+        else if(name != null)
+            adFeeSettings = adFeeSettingRepository.findAllByNameContains(name, pageable);
+        else
+            adFeeSettings= adFeeSettingRepository.findAll(pageable);
 
         return adFeeMapper.toListResponse(adFeeSettings);
     }

--- a/src/main/java/com/myce/system/service/fee/impl/ExpoFeeServiceImpl.java
+++ b/src/main/java/com/myce/system/service/fee/impl/ExpoFeeServiceImpl.java
@@ -23,14 +23,14 @@ public class ExpoFeeServiceImpl implements ExpoFeeService {
     @Transactional
     public void saveExpoFee(ExpoFeeRequest request) {
         if(request.getIsActive()) {
-            updateInactiveExpoFee();
+            updateAlreadyActiveSetting();
         }
 
         ExpoFeeSetting expoFeeSetting = expoFeeMapper.toExpoFeeSetting(request);
         expoFeeSettingRepository.save(expoFeeSetting);
     }
 
-    private void updateInactiveExpoFee() {
+    private void updateAlreadyActiveSetting() {
         Optional<ExpoFeeSetting> expoFeeSettingOptional = expoFeeSettingRepository.findByIsActiveTrue();
         if(expoFeeSettingOptional.isEmpty()) return;
 

--- a/src/main/java/com/myce/system/service/fee/impl/ExpoFeeServiceImpl.java
+++ b/src/main/java/com/myce/system/service/fee/impl/ExpoFeeServiceImpl.java
@@ -1,5 +1,6 @@
 package com.myce.system.service.fee.impl;
 
+import com.myce.system.dto.fee.ExpoFeeListResponse;
 import com.myce.system.dto.fee.ExpoFeeRequest;
 import com.myce.system.entity.ExpoFeeSetting;
 import com.myce.system.repository.ExpoFeeSettingRepository;
@@ -9,6 +10,10 @@ import jakarta.transaction.Transactional;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -28,6 +33,17 @@ public class ExpoFeeServiceImpl implements ExpoFeeService {
 
         ExpoFeeSetting expoFeeSetting = expoFeeMapper.toExpoFeeSetting(request);
         expoFeeSettingRepository.save(expoFeeSetting);
+    }
+
+    @Override
+    public ExpoFeeListResponse getExpoFeeList(int page, String name) {
+        Sort sort = Sort.by(Sort.Direction.DESC, "createdAt");
+        Pageable pageable = PageRequest.of(page, 10, sort);
+        Page<ExpoFeeSetting> expoFeeSettings;
+        if(name != null) expoFeeSettings = expoFeeSettingRepository.findAllByNameContaining(name, pageable);
+        else expoFeeSettings = expoFeeSettingRepository.findAll(pageable);
+
+        return expoFeeMapper.toListResponse(expoFeeSettings);
     }
 
     private void updateAlreadyActiveSetting() {

--- a/src/main/java/com/myce/system/service/mapper/AdFeeMapper.java
+++ b/src/main/java/com/myce/system/service/mapper/AdFeeMapper.java
@@ -5,7 +5,6 @@ import com.myce.system.dto.fee.AdFeeListResponse;
 import com.myce.system.dto.fee.AdFeeRequest;
 import com.myce.system.dto.fee.AdFeeResponse;
 import com.myce.system.entity.AdFeeSetting;
-import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
 
@@ -22,8 +21,9 @@ public class AdFeeMapper {
     }
 
     public AdFeeListResponse toListResponse(Page<AdFeeSetting> adFeeSettingList) {
-        AdFeeListResponse adFeeListResponse =
-                new AdFeeListResponse(adFeeSettingList.getNumber(), adFeeSettingList.getTotalPages());
+        int currentPage = adFeeSettingList.getNumber() + 1;
+        int totalPages = adFeeSettingList.getTotalPages();
+        AdFeeListResponse adFeeListResponse = new AdFeeListResponse(currentPage, totalPages);
         adFeeSettingList.forEach(adFeeSetting -> {
             AdFeeResponse response = toAdFeeResponse(adFeeSetting);
             adFeeListResponse.addAdFee(response);

--- a/src/main/java/com/myce/system/service/mapper/AdFeeMapper.java
+++ b/src/main/java/com/myce/system/service/mapper/AdFeeMapper.java
@@ -1,8 +1,12 @@
 package com.myce.system.service.mapper;
 
 import com.myce.advertisement.entity.AdPosition;
+import com.myce.system.dto.fee.AdFeeListResponse;
 import com.myce.system.dto.fee.AdFeeRequest;
+import com.myce.system.dto.fee.AdFeeResponse;
 import com.myce.system.entity.AdFeeSetting;
+import java.util.List;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -11,8 +15,32 @@ public class AdFeeMapper {
     public AdFeeSetting getAdFeeSetting(AdFeeRequest request, AdPosition adPosition) {
         return AdFeeSetting.builder()
                 .adPosition(adPosition)
+                .name(request.getName())
                 .feePerDay(request.getFeePerDay())
                 .isActive(request.getIsActive())
                 .build();
+    }
+
+    public AdFeeListResponse toListResponse(Page<AdFeeSetting> adFeeSettingList) {
+        AdFeeListResponse adFeeListResponse =
+                new AdFeeListResponse(adFeeSettingList.getNumber(), adFeeSettingList.getTotalPages());
+        adFeeSettingList.forEach(adFeeSetting -> {
+            AdFeeResponse response = toAdFeeResponse(adFeeSetting);
+            adFeeListResponse.addAdFee(response);
+        });
+        return adFeeListResponse;
+    }
+
+    private AdFeeResponse toAdFeeResponse(AdFeeSetting adFeeSetting) {
+        return AdFeeResponse.builder()
+                .id(adFeeSetting.getId())
+                .position(adFeeSetting.getAdPosition().getName())
+                .name(adFeeSetting.getName())
+                .feePerDay(adFeeSetting.getFeePerDay())
+                .isActive(adFeeSetting.getIsActive())
+                .createdAt(adFeeSetting.getCreatedAt())
+                .updatedAt(adFeeSetting.getUpdatedAt())
+                .build();
+
     }
 }

--- a/src/main/java/com/myce/system/service/mapper/ExpoFeeMapper.java
+++ b/src/main/java/com/myce/system/service/mapper/ExpoFeeMapper.java
@@ -1,7 +1,10 @@
 package com.myce.system.service.mapper;
 
+import com.myce.system.dto.fee.ExpoFeeListResponse;
 import com.myce.system.dto.fee.ExpoFeeRequest;
+import com.myce.system.dto.fee.ExpoFeeResponse;
 import com.myce.system.entity.ExpoFeeSetting;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -14,6 +17,31 @@ public class ExpoFeeMapper {
                 .settlementCommission(request.getSettlementCommission())
                 .dailyUsageFee(request.getDailyUsageFee())
                 .isActive(request.getIsActive())
+                .build();
+    }
+
+    public ExpoFeeListResponse toListResponse(Page<ExpoFeeSetting> expoFeeSettings) {
+        int currentPage = expoFeeSettings.getNumber() + 1;
+        int totalPages = expoFeeSettings.getTotalPages();
+        ExpoFeeListResponse expoFeeListResponse = new ExpoFeeListResponse(currentPage, totalPages);
+        expoFeeSettings.forEach(expoFeeSetting -> {
+            ExpoFeeResponse response = toResponse(expoFeeSetting);
+            expoFeeListResponse.addExpoFee(response);
+        });
+        return expoFeeListResponse;
+    }
+
+    private ExpoFeeResponse toResponse(ExpoFeeSetting expoFeeSetting) {
+        return ExpoFeeResponse.builder()
+                .id(expoFeeSetting.getId())
+                .name(expoFeeSetting.getName())
+                .deposit(expoFeeSetting.getDeposit())
+                .premiumDeposit(expoFeeSetting.getPremiumDeposit())
+                .settlementCommission(expoFeeSetting.getSettlementCommission())
+                .dailyUsageFee(expoFeeSetting.getDailyUsageFee())
+                .isActive(expoFeeSetting.getIsActive())
+                .createTime(expoFeeSetting.getCreatedAt())
+                .updateTime(expoFeeSetting.getUpdatedAt())
                 .build();
     }
 


### PR DESCRIPTION
## 개발 내용
- 박람회 요금제 목록 조회 -> `/api/settings/expo-fee`
  - 페이징 처리 -> `page={{num}}`
  - 이름 검색 -> `name={{value}}`
- 광고 요금제 목록 조회 -> `/api/settings/ad-fee`
  - 페이징 처리 -> `page={{num}}`
  - 광고 위치 검색 -> `position={{positionId}}`
  - 이름 검색 -> `name={{value}}`  