### PR TITLE
[CRM-175] feat : 요금제 활성화 설정 API 개발

### DIFF
--- a/src/main/java/com/myce/common/exception/CustomErrorCode.java
+++ b/src/main/java/com/myce/common/exception/CustomErrorCode.java
@@ -129,6 +129,9 @@ public enum CustomErrorCode {
 
     // 시스템 설정 에러
     NOT_EXIST_MESSAGE_TEMPLATE(HttpStatus.NOT_FOUND, "SY001", "메시지 템플릿이 존재하지 않습니다."),
+    NOT_EXIST_AD_FEE_SETTING(HttpStatus.NOT_FOUND, "SY002", "광고 요금제가 존재하지 않습니다."),
+    NOT_EXIST_EXPO_FEE_SETTING(HttpStatus.NOT_FOUND, "SY003", "박람회 요금제가 존재하지 않습니다."),
+    ALREADY_SET_ACTIVATION(HttpStatus.BAD_REQUEST, "SY004", "이미 설정되어있는 활성화 값입니다."),
 
     // 엑셀 EX
     EXCEL_EXPORT_FAILED(HttpStatus.NOT_FOUND, "EX001", "엑셀 추출에 실패하였습니다.");

--- a/src/main/java/com/myce/system/controller/AdFeeController.java
+++ b/src/main/java/com/myce/system/controller/AdFeeController.java
@@ -2,12 +2,15 @@ package com.myce.system.controller;
 
 import com.myce.system.dto.fee.AdFeeListResponse;
 import com.myce.system.dto.fee.AdFeeRequest;
+import com.myce.system.dto.fee.FeeActiveRequest;
 import com.myce.system.service.fee.AdFeeService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -20,7 +23,7 @@ public class AdFeeController {
 
     private final AdFeeService adFeeService;
 
-    @PostMapping()
+    @PostMapping
     public ResponseEntity<Void> save(@RequestBody @Valid AdFeeRequest request) {
         adFeeService.saveAdFee(request);
         return ResponseEntity.noContent().build();
@@ -33,5 +36,11 @@ public class AdFeeController {
             @RequestParam(value = "name", required = false) String name) {
         AdFeeListResponse response = adFeeService.getAdFeeList(page, positionId, name);
         return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/{id}/activation")
+    public ResponseEntity<Void> updateActivation(@PathVariable Long id, @RequestBody FeeActiveRequest request) {
+        adFeeService.updateAdFeeActivation(id, request);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/myce/system/controller/ExpoFeeController.java
+++ b/src/main/java/com/myce/system/controller/ExpoFeeController.java
@@ -2,13 +2,15 @@ package com.myce.system.controller;
 
 import com.myce.system.dto.fee.ExpoFeeListResponse;
 import com.myce.system.dto.fee.ExpoFeeRequest;
+import com.myce.system.dto.fee.FeeActiveRequest;
 import com.myce.system.service.fee.ExpoFeeService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -30,9 +32,14 @@ public class ExpoFeeController {
     @GetMapping
     public ResponseEntity<ExpoFeeListResponse> getExpoFeeSettings(
             @RequestParam(value = "page", defaultValue = "0", required = false) int page,
-            @RequestParam(value = "name", required = false) String name
-    ) {
+            @RequestParam(value = "name", required = false) String name) {
         ExpoFeeListResponse response = expoFeeService.getExpoFeeList(page, name);
         return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/{id}/activation")
+    public ResponseEntity<Void> updateActivation(@PathVariable Long id, @RequestBody FeeActiveRequest request) {
+        expoFeeService.updateExpoFeeActivation(id, request);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/myce/system/dto/fee/FeeActiveRequest.java
+++ b/src/main/java/com/myce/system/dto/fee/FeeActiveRequest.java
@@ -1,0 +1,13 @@
+package com.myce.system.dto.fee;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class FeeActiveRequest {
+
+    @NotNull(message = "활성화 여부를 입력해주세요.")
+    private Boolean isActive;
+}

--- a/src/main/java/com/myce/system/entity/AdFeeSetting.java
+++ b/src/main/java/com/myce/system/entity/AdFeeSetting.java
@@ -11,7 +11,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,11 +21,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity @Getter
 @NoArgsConstructor
-@Table(name = "ad_fee_setting",
-        uniqueConstraints = {
-                @UniqueConstraint(name = "uk_ad_position_active",
-                        columnNames = {"ad_position_id", "is_active"})
-        })
+@Table(name = "ad_fee_setting")
 @EntityListeners(AuditingEntityListener.class)
 public class AdFeeSetting {
 

--- a/src/main/java/com/myce/system/service/fee/AdFeeService.java
+++ b/src/main/java/com/myce/system/service/fee/AdFeeService.java
@@ -2,10 +2,13 @@ package com.myce.system.service.fee;
 
 import com.myce.system.dto.fee.AdFeeListResponse;
 import com.myce.system.dto.fee.AdFeeRequest;
+import com.myce.system.dto.fee.FeeActiveRequest;
 
 public interface AdFeeService {
 
     void saveAdFee(AdFeeRequest request);
 
     AdFeeListResponse getAdFeeList(int page, Long positionId, String name);
+
+    void updateAdFeeActivation(Long targetId, FeeActiveRequest request);
 }

--- a/src/main/java/com/myce/system/service/fee/ExpoFeeService.java
+++ b/src/main/java/com/myce/system/service/fee/ExpoFeeService.java
@@ -2,9 +2,12 @@ package com.myce.system.service.fee;
 
 import com.myce.system.dto.fee.ExpoFeeListResponse;
 import com.myce.system.dto.fee.ExpoFeeRequest;
+import com.myce.system.dto.fee.FeeActiveRequest;
 
 public interface ExpoFeeService {
     void saveExpoFee(ExpoFeeRequest request);
 
     ExpoFeeListResponse getExpoFeeList(int page, String name);
+
+    void updateExpoFeeActivation(Long targetId, FeeActiveRequest request);
 }

--- a/src/main/java/com/myce/system/service/fee/impl/AdFeeServiceImpl.java
+++ b/src/main/java/com/myce/system/service/fee/impl/AdFeeServiceImpl.java
@@ -6,12 +6,12 @@ import com.myce.common.exception.CustomErrorCode;
 import com.myce.common.exception.CustomException;
 import com.myce.system.dto.fee.AdFeeListResponse;
 import com.myce.system.dto.fee.AdFeeRequest;
+import com.myce.system.dto.fee.FeeActiveRequest;
 import com.myce.system.entity.AdFeeSetting;
 import com.myce.system.repository.AdFeeSettingRepository;
 import com.myce.system.service.fee.AdFeeService;
 import com.myce.system.service.mapper.AdFeeMapper;
 import jakarta.transaction.Transactional;
-import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -64,6 +64,23 @@ public class AdFeeServiceImpl implements AdFeeService {
         return adFeeMapper.toListResponse(adFeeSettings);
     }
 
+    @Override
+    @Transactional
+    public void updateAdFeeActivation(Long targetId, FeeActiveRequest request) {
+        AdFeeSetting adFeeSetting = adFeeSettingRepository.findById(targetId)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_EXIST_AD_FEE_SETTING));
+
+        boolean isActive = request.getIsActive();
+        if(isActive == adFeeSetting.getIsActive())
+            throw new CustomException(CustomErrorCode.ALREADY_SET_ACTIVATION);
+
+
+        if(isActive) {
+            updateAlreadyActiveSetting(adFeeSetting.getAdPosition().getId());
+            adFeeSetting.active();
+        } else adFeeSetting.inactive();
+    }
+
     private void updateAlreadyActiveSetting(Long adPositionId) {
         Optional<AdFeeSetting> optionalAdFeeSetting =
                 adFeeSettingRepository.findByAdPositionIdAndIsActiveTrue(adPositionId);
@@ -72,7 +89,5 @@ public class AdFeeServiceImpl implements AdFeeService {
         AdFeeSetting adFeeSetting = optionalAdFeeSetting.get();
         log.debug("Change ad fee active status to inactive. adFeeId={}", adFeeSetting.getId());
         adFeeSetting.inactive();
-        adFeeSettingRepository.save(adFeeSetting);
-        adFeeSettingRepository.flush();
     }
 }

--- a/src/main/java/com/myce/system/service/fee/impl/ExpoFeeServiceImpl.java
+++ b/src/main/java/com/myce/system/service/fee/impl/ExpoFeeServiceImpl.java
@@ -1,7 +1,10 @@
 package com.myce.system.service.fee.impl;
 
+import com.myce.common.exception.CustomErrorCode;
+import com.myce.common.exception.CustomException;
 import com.myce.system.dto.fee.ExpoFeeListResponse;
 import com.myce.system.dto.fee.ExpoFeeRequest;
+import com.myce.system.dto.fee.FeeActiveRequest;
 import com.myce.system.entity.ExpoFeeSetting;
 import com.myce.system.repository.ExpoFeeSettingRepository;
 import com.myce.system.service.fee.ExpoFeeService;
@@ -44,6 +47,19 @@ public class ExpoFeeServiceImpl implements ExpoFeeService {
         else expoFeeSettings = expoFeeSettingRepository.findAll(pageable);
 
         return expoFeeMapper.toListResponse(expoFeeSettings);
+    }
+
+    @Override
+    @Transactional
+    public void updateExpoFeeActivation(Long targetId, FeeActiveRequest request) {
+        ExpoFeeSetting expoFeeSetting = expoFeeSettingRepository.findById(targetId)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_EXIST_EXPO_FEE_SETTING));
+
+        boolean isActive = request.getIsActive();
+        if(isActive) {
+            updateAlreadyActiveSetting();
+            expoFeeSetting.active();
+        } else expoFeeSetting.inactive();
     }
 
     private void updateAlreadyActiveSetting() {


### PR DESCRIPTION
## 개발 내용
- 박람회 요금제 활성화 여부 설정 API 개발 -> `/api/settings/expo-fee/{id}/activation`
- 광고 요금제 활성화 여부 설정 API개발 -> `/api/settings/ad-fee/{id}/activation`
> 활성화 시 기존 활성화 요금제는 비활성화 처리


## 수정 내용
- AdFeeSetting의 position&isActive 유니크 설정 제거
  - 이유 : 요금제가 로그로 쌓이는 형식이라 여러개의 false가 존재할 수 있습니다. 