### PR TITLE
[CRM-141] 예약자 메일 전송 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.0'
 	implementation 'org.apache.poi:poi:5.4.1' //엑셀 추출 라이브러리
 	implementation 'org.apache.poi:poi-ooxml:5.4.1' //.xlsx API 포함
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/com/myce/notification/service/EmailSendService.java
+++ b/src/main/java/com/myce/notification/service/EmailSendService.java
@@ -1,5 +1,8 @@
 package com.myce.notification.service;
 
+import java.util.List;
+
 public interface EmailSendService {
     void sendMail(String to, String subject, String body);
+    void sendMailToMultiple(List<String> recipients, String subject, String content);
 }

--- a/src/main/java/com/myce/notification/service/impl/EmailSendServiceImpl.java
+++ b/src/main/java/com/myce/notification/service/impl/EmailSendServiceImpl.java
@@ -10,6 +10,7 @@ import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
 
 import java.io.UnsupportedEncodingException;
+import java.util.List;
 
 @Slf4j
 @Service
@@ -33,4 +34,22 @@ public class EmailSendServiceImpl implements EmailSendService {
         }
     }
 
+    public void sendMailToMultiple(List<String> recipients, String subject, String content){
+        MimeMessage mimeMessage = mailSender.createMimeMessage();
+        try {
+            MimeMessageHelper messageHelper = new MimeMessageHelper(mimeMessage, true, "UTF-8");
+            messageHelper.setFrom("noreply@myce.live", "MYCE");
+
+            String[] toArray = recipients.toArray(new String[0]);
+            messageHelper.setBcc(toArray);
+
+            messageHelper.setSubject(subject);
+            messageHelper.setText(content, true);
+
+            mailSender.send(mimeMessage);
+            log.info("Email sent successfully. from=noreply@myce.live, recipients={}명, subject={}", recipients.size(), subject);
+        } catch (MessagingException | UnsupportedEncodingException me) {
+            log.error("Failed to send email. recipients={}명, subject={}", recipients.size(), subject);
+        }
+    }
 }

--- a/src/main/java/com/myce/reservation/controller/ExpoAdminMailController.java
+++ b/src/main/java/com/myce/reservation/controller/ExpoAdminMailController.java
@@ -1,0 +1,30 @@
+package com.myce.reservation.controller;
+
+import com.myce.auth.dto.CustomUserDetails;
+import com.myce.auth.dto.type.LoginType;
+import com.myce.reservation.dto.ExpoAdminEmailRequest;
+import com.myce.reservation.service.ExpoAdminEmailService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/expos/{expoId}/emails")
+@RequiredArgsConstructor
+public class ExpoAdminMailController {
+
+    private final ExpoAdminEmailService service;
+
+    @PostMapping
+    public ResponseEntity<Void> sendEmail(
+            @PathVariable Long expoId,
+            @RequestBody @Valid ExpoAdminEmailRequest dto,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails){
+        Long memberId = customUserDetails.getMemberId();
+        LoginType loginType = customUserDetails.getLoginType();
+        service.sendMail(memberId,loginType,expoId,dto);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/myce/reservation/dto/ExpoAdminEmailRequest.java
+++ b/src/main/java/com/myce/reservation/dto/ExpoAdminEmailRequest.java
@@ -1,0 +1,22 @@
+package com.myce.reservation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class ExpoAdminEmailRequest {
+
+    @NotEmpty(message = "수신자는 비어있을 수 없습니다.")
+    private List<String> recipients;
+
+    @NotBlank(message = "제목 입력은 필수입니다.")
+    private String subject;
+
+    @NotBlank(message = "내용 입력은 필수입니다.")
+    private String content;
+}

--- a/src/main/java/com/myce/reservation/service/ExpoAdminEmailService.java
+++ b/src/main/java/com/myce/reservation/service/ExpoAdminEmailService.java
@@ -1,0 +1,8 @@
+package com.myce.reservation.service;
+
+import com.myce.auth.dto.type.LoginType;
+import com.myce.reservation.dto.ExpoAdminEmailRequest;
+
+public interface ExpoAdminEmailService {
+    void sendMail(Long memberId, LoginType loginType, Long expoId, ExpoAdminEmailRequest dto);
+}

--- a/src/main/java/com/myce/reservation/service/Impl/ExpoAdminEmailServiceImpl.java
+++ b/src/main/java/com/myce/reservation/service/Impl/ExpoAdminEmailServiceImpl.java
@@ -73,7 +73,6 @@ public class ExpoAdminEmailServiceImpl implements ExpoAdminEmailService {
 
         return templateEngine.process("mail/mail-basic",ctx);
     }
-
     private String toPreheader(String html, int maxLen) {
         if (html == null) return "";
         String text = html.replaceAll("<[^>]+>", " ").replaceAll("\\s+", " ").trim();

--- a/src/main/java/com/myce/reservation/service/Impl/ExpoAdminEmailServiceImpl.java
+++ b/src/main/java/com/myce/reservation/service/Impl/ExpoAdminEmailServiceImpl.java
@@ -1,0 +1,98 @@
+package com.myce.reservation.service.Impl;
+
+import com.myce.auth.dto.type.LoginType;
+import com.myce.common.entity.BusinessProfile;
+import com.myce.common.entity.type.TargetType;
+import com.myce.common.exception.CustomErrorCode;
+import com.myce.common.exception.CustomException;
+import com.myce.common.repository.BusinessProfileRepository;
+import com.myce.expo.entity.Expo;
+import com.myce.expo.repository.AdminPermissionRepository;
+import com.myce.expo.repository.ExpoRepository;
+import com.myce.notification.service.EmailSendService;
+import com.myce.reservation.dto.ExpoAdminEmailRequest;
+import com.myce.reservation.service.ExpoAdminEmailService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+
+import java.util.Locale;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ExpoAdminEmailServiceImpl implements ExpoAdminEmailService {
+
+    private final ExpoRepository expoRepository;
+    private final BusinessProfileRepository businessProfileRepository;
+    private final AdminPermissionRepository adminPermissionRepository;
+    private final EmailSendService emailSendService;
+    private final SpringTemplateEngine templateEngine;
+    
+    //TODO : 추후 링크 교체, 또는 @Value로 값 주입
+    private final String TERMS_URL= "http://www.myce.live";
+    private final String REFUND_URL = "http://www.myce.live";
+    private final String PRIVACY_URL = "http://www.myce.live";
+
+    @Override
+    public void sendMail(Long memberId, LoginType loginType, Long expoId, ExpoAdminEmailRequest dto) {
+        validateMyAccess(expoId, memberId, loginType);
+
+        String html = renderEmailHtml(expoId,dto);
+        emailSendService.sendMailToMultiple(dto.getRecipients(), dto.getSubject(), html);
+        //TODO : 이메일 로그 저장
+    }
+
+    //TODO: 1차 구현 이후 유틸메소드화(중복 코드들 제거 및 유지보수 용이하도록) 및 권한 로직 수정
+    private void validateMyAccess(Long expoId, Long memberId, LoginType loginType) {
+        if(memberId == null || loginType == null){
+            throw new CustomException(CustomErrorCode.MEMBER_NOT_EXIST);
+        }
+
+        switch(loginType){
+            case MEMBER -> {
+                if (!expoRepository.existsByIdAndMemberId(expoId, memberId)) {
+                    throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
+                }
+            }
+            case ADMIN_CODE -> {
+                if(!adminPermissionRepository.existsByAdminCodeIdAndAdminCodeExpoIdAndIsReserverListViewTrue(memberId, expoId)){
+                    throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
+                }
+            }
+            default -> throw new CustomException(CustomErrorCode.INVALID_LOGIN_TYPE);
+        }
+    }
+
+    private String renderEmailHtml(Long expoId, ExpoAdminEmailRequest dto){
+        String expoName = expoRepository.findById(expoId)
+                .map(Expo::getTitle)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.EXPO_NOT_FOUND));
+
+        Optional<BusinessProfile> profile = businessProfileRepository
+                .findByTargetIdAndTargetType(expoId,TargetType.EXPO);
+
+        String contactPhone = profile.map(BusinessProfile::getContactPhone).orElse(null);
+        String contactEmail = profile.map(BusinessProfile::getContactEmail).orElse(null);
+
+        Context ctx = new Context(Locale.KOREA);
+        ctx.setVariable("preheader", toPreheader(dto.getContent(), 80));
+        ctx.setVariable("subject", dto.getSubject());
+        ctx.setVariable("content", dto.getContent());
+        ctx.setVariable("expoName",expoName);
+        ctx.setVariable("contactPhone",contactPhone);
+        ctx.setVariable("contactEmail",contactEmail);
+        ctx.setVariable("termsUrl", TERMS_URL);
+        ctx.setVariable("refundUrl", REFUND_URL);
+        ctx.setVariable("privacyUrl", PRIVACY_URL);
+
+        return templateEngine.process("mail/mail-basic",ctx);
+    }
+
+    private String toPreheader(String html, int maxLen) {
+        if (html == null) return "";
+        String text = html.replaceAll("<[^>]+>", " ").replaceAll("\\s+", " ").trim();
+        return text.length() > maxLen ? text.substring(0, maxLen) + "…" : text;
+    }
+}

--- a/src/main/java/com/myce/reservation/service/Impl/ExpoAdminEmailServiceImpl.java
+++ b/src/main/java/com/myce/reservation/service/Impl/ExpoAdminEmailServiceImpl.java
@@ -12,6 +12,9 @@ import com.myce.expo.repository.ExpoRepository;
 import com.myce.notification.service.EmailSendService;
 import com.myce.reservation.dto.ExpoAdminEmailRequest;
 import com.myce.reservation.service.ExpoAdminEmailService;
+import com.myce.reservation.service.mapper.ExpoAdminEmailMapper;
+import com.myce.system.repository.EmailLogRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.thymeleaf.context.Context;
@@ -27,8 +30,10 @@ public class ExpoAdminEmailServiceImpl implements ExpoAdminEmailService {
     private final ExpoRepository expoRepository;
     private final BusinessProfileRepository businessProfileRepository;
     private final AdminPermissionRepository adminPermissionRepository;
+    private final EmailLogRepository emailLogRepository;
     private final EmailSendService emailSendService;
     private final SpringTemplateEngine templateEngine;
+    private final ExpoAdminEmailMapper mapper;
     
     //TODO : 추후 링크 교체, 또는 @Value로 값 주입
     private final String TERMS_URL= "http://www.myce.live";
@@ -36,35 +41,15 @@ public class ExpoAdminEmailServiceImpl implements ExpoAdminEmailService {
     private final String PRIVACY_URL = "http://www.myce.live";
 
     @Override
+    @Transactional
     public void sendMail(Long memberId, LoginType loginType, Long expoId, ExpoAdminEmailRequest dto) {
         validateMyAccess(expoId, memberId, loginType);
 
         String html = renderEmailHtml(expoId,dto);
         emailSendService.sendMailToMultiple(dto.getRecipients(), dto.getSubject(), html);
-        //TODO : 이메일 로그 저장
+
+        emailLogRepository.save(mapper.toDocument(expoId,dto));
     }
-
-    //TODO: 1차 구현 이후 유틸메소드화(중복 코드들 제거 및 유지보수 용이하도록) 및 권한 로직 수정
-    private void validateMyAccess(Long expoId, Long memberId, LoginType loginType) {
-        if(memberId == null || loginType == null){
-            throw new CustomException(CustomErrorCode.MEMBER_NOT_EXIST);
-        }
-
-        switch(loginType){
-            case MEMBER -> {
-                if (!expoRepository.existsByIdAndMemberId(expoId, memberId)) {
-                    throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
-                }
-            }
-            case ADMIN_CODE -> {
-                if(!adminPermissionRepository.existsByAdminCodeIdAndAdminCodeExpoIdAndIsReserverListViewTrue(memberId, expoId)){
-                    throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
-                }
-            }
-            default -> throw new CustomException(CustomErrorCode.INVALID_LOGIN_TYPE);
-        }
-    }
-
     private String renderEmailHtml(Long expoId, ExpoAdminEmailRequest dto){
         String expoName = expoRepository.findById(expoId)
                 .map(Expo::getTitle)
@@ -94,5 +79,26 @@ public class ExpoAdminEmailServiceImpl implements ExpoAdminEmailService {
         if (html == null) return "";
         String text = html.replaceAll("<[^>]+>", " ").replaceAll("\\s+", " ").trim();
         return text.length() > maxLen ? text.substring(0, maxLen) + "…" : text;
+    }
+
+    //TODO: 1차 구현 이후 유틸메소드화(중복 코드들 제거 및 유지보수 용이하도록) 및 권한 로직 수정
+    private void validateMyAccess(Long expoId, Long memberId, LoginType loginType) {
+        if(memberId == null || loginType == null){
+            throw new CustomException(CustomErrorCode.MEMBER_NOT_EXIST);
+        }
+
+        switch(loginType){
+            case MEMBER -> {
+                if (!expoRepository.existsByIdAndMemberId(expoId, memberId)) {
+                    throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
+                }
+            }
+            case ADMIN_CODE -> {
+                if(!adminPermissionRepository.existsByAdminCodeIdAndAdminCodeExpoIdAndIsReserverListViewTrue(memberId, expoId)){
+                    throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
+                }
+            }
+            default -> throw new CustomException(CustomErrorCode.INVALID_LOGIN_TYPE);
+        }
     }
 }

--- a/src/main/java/com/myce/reservation/service/mapper/ExpoAdminEmailMapper.java
+++ b/src/main/java/com/myce/reservation/service/mapper/ExpoAdminEmailMapper.java
@@ -1,0 +1,18 @@
+package com.myce.reservation.service.mapper;
+
+import com.myce.reservation.dto.ExpoAdminEmailRequest;
+import com.myce.system.document.EmailLog;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ExpoAdminEmailMapper {
+    public EmailLog toDocument(Long expoId, ExpoAdminEmailRequest dto){
+        return EmailLog.builder()
+                .expoId(expoId)
+                .subject(dto.getSubject())
+                .recipientNames(dto.getRecipients())
+                .recipientCount(dto.getRecipients().size())
+                .content(dto.getContent())
+                .build();
+    }
+}

--- a/src/main/java/com/myce/system/document/EmailLog.java
+++ b/src/main/java/com/myce/system/document/EmailLog.java
@@ -5,6 +5,7 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 
 @Getter
@@ -15,16 +16,18 @@ public class EmailLog {
     @Id
     private String id;
     private Long expoId;
-    private String title;
-    private String recipientName;
+    private String subject;
+    private List<String> recipientNames;
+    private Integer recipientCount;
     private String content;
     private LocalDateTime createdAt;
 
     @Builder
-    public EmailLog(Long expoId, String title, String recipientName, String content) {
+    public EmailLog(Long expoId, String subject, List<String> recipientNames, Integer recipientCount, String content) {
         this.expoId = expoId;
-        this.title = title;
-        this.recipientName = recipientName;
+        this.subject = subject;
+        this.recipientCount = recipientCount;
+        this.recipientNames = recipientNames;
         this.content = content;
         this.createdAt = LocalDateTime.now();
     }

--- a/src/main/java/com/myce/system/repository/EmailLogRepository.java
+++ b/src/main/java/com/myce/system/repository/EmailLogRepository.java
@@ -1,0 +1,7 @@
+package com.myce.system.repository;
+
+import com.myce.system.document.EmailLog;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface EmailLogRepository extends MongoRepository<EmailLog,String> {
+}

--- a/src/main/resources/templates/mail/mail-basic.html
+++ b/src/main/resources/templates/mail/mail-basic.html
@@ -1,0 +1,117 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>MYCE</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <style>
+        @media (max-width: 640px) {
+            .container { width: 100% !important; }
+            .px-32 { padding-left: 16px !important; padding-right: 16px !important; }
+        }
+    </style>
+</head>
+<body style="margin:0; padding:0; background:#f6f7f9;">
+
+<div style="display:none; max-height:0; overflow:hidden; opacity:0; color:transparent; mso-hide:all;"
+     th:text="${preheader}">${preheader}</div>
+
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#f6f7f9;">
+    <tr>
+        <td align="center" style="padding:24px 12px;">
+            <table role="presentation" width="600" class="container" cellpadding="0" cellspacing="0" style="width:600px; background:#ffffff; border-radius:8px; overflow:hidden;">
+                <!-- Header -->
+                <tr>
+                    <td class="px-32" style="padding:28px 32px 8px 32px; font-family: 'Apple SD Gothic Neo','Malgun Gothic','Segoe UI',Arial,sans-serif;">
+                        <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                            <tr>
+                                <td valign="middle" style="font-size:28px; font-weight:800; letter-spacing:0.4px; color:#111111;">
+                                    MYCE
+                                </td>
+                                <td valign="middle" align="right" style="font-size:12px; color:#666666;">
+                                    Manage Your Conference & Expos
+                                </td>
+                            </tr>
+                        </table>
+                        <div style="height:12px;"></div>
+                        <div style="border-bottom:2px solid #111111; width:100%;"></div>
+                    </td>
+                </tr>
+
+                <!-- Title -->
+                <tr>
+                    <td class="px-32" style="padding:28px 32px 8px 32px; font-family: 'Apple SD Gothic Neo','Malgun Gothic','Segoe UI',Arial,sans-serif;">
+                        <div style="font-size:23px; line-height:1.25; font-weight:800; color:#1a1a1a;"
+                             th:text="${subject}">제목</div>
+                    </td>
+                </tr>
+
+                <!-- Content -->
+                <tr>
+                    <td class="px-32" style="padding:8px 32px 8px 32px; font-family: 'Apple SD Gothic Neo','Malgun Gothic','Segoe UI',Arial,sans-serif;">
+                        <div style="font-size:15px; line-height:1.8; color:#222222;"
+                             th:utext="${content}">내용</div>
+                    </td>
+                </tr>
+
+                <!-- CONTACT START -->
+                <tr th:if="${expoName} or ${contactPhone} or ${contactEmail}">
+                    <td class="px-32" style="padding:16px 32px 8px 32px; font-family:'Apple SD Gothic Neo','Malgun Gothic','Segoe UI',Arial,sans-serif;">
+                        <div style="font-size:13px; line-height:1.7; color:#333;">
+                            <div style="background:#f9fafb; border:1px solid #eceff3; border-radius:6px; padding:12px 14px;">
+                                <p style="margin:0 0 6px 0; font-weight:700; color:#111;"
+                                   th:if="${expoName}" th:text="${expoName}">박람회 이름</p>
+                                <p style="margin:0 0 4px 0;" th:if="${contactPhone}">
+                                    담당자 연락처 : <span th:text="${contactPhone}">담당자 연락처</span>
+                                </p>
+                                <p style="margin:0;" th:if="${contactEmail}">
+                                    담당자 이메일 : <span th:text="${contactEmail}">담당자 이메일</span>
+                                </p>
+                            </div>
+                        </div>
+                    </td>
+                </tr>
+                <!-- CONTACT END -->
+
+                <!-- Divider -->
+                <tr>
+                    <td style="padding:0 32px;">
+                        <div style="border-top:1px solid #e9ebf0; width:100%;"></div>
+                    </td>
+                </tr>
+
+                <!-- Footer (발신전용 + 약관/정책) -->
+                <tr>
+                    <td class="px-32" style="padding:18px 32px 8px 32px; font-family: 'Apple SD Gothic Neo','Malgun Gothic','Segoe UI',Arial,sans-serif;">
+                        <div style="font-size:12px; line-height:1.7; color:#666666;">
+                            <p style="margin:0 0 8px 0;">본 메일은 발신전용입니다.</p>
+                            <p style="margin:0 0 8px 0;">
+                                MYCE는 티켓 중개(통신판매중개) 플랫폼으로, 행사 주최·운영의 책임은 각 주최자에게 있습니다.
+                            </p>
+                            <p style="margin:0 0 8px 0;">
+                                결제/취소/환불은 MYCE 고객센터를 통해 안내·처리됩니다.
+                            </p>
+                            <p style="margin:0 0 8px 0;">
+                                자세한 내용은 이용약관/환불정책/개인정보 처리방침을 확인해 주세요.
+                            </p>
+                            <p style="margin:8px 0 12px 0;">
+                                <a th:href="${termsUrl}"  style="color:#111111; text-decoration:underline;">이용약관</a>
+                                &nbsp;|&nbsp;
+                                <a th:href="${refundUrl}" style="color:#111111; text-decoration:underline;">환불정책</a>
+                                &nbsp;|&nbsp;
+                                <a th:href="${privacyUrl}" style="color:#111111; text-decoration:underline;">개인정보 처리방침</a>
+                            </p>
+                            <p style="margin:0; color:#888888;">© MYCE Corp. All rights reserved.</p>
+                        </div>
+                    </td>
+                </tr>
+
+                <tr><td style="height:24px;"></td></tr>
+            </table>
+
+            <div style="height:24px;"></div>
+        </td>
+    </tr>
+</table>
+</body>
+</html>


### PR DESCRIPTION
- 메일 템플릿을 위한 타임리프 의존성을 추가하였습니다.
- EmailSendService에 다중 메일 발송을 위한 메소드를 추가하였습니다.
- 권한 검증 로직은 1차 구현 이후 유틸메소드화(중복 코드들 제거 및 유지보수 용이하도록) 예정이며 게시가 종료된 박람회의 관리 페이지도 접근 할 수 있도록 수정 할 예정입니다.