### PR TITLE
[CRM-141] refactor : 이메일 전송 내역 확인을 위한 내부 클래스 추가

### DIFF
--- a/src/main/java/com/myce/reservation/dto/ExpoAdminEmailRequest.java
+++ b/src/main/java/com/myce/reservation/dto/ExpoAdminEmailRequest.java
@@ -6,13 +6,14 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
+import com.myce.system.document.EmailLog;
 
 @Getter
 @NoArgsConstructor
 public class ExpoAdminEmailRequest {
 
     @NotEmpty(message = "수신자는 비어있을 수 없습니다.")
-    private List<String> recipients;
+    private List<EmailLog.RecipientInfo> recipientInfos;
 
     @NotBlank(message = "제목 입력은 필수입니다.")
     private String subject;

--- a/src/main/java/com/myce/reservation/service/Impl/ExpoAdminEmailServiceImpl.java
+++ b/src/main/java/com/myce/reservation/service/Impl/ExpoAdminEmailServiceImpl.java
@@ -20,6 +20,7 @@ import org.springframework.stereotype.Service;
 import org.thymeleaf.context.Context;
 import org.thymeleaf.spring6.SpringTemplateEngine;
 
+import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 
@@ -46,7 +47,12 @@ public class ExpoAdminEmailServiceImpl implements ExpoAdminEmailService {
     public void sendMail(Long memberId, LoginType loginType, Long expoId, ExpoAdminEmailRequest dto) {
         validateMyAccess(expoId, memberId, loginType);
         String html = renderEmailHtml(expoId,dto);
-        emailSendService.sendMailToMultiple(dto.getRecipients(), dto.getSubject(), html);
+
+        List<String> emails = dto.getRecipientInfos().stream()
+                        .map(info -> info.getEmail())
+                        .toList();
+        emailSendService.sendMailToMultiple(emails, dto.getSubject(), html);
+
         emailLogRepository.save(mapper.toDocument(expoId,dto));
     }
     private String renderEmailHtml(Long expoId, ExpoAdminEmailRequest dto){

--- a/src/main/java/com/myce/reservation/service/mapper/ExpoAdminEmailMapper.java
+++ b/src/main/java/com/myce/reservation/service/mapper/ExpoAdminEmailMapper.java
@@ -10,8 +10,7 @@ public class ExpoAdminEmailMapper {
         return EmailLog.builder()
                 .expoId(expoId)
                 .subject(dto.getSubject())
-                .recipientNames(dto.getRecipients())
-                .recipientCount(dto.getRecipients().size())
+                .recipientInfos(dto.getRecipientInfos())
                 .content(dto.getContent())
                 .build();
     }

--- a/src/main/java/com/myce/system/document/EmailLog.java
+++ b/src/main/java/com/myce/system/document/EmailLog.java
@@ -17,18 +17,26 @@ public class EmailLog {
     private String id;
     private Long expoId;
     private String subject;
-    private List<String> recipientNames;
+    private List<RecipientInfo> recipientInfos;
     private Integer recipientCount;
     private String content;
     private LocalDateTime createdAt;
 
     @Builder
-    public EmailLog(Long expoId, String subject, List<String> recipientNames, Integer recipientCount, String content) {
+    public EmailLog(Long expoId, String subject, List<RecipientInfo> recipientInfos, String content) {
         this.expoId = expoId;
         this.subject = subject;
-        this.recipientCount = recipientCount;
-        this.recipientNames = recipientNames;
+        this.recipientInfos = recipientInfos;
+        this.recipientCount = recipientInfos.size();
         this.content = content;
         this.createdAt = LocalDateTime.now();
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class RecipientInfo {
+        private String email;
+        private String name;
     }
 }


### PR DESCRIPTION
<img width="1108" height="244" alt="image" src="https://github.com/user-attachments/assets/4e47a88f-28af-49c1-93c4-f6820bcc555e" />
이메일 전송 내역에서 이메일과 이름을 함께 조회할 수 있도록 리팩토링하였습니다.