### PR TITLE
[CRM-83] fix : 회원가입 시 아이디 비밀번호 체크 및 아이디 찾기 값 변경 

### DIFF
--- a/src/main/java/com/myce/auth/controller/AuthController.java
+++ b/src/main/java/com/myce/auth/controller/AuthController.java
@@ -38,8 +38,10 @@ public class AuthController {
     }
 
     @GetMapping("/find-id")
-    public ResponseEntity<FindLoginIdResponse> findLoginId(@RequestBody @Valid FindLoginIdRequest request) {
-        FindLoginIdResponse response = authService.getLoginId(request);
+    public ResponseEntity<FindLoginIdResponse> findLoginId(
+            @RequestParam(value = "name") String name,
+            @RequestParam(value = "email") String email) {
+        FindLoginIdResponse response = authService.getLoginId(name, email);
         return ResponseEntity.ok().body(response);
     }
 

--- a/src/main/java/com/myce/auth/service/AuthService.java
+++ b/src/main/java/com/myce/auth/service/AuthService.java
@@ -12,7 +12,7 @@ public interface AuthService {
 
     void signup(SignupRequest signupRequest);
 
-    FindLoginIdResponse getLoginId(FindLoginIdRequest findLoginIdRequest);
+    FindLoginIdResponse getLoginId(String name, String email);
 
     void sendTempPasswordMail(TempPasswordRequest request);
 

--- a/src/main/java/com/myce/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/myce/auth/service/impl/AuthServiceImpl.java
@@ -40,6 +40,14 @@ public class AuthServiceImpl implements AuthService {
     private final EmailSendService emailSendService;
 
     public void signup(SignupRequest signupRequest) {
+        if(memberRepository.existsByLoginId(signupRequest.getLoginId())) {
+            throw new CustomException(CustomErrorCode.ALREADY_EXIST_LOGIN_ID);
+        }
+
+        if(memberRepository.existsByEmail(signupRequest.getEmail())) {
+            throw new CustomException(CustomErrorCode.ALREADY_EXIST_EMAIL);
+        }
+
         MemberGrade memberGrade = memberGradeRepository.findByGradeCode(GradeCode.BRONZE).orElseThrow();
         String password = passwordEncoder.encode(signupRequest.getPassword());
         Member member = authMapper.signupRequestToMember(signupRequest, memberGrade, password);
@@ -48,8 +56,8 @@ public class AuthServiceImpl implements AuthService {
     }
 
     @Override
-    public FindLoginIdResponse getLoginId(FindLoginIdRequest request) {
-        Member member = memberRepository.findByNameAndEmail(request.getName(), request.getEmail())
+    public FindLoginIdResponse getLoginId(String name, String email) {
+        Member member = memberRepository.findByNameAndEmail(name, email)
                 .orElseThrow(() -> new CustomException(CustomErrorCode.MEMBER_NOT_EXIST));
         return authMapper.getFindLoginIdResponse(member.getLoginId());
     }

--- a/src/main/java/com/myce/common/exception/CustomErrorCode.java
+++ b/src/main/java/com/myce/common/exception/CustomErrorCode.java
@@ -24,6 +24,8 @@ public enum CustomErrorCode {
     CURRENT_PASSWORD_NOT_MATCH(HttpStatus.BAD_REQUEST, "M004", "기존 비밀번호가 일치하지 않습니다."),
     PASSWORD_CONFIRMATION_MISMATCH(HttpStatus.BAD_REQUEST, "M005", "새로운 비밀번호가 일치하지 않습니다."),
     GENDER_TYPE_INVALID(HttpStatus.BAD_REQUEST, "M006", "유효하지 않은 성별 값입니다."),
+    ALREADY_EXIST_LOGIN_ID(HttpStatus.BAD_REQUEST, "M007", "이미 존재하는 아이디입니다."),
+    ALREADY_EXIST_EMAIL(HttpStatus.BAD_REQUEST, "M008", "이미 존재하는 이메일입니다."),
 
     // 비회원 G
     GUEST_NOT_EXIST(HttpStatus.NOT_FOUND, "G001", "비회원 정보가 존재하지 않습니다."),

--- a/src/main/java/com/myce/member/repository/MemberRepository.java
+++ b/src/main/java/com/myce/member/repository/MemberRepository.java
@@ -17,6 +17,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     boolean existsByLoginId(String loginId);
 
+    boolean existsByEmail(String email);
+
     @Query("SELECT m FROM Member m WHERE m.id = (SELECT e.member.id FROM Expo e WHERE e.id=:expoId)")
     Optional<Member> findByExpoId(Long expoId);
 }


### PR DESCRIPTION
## 수정 내용
- Get메소드에 대한 API가 RequestBody를 쓰고 있어서 RequestParam으로 변경
- 회원가입 시 아이디, 이메일 중복 예외 처리