### PR TITLE
feat: 예상 결제 정보, 첨부 파일 칸 삭제

### DIFF
--- a/src/main/java/com/myce/expo/service/impl/ExpoServiceImpl.java
+++ b/src/main/java/com/myce/expo/service/impl/ExpoServiceImpl.java
@@ -20,12 +20,9 @@ import com.myce.expo.entity.Booth;
 import com.myce.expo.repository.BoothRepository;
 import com.myce.expo.service.mapper.BoothMapper;
 import com.myce.expo.entity.type.ExpoStatus;
-import com.myce.expo.entity.Ticket;
-import com.myce.expo.entity.type.ExpoStatus;
 import com.myce.expo.repository.CategoryRepository;
 import com.myce.expo.repository.ExpoRepository;
 import com.myce.expo.repository.ReviewRepository;
-import com.myce.expo.repository.TicketRepository;
 import com.myce.expo.repository.TicketRepository;
 import com.myce.expo.service.ExpoService;
 import com.myce.expo.service.mapper.ExpoMapper;
@@ -41,13 +38,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.stream.Collectors;
 
 @Service

--- a/src/main/java/com/myce/expo/service/impl/PlatformExpoManageServiceImpl.java
+++ b/src/main/java/com/myce/expo/service/impl/PlatformExpoManageServiceImpl.java
@@ -208,9 +208,14 @@ public class PlatformExpoManageServiceImpl implements PlatformExpoManageService 
         Integer deposit = feeSetting.getDeposit() != null ? feeSetting.getDeposit() : 0;
         Integer dailyUsageFee = feeSetting.getDailyUsageFee() != null ? feeSetting.getDailyUsageFee() : 0;
         Integer dailyFee = dailyUsageFee * totalDays;
-        Integer premiumDeposit = feeSetting.getPremiumDeposit() != null ? feeSetting.getPremiumDeposit() : 0;
-        Integer premiumFee = expo.getIsPremium() ? premiumDeposit : 0;
         
-        return deposit + dailyFee + premiumFee;
+        if (expo.getIsPremium()) {
+            // 프리미엄일 경우: 기본 등록금 + 프리미엄 이용료 + 사용료
+            Integer premiumDeposit = feeSetting.getPremiumDeposit() != null ? feeSetting.getPremiumDeposit() : 0;
+            return deposit + premiumDeposit + dailyFee;
+        } else {
+            // 기본일 경우: 기본 등록금 + 사용료
+            return deposit + dailyFee;
+        }
     }
 }

--- a/src/main/java/com/myce/expo/service/mapper/ExpoPaymentInfoMapper.java
+++ b/src/main/java/com/myce/expo/service/mapper/ExpoPaymentInfoMapper.java
@@ -27,8 +27,7 @@ public class ExpoPaymentInfoMapper {
                 .expo(expo)
                 .status(PaymentStatus.PENDING)
                 .deposit(feeSetting.getDeposit() != null ? feeSetting.getDeposit() : 0)
-                .premiumDeposit(expo.getIsPremium() ? 
-                    (feeSetting.getPremiumDeposit() != null ? feeSetting.getPremiumDeposit() : 0) : 0)
+                .premiumDeposit(feeSetting.getPremiumDeposit() != null ? feeSetting.getPremiumDeposit() : 0)
                 .totalDay(totalDays)
                 .dailyUsageFee(feeSetting.getDailyUsageFee() != null ? feeSetting.getDailyUsageFee() : 0)
                 .totalAmount(totalAmount)

--- a/src/main/java/com/myce/member/dto/expo/ExpoPaymentDetailResponse.java
+++ b/src/main/java/com/myce/member/dto/expo/ExpoPaymentDetailResponse.java
@@ -26,8 +26,7 @@ public class ExpoPaymentDetailResponse {
     private Integer totalDays;         // 총 일수
     private Integer dailyUsageFee;     // 일당 사용료
     private Integer usageFeeAmount;    // 사용료 총액 (일당 * 총일수)
-    private Integer depositAmount;     // 등록금 (프리미엄이면 premiumDeposit, 아니면 deposit)
-    private Integer totalAmount;       // 총 결제해야 할 금액
+    private Integer depositAmount;     // 기본 등록금
+    private Integer premiumDepositAmount; // 프리미엄 이용료 (프리미엄일 때만)
     private Boolean isPremium;         // 프리미엄 여부
-    private BigDecimal commissionRate; // 수수료율 (퍼센트)
 }

--- a/src/main/java/com/myce/member/mapper/expo/ExpoPaymentDetailMapper.java
+++ b/src/main/java/com/myce/member/mapper/expo/ExpoPaymentDetailMapper.java
@@ -16,10 +16,9 @@ public class ExpoPaymentDetailMapper {
         // 사용료 총액 계산 (일당 * 총일수)
         int usageFeeAmount = expoPaymentInfo.getDailyUsageFee() * expoPaymentInfo.getTotalDay();
         
-        // 등록금 계산 (프리미엄이면 premiumDeposit, 아니면 deposit)
-        int depositAmount = expo.getIsPremium() ? 
-                expoPaymentInfo.getPremiumDeposit() : 
-                expoPaymentInfo.getDeposit();
+        // 기본 등록금과 프리미엄 이용료 분리
+        int depositAmount = expoPaymentInfo.getDeposit();
+        Integer premiumDepositAmount = expo.getIsPremium() ? expoPaymentInfo.getPremiumDeposit() : null;
         
         return ExpoPaymentDetailResponse.builder()
                 .expoTitle(expo.getTitle())
@@ -31,9 +30,8 @@ public class ExpoPaymentDetailMapper {
                 .dailyUsageFee(expoPaymentInfo.getDailyUsageFee())
                 .usageFeeAmount(usageFeeAmount)
                 .depositAmount(depositAmount)
-                .totalAmount(expoPaymentInfo.getTotalAmount())
+                .premiumDepositAmount(premiumDepositAmount)
                 .isPremium(expo.getIsPremium())
-                .commissionRate(expoPaymentInfo.getCommissionRate())
                 .build();
     }
 }


### PR DESCRIPTION
      결제 신청 모달에서 수수료 삭제
      예상 결제 정보 삭제
      결제 정보 조회 버튼 추가

      행사 정보도 확인할수 있도록 수정
      티켓 없을시 티켓 구매 버튼 비활성화 대신 티켓 구매 드롭다운 클릭시 없다고 보여줘

      주최자랑 연락처정보 상세설명 칸으로 이관

      행사 가격 프론트에서 제거

      QR체크인 관리자 대시보드 창으로 이동
      마이페이지- 박람회 신청 내역에 관리자 페이지 이동 탭 추가