### PR TITLE
fix : 전체 이메일 전송 버그 수정

### DIFF
--- a/src/main/java/com/myce/reservation/repository/ReserverRepository.java
+++ b/src/main/java/com/myce/reservation/repository/ReserverRepository.java
@@ -156,4 +156,38 @@ public interface ReserverRepository extends JpaRepository<Reserver, Long> {
         where res.id = :reservationId
     """)
     List<ExpoAdminPaymentDetailResponse> findDetailById(@Param("reservationId") Long reservationId);
+
+    @Query("""
+          SELECT DISTINCT rv
+          FROM Reserver rv
+          JOIN rv.reservation r
+          JOIN r.ticket t
+          LEFT JOIN com.myce.qrcode.entity.QrCode qc ON qc.reserver = rv
+          WHERE r.expo.id = :expoId
+            AND r.status = com.myce.reservation.entity.code.ReservationStatus.CONFIRMED
+            AND (:name IS NULL OR LOWER(rv.name) LIKE LOWER(CONCAT('%', :name, '%')))
+            AND (:phone IS NULL OR rv.phone LIKE CONCAT('%', :phone, '%'))
+            AND (:reservationCode IS NULL OR r.reservationCode LIKE CONCAT('%', :reservationCode, '%'))
+            AND (:ticketName IS NULL OR t.name = :ticketName)
+            AND (
+              :entranceStatus IS NULL OR
+              (
+                (:entranceStatus = '입장 완료' AND qc.status = com.myce.qrcode.entity.code.QrCodeStatus.USED)
+                OR (:entranceStatus = '티켓 만료' AND qc.status = com.myce.qrcode.entity.code.QrCodeStatus.EXPIRED)
+                OR (:entranceStatus = '발급 대기' AND qc.id IS NULL)
+                OR (:entranceStatus = '입장 전' AND qc.status IN (
+                      com.myce.qrcode.entity.code.QrCodeStatus.APPROVED,
+                      com.myce.qrcode.entity.code.QrCodeStatus.ACTIVE
+                    ))
+              )
+            )
+    """)
+    List<Reserver> findReserversByFilter(
+            @Param("expoId") Long expoId,
+            @Param("entranceStatus") String entranceStatus,
+            @Param("name") String name,
+            @Param("phone") String phone,
+            @Param("reservationCode") String reservationCode,
+            @Param("ticketName") String ticketName
+    );
 }

--- a/src/main/java/com/myce/system/controller/ExpoAdminEmailController.java
+++ b/src/main/java/com/myce/system/controller/ExpoAdminEmailController.java
@@ -30,10 +30,15 @@ public class ExpoAdminEmailController {
     public ResponseEntity<Void> sendEmail(
             @PathVariable Long expoId,
             @RequestBody @Valid ExpoAdminEmailRequest dto,
+            @RequestParam(required = false) String entranceStatus,
+            @RequestParam(required = false) String name,
+            @RequestParam(required = false) String phone,
+            @RequestParam(required = false) String reservationCode,
+            @RequestParam(required = false) String ticketName,
             @AuthenticationPrincipal CustomUserDetails customUserDetails){
         Long memberId = customUserDetails.getMemberId();
         LoginType loginType = customUserDetails.getLoginType();
-        service.sendMail(memberId,loginType,expoId,dto);
+        service.sendMail(memberId,loginType,expoId,dto,entranceStatus,name,phone,reservationCode,ticketName);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/myce/system/service/email/ExpoAdminEmailService.java
+++ b/src/main/java/com/myce/system/service/email/ExpoAdminEmailService.java
@@ -4,5 +4,13 @@ import com.myce.auth.dto.type.LoginType;
 import com.myce.system.dto.email.ExpoAdminEmailRequest;
 
 public interface ExpoAdminEmailService {
-    void sendMail(Long memberId, LoginType loginType, Long expoId, ExpoAdminEmailRequest dto);
+    void sendMail(Long memberId,
+                  LoginType loginType,
+                  Long expoId,
+                  ExpoAdminEmailRequest dto,
+                  String entranceStatus,
+                  String name,
+                  String phone,
+                  String reservationCode,
+                  String ticketName);
 }

--- a/src/main/java/com/myce/system/service/email/Impl/ExpoAdminEmailServiceImpl.java
+++ b/src/main/java/com/myce/system/service/email/Impl/ExpoAdminEmailServiceImpl.java
@@ -47,13 +47,22 @@ public class ExpoAdminEmailServiceImpl implements ExpoAdminEmailService {
 
     @Override
     @Transactional
-    public void sendMail(Long memberId, LoginType loginType, Long expoId, ExpoAdminEmailRequest dto) {
+    public void sendMail(Long memberId,
+                         LoginType loginType,
+                         Long expoId,
+                         ExpoAdminEmailRequest dto,
+                         String entranceStatus,
+                         String name,
+                         String phone,
+                         String reservationCode,
+                         String ticketName) {
+
         validateMyAccess(expoId, memberId, loginType);
         String html = renderEmailHtml(expoId,dto);
 
         List<EmailLog.RecipientInfo> recipientInfos;
         if(dto.isSelectAllMatching()){
-            recipientInfos = reserverRepository.findReserversByExpo(expoId)
+            recipientInfos = reserverRepository.findReserversByFilter(expoId, entranceStatus, name, phone, reservationCode, ticketName)
                     .stream()
                     .map(r -> new EmailLog.RecipientInfo(r.getEmail(),r.getName()))
                     .toList();
@@ -64,7 +73,8 @@ public class ExpoAdminEmailServiceImpl implements ExpoAdminEmailService {
         List<String> emails = recipientInfos.stream()
                         .map(EmailLog.RecipientInfo::getEmail)
                         .toList();
-        emailSendService.sendMailToMultiple(emails, dto.getSubject(), html);
+        
+        emailSendService.sendMailToMultiple(emails, dto.getSubject(), html); //TODO: 추후 대량 이메일 전송 대비 배치 도입 고려
 
         emailLogRepository.save(mapper.toDocument(expoId,dto,recipientInfos));
     }


### PR DESCRIPTION
전체 선택 모드에서 이메일 전송 시, 현재 사용자의 탭 상태와 검색 결과가
쿼리에 반영되지 않아 의도하지 않은 수신자에게 메일이 전송되는 문제가 있었습니다.

이제 전체 선택 시에도 현재 필터(탭, 검색어, 티켓명, 입장 상태 등)를
쿼리 파라미터로 전달하여, 검색 결과에 포함된 수신자에게만 전체 메일이 발송되도록 수정했습니다.

* 전체 전송이 아닌 일반 선택 메일 전송에는 문제 없는 것 같습니다.