### PR TITLE
[CRM-179] 권한별 회원 목록 조회

### DIFF
--- a/src/main/java/com/myce/common/exception/CustomErrorCode.java
+++ b/src/main/java/com/myce/common/exception/CustomErrorCode.java
@@ -26,6 +26,7 @@ public enum CustomErrorCode {
     GENDER_TYPE_INVALID(HttpStatus.BAD_REQUEST, "M006", "유효하지 않은 성별 값입니다."),
     ALREADY_EXIST_LOGIN_ID(HttpStatus.BAD_REQUEST, "M007", "이미 존재하는 아이디입니다."),
     ALREADY_EXIST_EMAIL(HttpStatus.BAD_REQUEST, "M008", "이미 존재하는 이메일입니다."),
+    MEMBER_ROLE_NOT_EXIST(HttpStatus.NOT_FOUND, "M009", "존재하지 않는 권한입니다."),
 
     // 비회원 G
     GUEST_NOT_EXIST(HttpStatus.NOT_FOUND, "G001", "비회원 정보가 존재하지 않습니다."),

--- a/src/main/java/com/myce/member/controller/MemberController.java
+++ b/src/main/java/com/myce/member/controller/MemberController.java
@@ -1,6 +1,7 @@
 package com.myce.member.controller;
 
 import com.myce.auth.dto.CustomUserDetails;
+import com.myce.member.dto.MemberInfoListResponse;
 import com.myce.member.dto.MemberInfoResponse;
 import com.myce.member.dto.MileageUpdateRequest;
 import com.myce.member.dto.PasswordChangeRequest;
@@ -8,10 +9,12 @@ import com.myce.member.service.MemberMileageService;
 import com.myce.member.service.MemberService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/members")
 @RequiredArgsConstructor
@@ -23,7 +26,6 @@ public class MemberController {
     @DeleteMapping("/withdraw")
     public ResponseEntity<Void> withdrawMember(
             @AuthenticationPrincipal CustomUserDetails customUserDetails) {
-        
         Long memberId = customUserDetails.getMemberId();
         memberService.withdrawMember(memberId);
         
@@ -38,6 +40,15 @@ public class MemberController {
         memberService.changePassword(memberId, request);
 
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping
+    public ResponseEntity<MemberInfoListResponse> getMemberByRole(
+            @RequestParam(required = false, defaultValue = "0") Integer page,
+            @RequestParam String role) {
+        log.debug("[getMemberByRole] {}", role);
+        MemberInfoListResponse response = memberService.getMemberInfoByRole(page, role);
+        return ResponseEntity.ok(response);
     }
 
     @GetMapping("/my-info")

--- a/src/main/java/com/myce/member/dto/MemberInfoListResponse.java
+++ b/src/main/java/com/myce/member/dto/MemberInfoListResponse.java
@@ -1,0 +1,22 @@
+package com.myce.member.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class MemberInfoListResponse {
+    private final int currentPage;
+    private final int totalPage;
+    private final List<MemberInfoResponse> memberInfos;
+
+    public MemberInfoListResponse(int currentPage, int totalPage) {
+        this.currentPage = currentPage;
+        this.totalPage = totalPage;
+        memberInfos = new ArrayList<>();
+    }
+
+    public void addMemberInfo(MemberInfoResponse memberInfoResponse) {
+        memberInfos.add(memberInfoResponse);
+    }
+}

--- a/src/main/java/com/myce/member/dto/MemberInfoResponse.java
+++ b/src/main/java/com/myce/member/dto/MemberInfoResponse.java
@@ -1,6 +1,7 @@
 package com.myce.member.dto;
 
 import com.myce.member.entity.type.Gender;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,13 +14,15 @@ import java.time.LocalDate;
 @AllArgsConstructor
 @Builder
 public class MemberInfoResponse {
-    
+
+    private Long id;
     private String name;
     private LocalDate birth;
     private String loginId;
     private String phone;
     private String email;
     private Gender gender;
+    private LocalDateTime createdAt;
     private String gradeDescription;
     private String gradeImageUrl;
     private Integer mileage;

--- a/src/main/java/com/myce/member/entity/type/Role.java
+++ b/src/main/java/com/myce/member/entity/type/Role.java
@@ -1,5 +1,18 @@
 package com.myce.member.entity.type;
 
+import com.myce.common.exception.CustomErrorCode;
+import com.myce.common.exception.CustomException;
+
 public enum Role {
-    PLATFORM_ADMIN, USER, EXPO_ADMIN
+    PLATFORM_ADMIN, USER, EXPO_ADMIN;
+
+    public static Role fromName(String name) {
+        for(Role role : Role.values()) {
+            if(role.name().equals(name)) {
+                return role;
+            }
+        }
+
+        throw new CustomException(CustomErrorCode.MEMBER_ROLE_NOT_EXIST);
+    }
 }

--- a/src/main/java/com/myce/member/mapper/MemberInfoMapper.java
+++ b/src/main/java/com/myce/member/mapper/MemberInfoMapper.java
@@ -1,7 +1,9 @@
 package com.myce.member.mapper;
 
+import com.myce.member.dto.MemberInfoListResponse;
 import com.myce.member.dto.MemberInfoResponse;
 import com.myce.member.entity.Member;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -9,15 +11,28 @@ public class MemberInfoMapper {
     
     public MemberInfoResponse toResponseDto(Member member) {
         return MemberInfoResponse.builder()
+                .id(member.getId())
                 .name(member.getName())
                 .birth(member.getBirth())
                 .loginId(member.getLoginId())
                 .phone(member.getPhone())
                 .email(member.getEmail())
                 .gender(member.getGender())
+                .createdAt(member.getCreatedAt())
                 .gradeDescription(member.getMemberGrade().getDescription())
                 .gradeImageUrl("http://localhost:8080" + member.getMemberGrade().getGradeImageUrl())
                 .mileage(member.getMileage())
                 .build();
+    }
+
+    public MemberInfoListResponse toListResponseDto(Page<Member> members) {
+        int currentPage = members.getNumber() + 1;
+        int totalPages = members.getTotalPages();
+        MemberInfoListResponse memberInfoListResponse = new MemberInfoListResponse(currentPage, totalPages);
+        members.forEach((member) -> {
+            MemberInfoResponse response = toResponseDto(member);
+            memberInfoListResponse.addMemberInfo(response);
+        });
+        return memberInfoListResponse;
     }
 }

--- a/src/main/java/com/myce/member/repository/MemberRepository.java
+++ b/src/main/java/com/myce/member/repository/MemberRepository.java
@@ -2,6 +2,9 @@ package com.myce.member.repository;
 
 import com.myce.member.entity.Member;
 import com.myce.member.entity.type.ProviderType;
+import com.myce.member.entity.type.Role;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -14,6 +17,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByNameAndEmail(String name, String email);
 
     Optional<Member> findByNameAndEmailAndLoginId(String name, String email, String loginId);
+
+    Page<Member> findByRole(Role role, Pageable pageable);
 
     boolean existsByLoginId(String loginId);
 

--- a/src/main/java/com/myce/member/service/MemberService.java
+++ b/src/main/java/com/myce/member/service/MemberService.java
@@ -1,13 +1,17 @@
 package com.myce.member.service;
 
+import com.myce.member.dto.MemberInfoListResponse;
 import com.myce.member.dto.MemberInfoResponse;
 import com.myce.member.dto.PasswordChangeRequest;
+import com.myce.member.entity.type.Role;
 
 public interface MemberService {
   
     void withdrawMember(Long memberId);
 
     void changePassword(Long memberId, PasswordChangeRequest request);
+
+    MemberInfoListResponse getMemberInfoByRole(int page, String roleKeyword);
 
     MemberInfoResponse getMyInfo(Long memberId);
 

--- a/src/main/java/com/myce/member/service/impl/MemberExpoServiceImpl.java
+++ b/src/main/java/com/myce/member/service/impl/MemberExpoServiceImpl.java
@@ -6,20 +6,14 @@ import com.myce.common.exception.CustomErrorCode;
 import com.myce.common.exception.CustomException;
 import com.myce.common.repository.BusinessProfileRepository;
 import com.myce.expo.entity.AdminCode;
+import com.myce.expo.entity.AdminPermission;
 import com.myce.expo.entity.Expo;
 import com.myce.expo.entity.Ticket;
+import com.myce.expo.entity.type.ExpoStatus;
 import com.myce.expo.repository.AdminCodeRepository;
+import com.myce.expo.repository.AdminPermissionRepository;
 import com.myce.expo.repository.ExpoRepository;
 import com.myce.expo.repository.TicketRepository;
-import com.myce.expo.repository.AdminPermissionRepository;
-import com.myce.expo.entity.AdminPermission;
-import com.myce.member.entity.type.Role;
-import com.myce.member.entity.Member;
-import java.time.LocalDateTime;
-import java.util.UUID;
-import java.security.SecureRandom;
-import java.util.ArrayList;
-import com.myce.member.repository.MemberRepository;
 import com.myce.member.dto.expo.ExpoAdminCodeResponse;
 import com.myce.member.dto.expo.ExpoPaymentDetailResponse;
 import com.myce.member.dto.expo.ExpoRefundReceiptResponse;
@@ -27,34 +21,32 @@ import com.myce.member.dto.expo.ExpoSettlementReceiptResponse;
 import com.myce.member.dto.expo.ExpoSettlementRequest;
 import com.myce.member.dto.expo.MemberExpoDetailResponse;
 import com.myce.member.dto.expo.MemberExpoResponse;
+import com.myce.member.entity.Member;
+import com.myce.member.entity.type.Role;
 import com.myce.member.mapper.expo.ExpoAdminCodeMapper;
 import com.myce.member.mapper.expo.ExpoPaymentDetailMapper;
 import com.myce.member.mapper.expo.ExpoRefundReceiptMapper;
 import com.myce.member.mapper.expo.ExpoSettlementReceiptMapper;
 import com.myce.member.mapper.expo.MemberExpoDetailMapper;
 import com.myce.member.mapper.expo.MemberExpoMapper;
+import com.myce.member.repository.MemberRepository;
 import com.myce.member.service.MemberExpoService;
 import com.myce.payment.entity.ExpoPaymentInfo;
 import com.myce.payment.entity.type.PaymentStatus;
 import com.myce.payment.repository.ExpoPaymentInfoRepository;
-import com.myce.settlement.service.SettlementExpoAdminService;
 import com.myce.settlement.entity.Settlement;
 import com.myce.settlement.repository.SettlementRepository;
-import com.myce.expo.entity.type.ExpoStatus;
-import com.myce.expo.entity.AdminPermission;
-import com.myce.member.entity.Member;
-import com.myce.member.entity.type.Role;
+import com.myce.settlement.service.SettlementExpoAdminService;
+import java.security.SecureRandom;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.security.SecureRandom;
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.ArrayList;
 
 @Slf4j
 @Service
@@ -255,7 +247,7 @@ public class MemberExpoServiceImpl implements MemberExpoService {
         
         log.info("정산 신청 위임 완료 - 박람회 ID: {}, 회원 ID: {}", expoId, memberId);
     }
-    
+
     @Override
     @Transactional
     public void completeExpoPayment(Long memberId, Long expoId) {
@@ -263,35 +255,35 @@ public class MemberExpoServiceImpl implements MemberExpoService {
         // 박람회 조회 및 권한 확인
         Expo expo = expoRepository.findById(expoId)
                 .orElseThrow(() -> new CustomException(CustomErrorCode.EXPO_NOT_FOUND));
-        
+
         if (!expo.getMember().getId().equals(memberId)) {
             throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
         }
-        
+
         // 결제 대기 상태인지 확인
         if (expo.getStatus() != ExpoStatus.PENDING_PAYMENT) {
             throw new CustomException(CustomErrorCode.INVALID_EXPO_STATUS);
         }
-        
+
         // 1. 회원 역할을 EXPO_ADMIN으로 변경
         Member member = expo.getMember();
         member.updateRole(Role.EXPO_ADMIN);
         memberRepository.save(member);
-        
+
         // 2. 박람회 상태를 PENDING_PUBLISH로 변경
         expo.updateStatus(ExpoStatus.PENDING_PUBLISH);
         expoRepository.save(expo);
-        
+
         // 3. ExpoPaymentInfo 상태를 PENDING에서 SUCCESS로 업데이트
         ExpoPaymentInfo paymentInfo = expoPaymentInfoRepository.findByExpoId(expoId)
                 .orElseThrow(() -> new CustomException(CustomErrorCode.PAYMENT_INFO_NOT_FOUND));
         paymentInfo.updateStatus(PaymentStatus.SUCCESS);
         expoPaymentInfoRepository.save(paymentInfo);
-        
+
         // 4. 5개의 EXPO_ADMIN_CODE 생성 및 권한 설정
         List<AdminCode> adminCodes = generateAdminCodes(expo, 5);
         adminCodeRepository.saveAll(adminCodes);
-        
+
         // 5. 각 AdminCode에 대한 AdminPermission 생성 (모든 권한 true)
         List<AdminPermission> adminPermissions = new ArrayList<>();
         for (AdminCode adminCode : adminCodes) {
@@ -310,47 +302,47 @@ public class MemberExpoServiceImpl implements MemberExpoService {
             adminPermissions.add(permission);
         }
         adminPermissionRepository.saveAll(adminPermissions);
-        
-        log.info("결제 완료 처리 완료 - 박람회 ID: {}, 회원 ID: {}, 생성된 관리자 코드: {}개", 
+
+        log.info("결제 완료 처리 완료 - 박람회 ID: {}, 회원 ID: {}, 생성된 관리자 코드: {}개",
                 expoId, memberId, adminCodes.size());
     }
-    
+
     /**
      * 관리자 코드 생성
      */
     private List<AdminCode> generateAdminCodes(Expo expo, int count) {
         List<AdminCode> adminCodes = new ArrayList<>();
         SecureRandom random = new SecureRandom();
-        
+
         // expo의 displayEndDate + 30일로 만료시간 설정
         LocalDateTime expiredAt = expo.getDisplayEndDate().atStartOfDay().plusDays(30);
-        
+
         for (int i = 0; i < count; i++) {
             String code = "CODE" + generateRandomCode(6, random);
-            
+
             AdminCode adminCode = AdminCode.builder()
                     .expoId(expo.getId())
                     .code(code)
                     .expiredAt(expiredAt)
                     .build();
-            
+
             adminCodes.add(adminCode);
         }
-        
+
         return adminCodes;
     }
-    
+
     /**
      * 랜덤 코드 생성 (숫자와 대문자 알파벳)
      */
     private String generateRandomCode(int length, SecureRandom random) {
         String characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
         StringBuilder code = new StringBuilder();
-        
+
         for (int i = 0; i < length; i++) {
             code.append(characters.charAt(random.nextInt(characters.length())));
         }
-        
+
         return code.toString();
     }
 }

--- a/src/main/java/com/myce/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/myce/member/service/impl/MemberServiceImpl.java
@@ -2,14 +2,20 @@ package com.myce.member.service.impl;
 
 import com.myce.common.exception.CustomErrorCode;
 import com.myce.common.exception.CustomException;
+import com.myce.member.dto.MemberInfoListResponse;
 import com.myce.member.dto.MemberInfoResponse;
 import com.myce.member.dto.PasswordChangeRequest;
 import com.myce.member.entity.Member;
+import com.myce.member.entity.type.Role;
 import com.myce.member.mapper.MemberInfoMapper;
 import com.myce.member.repository.MemberRepository;
 import com.myce.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -48,6 +54,15 @@ public class MemberServiceImpl implements MemberService {
 
         member.resetPassword(passwordEncoder.encode(newPassword));
         log.debug("[Member] Change password of member. memberId={}", memberId);
+    }
+
+    @Override
+    public MemberInfoListResponse getMemberInfoByRole(int page, String roleKeyword) {
+        Role role = Role.fromName(roleKeyword);
+        Sort sort = Sort.by(Sort.Direction.DESC, "createdAt");
+        Pageable pageable = PageRequest.of(page, 15, sort);
+        Page<Member> memberPage = memberRepository.findByRole(role, pageable);
+        return memberInfoMapper.toListResponseDto(memberPage);
     }
 
     private Member findMemberById(Long memberId) {


### PR DESCRIPTION
## 개발 내용
  - 역할별 회원 목록 조회 (USER, EXPO_ADMIN, PLATFORM_ADMIN) - 최신가입자순
  - 페이징 동작 확인 (page=0,1,2...)
  - 잘못된 역할 입력 시 에러 처리