### PR TITLE
[CRM-281] refactor : 정산 권한 삭제

### DIFF
--- a/src/main/java/com/myce/expo/dto/ExpoAdminManagerRequest.java
+++ b/src/main/java/com/myce/expo/dto/ExpoAdminManagerRequest.java
@@ -15,6 +15,5 @@ public class ExpoAdminManagerRequest {
     private Boolean isPaymentView;
     private Boolean isEmailLogView;
     private Boolean isOperationsConfigUpdate;
-    private Boolean isSettlementView;
     private Boolean isInquiryView;
 }

--- a/src/main/java/com/myce/expo/dto/ExpoAdminManagerResponse.java
+++ b/src/main/java/com/myce/expo/dto/ExpoAdminManagerResponse.java
@@ -15,6 +15,5 @@ public class ExpoAdminManagerResponse {
     private Boolean isPaymentView;
     private Boolean isEmailLogView;
     private Boolean isOperationsConfigUpdate;
-    private Boolean isSettlementView;
     private Boolean isInquiryView;
 }

--- a/src/main/java/com/myce/expo/dto/ExpoAdminPermissionResponse.java
+++ b/src/main/java/com/myce/expo/dto/ExpoAdminPermissionResponse.java
@@ -16,6 +16,5 @@ public class ExpoAdminPermissionResponse {
     private Boolean isPaymentView;
     private Boolean isEmailLogView;
     private Boolean isOperationsConfigUpdate;
-    private Boolean isSettlementView;
     private Boolean isInquiryView;
 }

--- a/src/main/java/com/myce/expo/entity/AdminPermission.java
+++ b/src/main/java/com/myce/expo/entity/AdminPermission.java
@@ -44,9 +44,6 @@ public class AdminPermission {
     @Column(name = "is_operations_config_update", nullable = false, columnDefinition = "TINYINT(1)")
     private Boolean isOperationsConfigUpdate;
 
-    @Column(name = "is_settlement_view", nullable = false, columnDefinition = "TINYINT(1)")
-    private Boolean isSettlementView;
-
     @Column(name = "is_inquiry_view", nullable = false, columnDefinition = "TINYINT(1)")
     private Boolean isInquiryView;
 
@@ -61,8 +58,7 @@ public class AdminPermission {
     @Builder
     public AdminPermission(AdminCode adminCode, Boolean isExpoDetailUpdate, Boolean isBoothInfoUpdate,
                            Boolean isScheduleUpdate, Boolean isReserverListView, Boolean isPaymentView,
-                           Boolean isEmailLogView, Boolean isOperationsConfigUpdate, Boolean isSettlementView,
-                           Boolean isInquiryView) {
+                           Boolean isEmailLogView, Boolean isOperationsConfigUpdate, Boolean isInquiryView) {
         adminCode.setAdminPermission(this);
         this.adminCode = adminCode;
         this.isExpoDetailUpdate = isExpoDetailUpdate;
@@ -72,14 +68,13 @@ public class AdminPermission {
         this.isPaymentView = isPaymentView;
         this.isEmailLogView = isEmailLogView;
         this.isOperationsConfigUpdate = isOperationsConfigUpdate;
-        this.isSettlementView = isSettlementView;
         this.isInquiryView = isInquiryView;
     }
 
     public void updateAdminPermission(Boolean isExpoDetailUpdate, Boolean isBoothInfoUpdate,
                                       Boolean isScheduleUpdate, Boolean isReserverListView,
                                       Boolean isPaymentView, Boolean isEmailLogView,
-                                      Boolean isOperationsConfigUpdate, Boolean isSettlementView,Boolean isInquiryView){
+                                      Boolean isOperationsConfigUpdate,Boolean isInquiryView){
         this.isExpoDetailUpdate = isExpoDetailUpdate;
         this.isBoothInfoUpdate = isBoothInfoUpdate;
         this.isScheduleUpdate = isScheduleUpdate;
@@ -87,7 +82,6 @@ public class AdminPermission {
         this.isPaymentView = isPaymentView;
         this.isEmailLogView = isEmailLogView;
         this.isOperationsConfigUpdate = isOperationsConfigUpdate;
-        this.isSettlementView = isSettlementView;
         this.isInquiryView = isInquiryView;
     }
 }

--- a/src/main/java/com/myce/expo/repository/AdminPermissionRepository.java
+++ b/src/main/java/com/myce/expo/repository/AdminPermissionRepository.java
@@ -13,6 +13,5 @@ public interface AdminPermissionRepository extends JpaRepository<AdminPermission
     boolean existsByAdminCodeIdAndAdminCodeExpoIdAndIsPaymentViewTrue(Long adminCodeId, Long expoId);
     boolean existsByAdminCodeIdAndAdminCodeExpoIdAndIsEmailLogViewTrue(Long adminCodeId, Long expoId);
     boolean existsByAdminCodeIdAndAdminCodeExpoIdAndIsOperationsConfigUpdateTrue(Long adminCodeId, Long expoId);
-    boolean existsByAdminCodeIdAndAdminCodeExpoIdAndIsSettlementViewTrue(Long adminCodeId, Long expoId);
     boolean existsByAdminCodeIdAndAdminCodeExpoIdAndIsInquiryViewTrue(Long adminCodeId, Long expoId);
 }

--- a/src/main/java/com/myce/expo/service/impl/ExpoAdminManagerServiceImpl.java
+++ b/src/main/java/com/myce/expo/service/impl/ExpoAdminManagerServiceImpl.java
@@ -65,7 +65,7 @@ public class ExpoAdminManagerServiceImpl implements ExpoAdminManagerService {
                 permission.updateAdminPermission(
                         dto.getIsExpoDetailUpdate(), dto.getIsBoothInfoUpdate(), dto.getIsScheduleUpdate(),
                         dto.getIsReserverListView(), dto.getIsPaymentView(), dto.getIsEmailLogView(),
-                        dto.getIsOperationsConfigUpdate(), dto.getIsSettlementView(), dto.getIsInquiryView()
+                        dto.getIsOperationsConfigUpdate(), dto.getIsInquiryView()
                 );
             }else{
                 throw new CustomException(CustomErrorCode.ADMIN_CODE_NOT_FOUND);

--- a/src/main/java/com/myce/expo/service/mapper/ExpoAdminMangerMapper.java
+++ b/src/main/java/com/myce/expo/service/mapper/ExpoAdminMangerMapper.java
@@ -17,7 +17,6 @@ public class ExpoAdminMangerMapper {
                 .isPaymentView(adminCode.getAdminPermission().getIsPaymentView())
                 .isEmailLogView(adminCode.getAdminPermission().getIsEmailLogView())
                 .isOperationsConfigUpdate(adminCode.getAdminPermission().getIsOperationsConfigUpdate())
-                .isSettlementView(adminCode.getAdminPermission().getIsSettlementView())
                 .isInquiryView(adminCode.getAdminPermission().getIsInquiryView())
                 .build();
     }

--- a/src/main/java/com/myce/expo/service/mapper/ExpoAdminPermissionMapper.java
+++ b/src/main/java/com/myce/expo/service/mapper/ExpoAdminPermissionMapper.java
@@ -19,7 +19,6 @@ public class ExpoAdminPermissionMapper {
                     .isPaymentView(true)
                     .isEmailLogView(true)
                     .isOperationsConfigUpdate(true)
-                    .isSettlementView(true)
                     .isInquiryView(true)
                     .build();
         }
@@ -32,7 +31,6 @@ public class ExpoAdminPermissionMapper {
                 .isPaymentView(adminPermission.getIsPaymentView())
                 .isEmailLogView(adminPermission.getIsEmailLogView())
                 .isOperationsConfigUpdate(adminPermission.getIsOperationsConfigUpdate())
-                .isSettlementView(adminPermission.getIsSettlementView())
                 .isInquiryView(adminPermission.getIsInquiryView())
                 .build();
     }

--- a/src/main/java/com/myce/member/service/impl/MemberExpoServiceImpl.java
+++ b/src/main/java/com/myce/member/service/impl/MemberExpoServiceImpl.java
@@ -304,7 +304,6 @@ public class MemberExpoServiceImpl implements MemberExpoService {
                     .isPaymentView(true)
                     .isEmailLogView(true)
                     .isOperationsConfigUpdate(true)
-                    .isSettlementView(true)
                     .isInquiryView(true)
                     .build();
             adminPermissions.add(permission);


### PR DESCRIPTION
박람회 관리자 정산 탭이 사라짐에 따라
admin_permission 엔티티에서 해당 isSettlementView 필드를 삭제하였습니다.
또한 DB에서도 isSettlementView를 삭제 하였습니다. 