### PR TITLE
[CRM-283] feat: 배너 2차 수정 사항 반영

### DIFF
--- a/src/main/java/com/myce/advertisement/controller/PlatformAdController.java
+++ b/src/main/java/com/myce/advertisement/controller/PlatformAdController.java
@@ -65,6 +65,12 @@ public class PlatformAdController {
         return ResponseEntity.ok().build();
     }
 
+    @PatchMapping("/{adId}/cancel/deny")
+    public ResponseEntity<Void> denyCancel(@PathVariable Long adId) {
+        currentAdService.denyCancel(adId);
+        return ResponseEntity.ok().build();
+    }
+
     @GetMapping("/{adId}/cancel-check")
     public AdCancelInfoCheck getCancelForm(@PathVariable Long adId) {
         return currentAdService.generateCancelCheck(adId);

--- a/src/main/java/com/myce/advertisement/dto/AdPaymentInfoCheck.java
+++ b/src/main/java/com/myce/advertisement/dto/AdPaymentInfoCheck.java
@@ -14,18 +14,21 @@ public class AdPaymentInfoCheck {
     private String requesterName;
     private LocalDate startAt;
     private LocalDate endAt;
+    private Integer totalDays;
     private HashMap<String, Integer> priceMap;
     private Integer totalPayment;
 
     @Builder
     public AdPaymentInfoCheck(String title, String requesterName,
                               LocalDate startAt, LocalDate endAt,
+                              Integer totalDays,
                               HashMap<String, Integer> priceMap,
                               Integer totalPayment) {
         this.title = title;
         this.requesterName = requesterName;
         this.startAt = startAt;
         this.endAt = endAt;
+        this.totalDays = totalDays;
         this.priceMap = priceMap;
         this.totalPayment = totalPayment;
     }

--- a/src/main/java/com/myce/advertisement/entity/Advertisement.java
+++ b/src/main/java/com/myce/advertisement/entity/Advertisement.java
@@ -116,6 +116,13 @@ public class Advertisement {
         this.status = AdvertisementStatus.PUBLISHED;
     }
 
+    public void denyCancel() {
+        if (this.status != AdvertisementStatus.PENDING_CANCEL) {
+            throw new CustomException(CustomErrorCode.INVALID_ADVERTISEMENT_STATUS);
+        }
+        this.status = AdvertisementStatus.PUBLISHED;
+    }
+
     public void complete() {
         if (this.status != AdvertisementStatus.PUBLISHED) {
             throw new CustomException(CustomErrorCode.INVALID_ADVERTISEMENT_STATUS);

--- a/src/main/java/com/myce/advertisement/service/PlatformCurrentAdService.java
+++ b/src/main/java/com/myce/advertisement/service/PlatformCurrentAdService.java
@@ -5,5 +5,7 @@ import com.myce.advertisement.dto.AdCancelInfoCheck;
 public interface PlatformCurrentAdService {
     void cancelCurrent(Long adId);
 
+    void denyCancel(Long adId);
+
     AdCancelInfoCheck generateCancelCheck(Long adId);
 }

--- a/src/main/java/com/myce/advertisement/service/impl/PlatformApplyAdServiceImpl.java
+++ b/src/main/java/com/myce/advertisement/service/impl/PlatformApplyAdServiceImpl.java
@@ -47,14 +47,17 @@ public class PlatformApplyAdServiceImpl implements PlatformApplyAdService {
         HashMap<String, Integer> priceMap = new HashMap<>();
         int totalPayment = 0;
 
-        log.info("generatePaymentCheck - Advertisement : {}", ad);
+        int feePerDay = feeSetting.getFeePerDay();
+        int totalDayFee = feePerDay * ad.getTotalDays();
+        int totalDays = ad.getTotalDays();
+
+        log.info("generatePaymentCheck - Advertisement : {}, {}", feePerDay, ad.getTotalDays());
 
         // todo: PG 수수료 고려 X
-        int totalDayFee = feeSetting.getFeePerDay() * ad.getTotalDays();
-        priceMap.put("총 이용료", totalDayFee);
+        priceMap.put("일일 이용료", feePerDay);
         totalPayment += totalDayFee;
 
-        return AdInfoMapper.getAdPaymentForm(ad, priceMap, totalPayment);
+        return AdInfoMapper.getAdPaymentForm(ad, priceMap, totalDays, totalPayment);
     }
 
     @Transactional

--- a/src/main/java/com/myce/advertisement/service/impl/PlatformCurrentAdServiceImpl.java
+++ b/src/main/java/com/myce/advertisement/service/impl/PlatformCurrentAdServiceImpl.java
@@ -48,6 +48,19 @@ public class PlatformCurrentAdServiceImpl implements PlatformCurrentAdService {
     }
 
     @Transactional
+    public void denyCancel(Long adId){
+        Advertisement ad = adRepository
+                .findById(adId)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.AD_NOT_FOUND));
+        Payment payment = paymentRepository
+                .findByTargetIdAndTargetType(ad.getId(), PaymentTargetType.AD)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.PAYMENT_INFO_NOT_FOUND));
+
+        ad.denyCancel();
+        refundRepository.deleteByPayment(payment);
+    }
+
+    @Transactional
     public void cancelCurrent(Long adId) {
         Advertisement ad = adRepository
                 .findById(adId)
@@ -62,7 +75,12 @@ public class PlatformCurrentAdServiceImpl implements PlatformCurrentAdService {
                 .orElseThrow(() -> new CustomException(CustomErrorCode.REFUND_NOT_FOUND));
 
         refund.updateToRefund();
-        adPayment.setStatus(PaymentStatus.PARTIAL_REFUNDED);
+
+        if(refund.getIsPartial()){
+            adPayment.setStatus(PaymentStatus.PARTIAL_REFUNDED);
+        }else{
+            adPayment.setStatus(PaymentStatus.REFUNDED);
+        }
         adPayment.setUpdatedAt(LocalDateTime.now());
 
         log.info("cancelCurrent - Advertisement : {}, Payment : {}", ad, payment);

--- a/src/main/java/com/myce/advertisement/service/mapper/AdInfoMapper.java
+++ b/src/main/java/com/myce/advertisement/service/mapper/AdInfoMapper.java
@@ -69,12 +69,13 @@ public class AdInfoMapper {
     }
 
     public static AdPaymentInfoCheck getAdPaymentForm(
-            Advertisement ad, HashMap<String, Integer> priceMap, int totalPayment) {
+            Advertisement ad, HashMap<String, Integer> priceMap, int totalDays, int totalPayment) {
         return AdPaymentInfoCheck.builder()
                 .title(ad.getTitle())
                 .requesterName(ad.getMember().getName())
                 .startAt(ad.getDisplayStartDate())
                 .endAt(ad.getDisplayEndDate())
+                .totalDays(totalDays)
                 .priceMap(priceMap)
                 .totalPayment(totalPayment)
                 .build();

--- a/src/main/java/com/myce/payment/repository/RefundRepository.java
+++ b/src/main/java/com/myce/payment/repository/RefundRepository.java
@@ -19,4 +19,6 @@ public interface RefundRepository extends JpaRepository<Refund, Long> {
     
     // 플랫폼 관리자용: 상태별 환불 신청 목록 조회
     Page<Refund> findByStatusOrderByCreatedAtDesc(RefundStatus status, Pageable pageable);
+
+    void deleteByPayment(Payment payment);
 }


### PR DESCRIPTION
### 구현 기능
* 배너 승인 영수증에 "총 일수"와 "일일 사용료" 추가
* 취소 대기 배너의 거부 api 추가
* 취소 승인 시 partial_refund 여부에 따른 분기 추가
* 기타 버튼 명칭 수정