### PR TITLE
fix: Settlement 자동 생성 시 실제 매출 계산 로직 구현

### DIFF
--- a/src/main/java/com/myce/member/mapper/expo/ExpoSettlementReceiptMapper.java
+++ b/src/main/java/com/myce/member/mapper/expo/ExpoSettlementReceiptMapper.java
@@ -18,22 +18,33 @@ public class ExpoSettlementReceiptMapper {
             ExpoPaymentInfo expoPaymentInfo,
             Settlement settlement) {
 
-        // 티켓별 판매 정보 계산
+        // 티켓별 판매 정보 계산 (프론트 표시용)
         List<ExpoSettlementReceiptResponse.TicketSalesInfo> ticketSales = tickets.stream()
                 .map(this::buildTicketSalesInfo)
                 .toList();
 
-        // 총 매출 계산
-        int totalRevenue = ticketSales.stream()
-                .mapToInt(ExpoSettlementReceiptResponse.TicketSalesInfo::getTotalSales)
-                .sum();
-
-        // 결제 시점에 저장된 수수료율 사용
-        BigDecimal commissionRate = expoPaymentInfo.getCommissionRate();
-        int commissionAmount = totalRevenue * commissionRate.intValue() / 100;
-
-        // 순수익 계산
-        int netProfit = totalRevenue - commissionAmount;
+        // Settlement 테이블에서 금액 정보 우선 사용
+        int totalRevenue, commissionAmount, netProfit;
+        BigDecimal commissionRate;
+        
+        if (settlement != null && settlement.getTotalAmount() != null) {
+            // Settlement 테이블에서 정확한 값 사용
+            totalRevenue = settlement.getTotalAmount();
+            commissionAmount = settlement.getSupplyAmount() != null ? settlement.getSupplyAmount() : 0;
+            netProfit = settlement.getSettleAmount() != null ? settlement.getSettleAmount() : 0;
+            
+            // 수수료율은 ExpoPaymentInfo에서 가져오기 (백분율 표시용)
+            commissionRate = expoPaymentInfo.getCommissionRate();
+        } else {
+            // Settlement이 없으면 기존 로직 (실시간 계산)
+            totalRevenue = ticketSales.stream()
+                    .mapToInt(ExpoSettlementReceiptResponse.TicketSalesInfo::getTotalSales)
+                    .sum();
+            
+            commissionRate = expoPaymentInfo.getCommissionRate();
+            commissionAmount = totalRevenue * commissionRate.intValue() / 100;
+            netProfit = totalRevenue - commissionAmount;
+        }
 
         // Builder로 기본 정보 설정
         ExpoSettlementReceiptResponse.ExpoSettlementReceiptResponseBuilder builder = ExpoSettlementReceiptResponse.builder()

--- a/src/main/java/com/myce/settlement/service/impl/SettlementSystemServiceImpl.java
+++ b/src/main/java/com/myce/settlement/service/impl/SettlementSystemServiceImpl.java
@@ -1,6 +1,10 @@
 package com.myce.settlement.service.impl;
 
 import com.myce.expo.entity.Expo;
+import com.myce.expo.entity.Ticket;
+import com.myce.expo.repository.TicketRepository;
+import com.myce.payment.entity.ExpoPaymentInfo;
+import com.myce.payment.repository.ExpoPaymentInfoRepository;
 import com.myce.settlement.entity.Settlement;
 import com.myce.settlement.repository.SettlementRepository;
 import com.myce.settlement.service.SettlementSystemService;
@@ -9,6 +13,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.List;
 
 /**
  * Settlement 시스템/스케줄러 서비스 구현체
@@ -21,6 +28,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class SettlementSystemServiceImpl implements SettlementSystemService {
     
     private final SettlementRepository settlementRepository;
+    private final TicketRepository ticketRepository;
+    private final ExpoPaymentInfoRepository expoPaymentInfoRepository;
     
     @Override
     @Transactional
@@ -33,12 +42,12 @@ public class SettlementSystemServiceImpl implements SettlementSystemService {
             return;
         }
         
-        // 2. Revenue calculation (placeholder - 0 for now)
+        // 2. 실제 매출 계산 (티켓 판매 데이터 기반)
         Integer totalRevenue = calculateExpoRevenue(expo.getId());
         if (totalRevenue == null) totalRevenue = 0;
         
-        // 3. Commission calculation (5% default)
-        Integer commissionAmount = (int)(totalRevenue * 0.05);
+        // 3. 수수료 계산 (ExpoPaymentInfo에서 수수료율 가져오기)
+        Integer commissionAmount = calculateCommissionAmount(expo.getId(), totalRevenue);
         
         // 4. Settlement creation using mapper
         Settlement settlement = SettlementSystemMapper.toInitialEntity(expo, totalRevenue, commissionAmount);
@@ -50,19 +59,51 @@ public class SettlementSystemServiceImpl implements SettlementSystemService {
     }
     
     /**
-     * Expo revenue calculation (reservation data based)
-     * TODO: Implement actual reservation/payment data revenue calculation
+     * 박람회 실제 매출 계산 (티켓 판매 데이터 기반)
      * 
-     * @param expoId Expo ID
-     * @return Total revenue
+     * @param expoId 박람회 ID
+     * @return 총 매출
      */
     private Integer calculateExpoRevenue(Long expoId) {
-        // Currently returns 0, add actual revenue calculation logic later
-        // List<Reservation> reservations = reservationRepository.findByExpoId(expoId);
-        // return reservations.stream()
-        //     .filter(r -> r.getStatus() == ReservationStatus.COMPLETED)
-        //     .mapToInt(r -> r.getTotalAmount())
-        //     .sum();
-        return 0;
+        List<Ticket> tickets = ticketRepository.findByExpoId(expoId);
+        
+        int totalRevenue = tickets.stream()
+                .mapToInt(ticket -> {
+                    // 판매된 수량 = 총 수량 - 남은 수량
+                    int soldCount = ticket.getTotalQuantity() - ticket.getRemainingQuantity();
+                    // 티켓별 총 판매금액 = 판매된 수량 * 티켓 가격
+                    return soldCount * ticket.getPrice();
+                })
+                .sum();
+        
+        log.debug("Calculated expo revenue for expo {}: {} (from {} tickets)", 
+                  expoId, totalRevenue, tickets.size());
+        
+        return totalRevenue;
+    }
+    
+    /**
+     * 수수료 계산 (ExpoPaymentInfo에서 수수료율 가져와서 계산)
+     * 
+     * @param expoId 박람회 ID
+     * @param totalRevenue 총 매출
+     * @return 수수료 금액
+     */
+    private Integer calculateCommissionAmount(Long expoId, Integer totalRevenue) {
+        ExpoPaymentInfo paymentInfo = expoPaymentInfoRepository.findByExpoId(expoId)
+                .orElse(null);
+        
+        if (paymentInfo == null || paymentInfo.getCommissionRate() == null) {
+            log.warn("No payment info or commission rate found for expo {}, using default 5%", expoId);
+            return (int)(totalRevenue * 0.05); // 5% 기본값
+        }
+        
+        BigDecimal commissionRate = paymentInfo.getCommissionRate();
+        int commissionAmount = totalRevenue * commissionRate.intValue() / 100;
+        
+        log.debug("Calculated commission for expo {}: {}% of {} = {}", 
+                  expoId, commissionRate, totalRevenue, commissionAmount);
+        
+        return commissionAmount;
     }
 }


### PR DESCRIPTION
- SettlementSystemServiceImpl: 티켓 판매 데이터 기반 실제 매출 계산
- ExpoSettlementReceiptMapper: Settlement 테이블 값 우선 사용하도록 수정
- calculateExpoRevenue(): 하드코딩 0 → 실제 티켓 판매량 × 가격 계산
- calculateCommissionAmount(): ExpoPaymentInfo에서 수수료율 가져와서 계산
- 정산 조회 시 Settlement과 Ticket 테이블 하이브리드 방식 적용
