### PR TITLE
[CRM-284] feat: 박람회 mypage flow 수정 

### DIFF
--- a/src/main/java/com/myce/member/controller/MemberAdController.java
+++ b/src/main/java/com/myce/member/controller/MemberAdController.java
@@ -2,6 +2,7 @@ package com.myce.member.controller;
 
 import com.myce.advertisement.dto.AdRejectInfoResponse;
 import com.myce.auth.dto.CustomUserDetails;
+import com.myce.member.dto.ad.AdRefundReceiptResponse;
 import com.myce.member.dto.ad.AdRefundRequest;
 import com.myce.member.dto.ad.AdvertisementDetailResponse;
 import com.myce.member.dto.ad.AdvertisementPaymentDetailResponse;
@@ -110,6 +111,17 @@ public class MemberAdController {
         AdRejectInfoResponse rejectInfo = memberAdService.getAdvertisementRejectInfo(memberId, advertisementId);
         
         return ResponseEntity.ok(rejectInfo);
+    }
+    
+    @GetMapping("/{advertisementId}/refund-history")
+    public ResponseEntity<AdRefundReceiptResponse> getAdvertisementRefundHistory(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @PathVariable Long advertisementId) {
+        
+        Long memberId = customUserDetails.getMemberId();
+        AdRefundReceiptResponse refundHistory = memberAdService.getAdvertisementRefundHistory(memberId, advertisementId);
+        
+        return ResponseEntity.ok(refundHistory);
     }
     
     @PostMapping("/{advertisementId}/payment/complete")

--- a/src/main/java/com/myce/member/controller/MemberMyPageController.java
+++ b/src/main/java/com/myce/member/controller/MemberMyPageController.java
@@ -22,11 +22,12 @@ public class MemberMyPageController {
     private final MemberMyPageService memberMyPageService;
     
     @GetMapping("/reserved-expos")
-    public ResponseEntity<List<ReservedExpoResponse>> getReservedExpos(
-            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+    public ResponseEntity<Page<ReservedExpoResponse>> getReservedExpos(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            Pageable pageable) {
         
         Long memberId = customUserDetails.getMemberId();
-        List<ReservedExpoResponse> reservedExpos = memberMyPageService.getReservedExpos(memberId);
+        Page<ReservedExpoResponse> reservedExpos = memberMyPageService.getReservedExpos(memberId, pageable);
         
         return ResponseEntity.ok(reservedExpos);
     }

--- a/src/main/java/com/myce/member/dto/ad/AdRefundReceiptResponse.java
+++ b/src/main/java/com/myce/member/dto/ad/AdRefundReceiptResponse.java
@@ -1,0 +1,37 @@
+package com.myce.member.dto.ad;
+
+import com.myce.advertisement.entity.type.AdvertisementStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AdRefundReceiptResponse {
+    
+    // 광고 기본 정보
+    private String adTitle;
+    private String applicantName;  // 신청자 (회사명)
+    private LocalDate displayStartDate;  // 게시 시작일
+    private LocalDate displayEndDate;    // 게시 종료일
+    private AdvertisementStatus status;
+    
+    // 원본 결제 정보
+    private Integer totalDays;         // 총 게시 일수
+    private Integer dailyFee;          // 일일 요금
+    private Integer totalAmount;       // 총 결제 금액
+    
+    // 사용 정보
+    private LocalDate refundRequestDate;  // 환불 요청일
+    private Integer usedDays;             // 사용한 일수
+    private Integer usedAmount;           // 사용한 금액
+    
+    // 환불 정보
+    private Integer remainingDays;        // 남은 게시 일수
+    private Integer refundAmount;         // 환불 금액
+}

--- a/src/main/java/com/myce/member/dto/expo/ReservedExpoResponse.java
+++ b/src/main/java/com/myce/member/dto/expo/ReservedExpoResponse.java
@@ -1,9 +1,13 @@
 package com.myce.member.dto.expo;
 
+import com.myce.reservation.entity.code.ReservationStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor
@@ -19,4 +23,6 @@ public class ReservedExpoResponse {
     private String ticketName;
     private Long reservationId;
     private String reservationCode;
+    private LocalDateTime createdAt;
+    private ReservationStatus reservationStatus;
 }

--- a/src/main/java/com/myce/member/mapper/ad/AdRefundReceiptMapper.java
+++ b/src/main/java/com/myce/member/mapper/ad/AdRefundReceiptMapper.java
@@ -1,0 +1,92 @@
+package com.myce.member.mapper.ad;
+
+import com.myce.advertisement.entity.Advertisement;
+import com.myce.common.entity.BusinessProfile;
+import com.myce.member.dto.ad.AdRefundReceiptResponse;
+import com.myce.payment.entity.AdPaymentInfo;
+import com.myce.payment.entity.Refund;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+@Component
+public class AdRefundReceiptMapper {
+    
+    public AdRefundReceiptResponse toRefundReceiptDto(Advertisement ad, 
+                                                     BusinessProfile businessProfile, 
+                                                     AdPaymentInfo adPaymentInfo) {
+        
+        // 환불 계산
+        LocalDate today = LocalDate.now();
+        LocalDate displayStartDate = ad.getDisplayStartDate();
+        
+        // 사용한 일수 계산 (게시 시작일부터 오늘까지)
+        int usedDays = (int) java.time.temporal.ChronoUnit.DAYS.between(displayStartDate, today) + 1;
+        if (usedDays < 0) usedDays = 0;
+        
+        // 남은 일수 계산
+        int remainingDays = adPaymentInfo.getTotalDay() - usedDays;
+        if (remainingDays < 0) remainingDays = 0;
+        
+        // 금액 계산
+        int usedAmount = usedDays * adPaymentInfo.getFeePerDay();
+        int refundAmount = remainingDays * adPaymentInfo.getFeePerDay();
+        
+        return AdRefundReceiptResponse.builder()
+                .adTitle(ad.getTitle())
+                .applicantName(businessProfile.getCompanyName())
+                .displayStartDate(ad.getDisplayStartDate())
+                .displayEndDate(ad.getDisplayEndDate())
+                .status(ad.getStatus())
+                .totalDays(adPaymentInfo.getTotalDay())
+                .dailyFee(adPaymentInfo.getFeePerDay())
+                .totalAmount(adPaymentInfo.getTotalAmount())
+                .refundRequestDate(today)
+                .usedDays(usedDays)
+                .usedAmount(usedAmount)
+                .remainingDays(remainingDays)
+                .refundAmount(refundAmount)
+                .build();
+    }
+    
+    public AdRefundReceiptResponse toRefundHistoryDto(Advertisement ad,
+                                                     BusinessProfile businessProfile,
+                                                     AdPaymentInfo adPaymentInfo,
+                                                     Refund refund) {
+        
+        // 실제 환불 내역 기반으로 생성
+        LocalDate refundDate = refund.getRefundedAt() != null ? 
+            refund.getRefundedAt().toLocalDate() : refund.getCreatedAt().toLocalDate();
+        
+        // 환불 종류에 따른 사용 일수 및 금액 계산
+        int usedDays = 0;
+        int usedAmount = 0;
+        int remainingDays = adPaymentInfo.getTotalDay();
+        
+        if (refund.getIsPartial()) {
+            // 부분 환불인 경우: 환불 금액으로 남은 일수 계산 후 사용 일수 도출
+            if (adPaymentInfo.getFeePerDay() > 0) {
+                remainingDays = refund.getAmount() / adPaymentInfo.getFeePerDay();
+                usedDays = adPaymentInfo.getTotalDay() - remainingDays;
+                usedAmount = usedDays * adPaymentInfo.getFeePerDay();
+            }
+        }
+        // 전액 환불인 경우는 기본값(0) 유지
+        
+        return AdRefundReceiptResponse.builder()
+                .adTitle(ad.getTitle())
+                .applicantName(businessProfile.getCompanyName())
+                .displayStartDate(ad.getDisplayStartDate())
+                .displayEndDate(ad.getDisplayEndDate())
+                .status(ad.getStatus())
+                .totalDays(adPaymentInfo.getTotalDay())
+                .dailyFee(adPaymentInfo.getFeePerDay())
+                .totalAmount(adPaymentInfo.getTotalAmount())
+                .refundRequestDate(refundDate) // 실제 환불 요청일
+                .usedDays(usedDays)
+                .usedAmount(usedAmount)
+                .remainingDays(remainingDays)
+                .refundAmount(refund.getAmount()) // 실제 환불된 금액
+                .build();
+    }
+}

--- a/src/main/java/com/myce/member/mapper/expo/ExpoRefundReceiptMapper.java
+++ b/src/main/java/com/myce/member/mapper/expo/ExpoRefundReceiptMapper.java
@@ -26,9 +26,19 @@ public class ExpoRefundReceiptMapper {
         int usedDays = (int) ChronoUnit.DAYS.between(displayStartDate, today) + 1; // +1은 시작일 포함
         if (usedDays < 0) usedDays = 0;
         
+        // 디버깅 로그 추가
+        System.out.println("=== 환불 계산 디버깅 ===");
+        System.out.println("게시 시작일: " + displayStartDate);
+        System.out.println("오늘: " + today);
+        System.out.println("총 게시 일수: " + expoPaymentInfo.getTotalDay());
+        System.out.println("계산된 사용 일수: " + usedDays);
+        
         // 남은 일수 계산
         int remainingDays = expoPaymentInfo.getTotalDay() - usedDays;
         if (remainingDays < 0) remainingDays = 0;
+        
+        System.out.println("계산된 남은 일수: " + remainingDays);
+        System.out.println("=====================");
         
         // 등록금 계산 (프리미엄 여부에 따라)
         int depositAmount = expo.getIsPremium() ? 
@@ -94,11 +104,21 @@ public class ExpoRefundReceiptMapper {
         int remainingDays = expoPaymentInfo.getTotalDay();
         
         if (refund.getIsPartial()) {
-            // 부분 환불인 경우: 전체 금액에서 환불 금액을 뺀서 사용된 금액 계산
-            usedAmount = expoPaymentInfo.getTotalAmount() - refund.getAmount();
+            // 부분 환불인 경우: 환불 금액으로 남은 일수 계산 후 사용 일수 도출
             if (expoPaymentInfo.getDailyUsageFee() > 0) {
-                usedDays = Math.max(0, usedAmount - depositAmount) / expoPaymentInfo.getDailyUsageFee();
-                remainingDays = expoPaymentInfo.getTotalDay() - usedDays;
+                remainingDays = refund.getAmount() / expoPaymentInfo.getDailyUsageFee();
+                usedDays = expoPaymentInfo.getTotalDay() - remainingDays;
+                usedAmount = usedDays * expoPaymentInfo.getDailyUsageFee();
+                
+                // 디버깅 로그 추가 (환불 완료 내역)
+                System.out.println("=== 환불 완료 내역 디버깅 (수정된 로직) ===");
+                System.out.println("총 게시 일수: " + expoPaymentInfo.getTotalDay());
+                System.out.println("환불 금액: " + refund.getAmount());
+                System.out.println("일일 이용료: " + expoPaymentInfo.getDailyUsageFee());
+                System.out.println("계산된 남은 일수: " + remainingDays);
+                System.out.println("계산된 사용 일수: " + usedDays);
+                System.out.println("계산된 사용 금액: " + usedAmount);
+                System.out.println("=====================");
             }
         }
         // 전액 환불인 경우는 기본값(0) 유지

--- a/src/main/java/com/myce/member/mapper/expo/ReservedExpoMapper.java
+++ b/src/main/java/com/myce/member/mapper/expo/ReservedExpoMapper.java
@@ -10,18 +10,24 @@ import java.util.stream.Collectors;
 @Component
 public class ReservedExpoMapper {
     
+    public ReservedExpoResponse toResponseDto(Reservation reservation) {
+        return ReservedExpoResponse.builder()
+                .expoId(reservation.getExpo().getId())
+                .title(reservation.getExpo().getTitle())
+                .thumbnailUrl(reservation.getExpo().getThumbnailUrl())
+                .ticketPrice(reservation.getTicket().getPrice())
+                .ticketCount(reservation.getQuantity())
+                .ticketName(reservation.getTicket().getName())
+                .reservationId(reservation.getId())
+                .reservationCode(reservation.getReservationCode())
+                .createdAt(reservation.getCreatedAt())
+                .reservationStatus(reservation.getStatus())
+                .build();
+    }
+    
     public List<ReservedExpoResponse> toResponseDtoList(List<Reservation> reservations) {
         return reservations.stream()
-                .map(reservation -> ReservedExpoResponse.builder()
-                        .expoId(reservation.getExpo().getId())
-                        .title(reservation.getExpo().getTitle())
-                        .thumbnailUrl(reservation.getExpo().getThumbnailUrl())
-                        .ticketPrice(reservation.getTicket().getPrice())
-                        .ticketCount(reservation.getQuantity())
-                        .ticketName(reservation.getTicket().getName())
-                        .reservationId(reservation.getId())
-                        .reservationCode(reservation.getReservationCode())
-                        .build())
+                .map(this::toResponseDto)
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/myce/member/service/MemberAdService.java
+++ b/src/main/java/com/myce/member/service/MemberAdService.java
@@ -1,6 +1,7 @@
 package com.myce.member.service;
 
 import com.myce.advertisement.dto.AdRejectInfoResponse;
+import com.myce.member.dto.ad.AdRefundReceiptResponse;
 import com.myce.member.dto.ad.AdRefundRequest;
 import com.myce.member.dto.ad.AdvertisementDetailResponse;
 import com.myce.member.dto.ad.AdvertisementPaymentDetailResponse;
@@ -26,6 +27,8 @@ public interface MemberAdService {
     AdvertisementRefundReceiptResponse getAdvertisementRefundReceipt(Long memberId, Long advertisementId);
     
     AdRejectInfoResponse getAdvertisementRejectInfo(Long memberId, Long advertisementId);
+    
+    AdRefundReceiptResponse getAdvertisementRefundHistory(Long memberId, Long advertisementId);
     
     void completeAdvertisementPayment(Long memberId, Long advertisementId);
 }

--- a/src/main/java/com/myce/member/service/MemberMyPageService.java
+++ b/src/main/java/com/myce/member/service/MemberMyPageService.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 public interface MemberMyPageService {
     
-    List<ReservedExpoResponse> getReservedExpos(Long memberId);
+    Page<ReservedExpoResponse> getReservedExpos(Long memberId, Pageable pageable);
 
     List<FavoriteExpoResponse> getFavoriteExpos(Long memberId);
 

--- a/src/main/java/com/myce/member/service/impl/MemberAdServiceImpl.java
+++ b/src/main/java/com/myce/member/service/impl/MemberAdServiceImpl.java
@@ -11,11 +11,13 @@ import com.myce.common.exception.CustomErrorCode;
 import com.myce.common.exception.CustomException;
 import com.myce.common.repository.BusinessProfileRepository;
 import com.myce.common.repository.RejectInfoRepository;
+import com.myce.member.dto.ad.AdRefundReceiptResponse;
 import com.myce.member.dto.ad.AdRefundRequest;
 import com.myce.member.dto.ad.AdvertisementDetailResponse;
 import com.myce.member.dto.ad.AdvertisementPaymentDetailResponse;
 import com.myce.member.dto.ad.AdvertisementRefundReceiptResponse;
 import com.myce.member.dto.ad.MemberAdvertisementResponse;
+import com.myce.member.mapper.ad.AdRefundReceiptMapper;
 import com.myce.member.mapper.ad.AdvertisementDetailMapper;
 import com.myce.member.mapper.ad.AdvertisementPaymentDetailMapper;
 import com.myce.member.mapper.ad.AdvertisementRefundReceiptMapper;
@@ -52,6 +54,7 @@ public class MemberAdServiceImpl implements MemberAdService {
     private final AdvertisementDetailMapper advertisementDetailMapper;
     private final AdvertisementPaymentDetailMapper advertisementPaymentDetailMapper;
     private final AdvertisementRefundReceiptMapper advertisementRefundReceiptMapper;
+    private final AdRefundReceiptMapper adRefundReceiptMapper;
     private final BusinessProfileRepository businessProfileRepository;
     private final AdPaymentInfoRepository adPaymentInfoRepository;
     private final PaymentRepository paymentRepository;
@@ -267,6 +270,8 @@ public class MemberAdServiceImpl implements MemberAdService {
             throw new CustomException(CustomErrorCode.INVALID_ADVERTISEMENT_STATUS);
         }
 
+        //TODO : 결제 API 연동, PAYMENT 생성 까지
+
         // 1. 광고 상태를 PENDING_PUBLISH로 변경
         advertisement.updateStatus(AdvertisementStatus.PENDING_PUBLISH);
         adRepository.save(advertisement);
@@ -278,5 +283,30 @@ public class MemberAdServiceImpl implements MemberAdService {
         adPaymentInfoRepository.save(paymentInfo);
 
         log.info("광고 결제 완료 처리 - 광고 ID: {}, 회원 ID: {}", advertisementId, memberId);
+    }
+    
+    @Override
+    public AdRefundReceiptResponse getAdvertisementRefundHistory(Long memberId, Long advertisementId) {
+        // 광고가 해당 회원의 것인지 확인
+        Advertisement advertisement = adRepository.findByIdAndMemberId(advertisementId, memberId)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.AD_NOT_FOUND));
+
+        Payment payment = paymentRepository.findByTargetIdAndTargetType(advertisementId, PaymentTargetType.AD)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.PAYMENT_INFO_NOT_FOUND));
+
+        // 비즈니스 프로필 조회
+        BusinessProfile businessProfile = businessProfileRepository.findByTargetIdAndTargetType(advertisementId, TargetType.ADVERTISEMENT)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.BUSINESS_NOT_EXIST));
+        
+        // 광고 결제 정보 조회
+        AdPaymentInfo adPaymentInfo = adPaymentInfoRepository.findByAdvertisementId(advertisementId)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.PAYMENT_INFO_NOT_FOUND));
+        
+        // 실제 환불 내역 조회 (REFUND 테이블에서)
+        Refund refund = refundRepository.findByPayment(payment)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.REFUND_NOT_FOUND));
+
+        
+        return adRefundReceiptMapper.toRefundHistoryDto(advertisement, businessProfile, adPaymentInfo, refund);
     }
 }

--- a/src/main/java/com/myce/member/service/impl/MemberExpoServiceImpl.java
+++ b/src/main/java/com/myce/member/service/impl/MemberExpoServiceImpl.java
@@ -302,6 +302,9 @@ public class MemberExpoServiceImpl implements MemberExpoService {
             throw new CustomException(CustomErrorCode.INVALID_EXPO_STATUS);
         }
 
+        //TODO : 결제 API 연동, PAYMENT 생성 까지
+
+
         // 1. 회원 역할을 EXPO_ADMIN으로 변경
         Member member = expo.getMember();
         member.updateRole(Role.EXPO_ADMIN);

--- a/src/main/java/com/myce/member/service/impl/MemberMyPageServiceImpl.java
+++ b/src/main/java/com/myce/member/service/impl/MemberMyPageServiceImpl.java
@@ -43,10 +43,10 @@ public class MemberMyPageServiceImpl implements MemberMyPageService {
     private final FavoriteRepository favoriteRepository;
 
     @Override
-    public List<ReservedExpoResponse> getReservedExpos(Long memberId) {
-        List<Reservation> reservations = reservationRepository.findReservationsByUserTypeAndUserIdWithExpoAndTicket(
-                UserType.MEMBER, memberId);
-        return reservedExpoMapper.toResponseDtoList(reservations);
+    public Page<ReservedExpoResponse> getReservedExpos(Long memberId, Pageable pageable) {
+        Page<Reservation> reservations = reservationRepository.findReservationsByUserTypeAndUserIdWithExpoAndTicket(
+                UserType.MEMBER, memberId, pageable);
+        return reservations.map(reservedExpoMapper::toResponseDto);
     }
 
     @Override

--- a/src/main/java/com/myce/payment/repository/RefundRepository.java
+++ b/src/main/java/com/myce/payment/repository/RefundRepository.java
@@ -6,6 +6,7 @@ import com.myce.payment.entity.type.RefundStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+
 import java.util.Optional;
 
 public interface RefundRepository extends JpaRepository<Refund, Long> {
@@ -21,4 +22,5 @@ public interface RefundRepository extends JpaRepository<Refund, Long> {
     Page<Refund> findByStatusOrderByCreatedAtDesc(RefundStatus status, Pageable pageable);
 
     void deleteByPayment(Payment payment);
+
 }

--- a/src/main/java/com/myce/reservation/dto/ReservationDetailResponse.java
+++ b/src/main/java/com/myce/reservation/dto/ReservationDetailResponse.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -20,6 +21,7 @@ public class ReservationDetailResponse {
     private ExpoInfo expoInfo;
     private ReservationInfo reservationInfo;
     private List<ReserverInfo> reserverInfos;
+    private PaymentInfo paymentInfo;
     
     @Getter
     @NoArgsConstructor
@@ -31,6 +33,8 @@ public class ReservationDetailResponse {
         private String title;
         private String location;
         private String locationDetail;
+        private LocalDate startDate;
+        private LocalDate endDate;
         private LocalDate displayStartDate;
         private LocalDate displayEndDate;
         private LocalTime startTime;
@@ -62,5 +66,22 @@ public class ReservationDetailResponse {
         private String phone;
         private String email;
         private String qrCodeUrl;
+    }
+    
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class PaymentInfo {
+        private Integer usedMileage;
+        private Integer savedMileage;
+        private Integer totalAmount;
+        private String paymentStatus;
+        private String paymentMethod;
+        private String paymentDetail;
+        private LocalDateTime paidAt;
+        private String memberGrade;
+        private BigDecimal mileageRate;
+        private String gradeDescription;
     }
 }

--- a/src/main/java/com/myce/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/myce/reservation/repository/ReservationRepository.java
@@ -23,9 +23,34 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     @Query("SELECT r FROM Reservation r " +
             "JOIN FETCH r.expo e " +
             "JOIN FETCH r.ticket t " +
-            "WHERE r.userType = :userType AND r.userId = :userId")
+            "WHERE r.userType = :userType AND r.userId = :userId " +
+            "ORDER BY r.createdAt DESC")
     List<Reservation> findReservationsByUserTypeAndUserIdWithExpoAndTicket(@Param("userType") UserType userType,
                                                                            @Param("userId") Long userId);
+
+    @Query(value = "SELECT r FROM Reservation r " +
+            "WHERE r.userType = :userType AND r.userId = :userId",
+            countQuery = "SELECT COUNT(r) FROM Reservation r " +
+            "WHERE r.userType = :userType AND r.userId = :userId")
+    Page<Reservation> findReservationsByUserTypeAndUserIdWithExpoAndTicket(@Param("userType") UserType userType,
+                                                                           @Param("userId") Long userId,
+                                                                           Pageable pageable);
+
+    @Query("""
+            SELECT r, rpi, p, mg 
+            FROM Reservation r 
+            JOIN FETCH r.expo e 
+            JOIN FETCH r.ticket t 
+            LEFT JOIN ReservationPaymentInfo rpi ON rpi.reservation.id = r.id 
+            LEFT JOIN Payment p ON p.targetType = 'RESERVATION' AND p.targetId = r.id 
+            LEFT JOIN Member m ON r.userType = 'MEMBER' AND r.userId = m.id 
+            LEFT JOIN m.memberGrade mg 
+            WHERE r.userType = :userType AND r.userId = :userId 
+            ORDER BY r.createdAt DESC
+            """)
+    Page<Object[]> findReservationsWithPaymentInfoByUserTypeAndUserId(@Param("userType") UserType userType,
+                                                                      @Param("userId") Long userId,
+                                                                      Pageable pageable);
 
     @Query("SELECT r FROM Reservation r " +
             "JOIN FETCH r.expo e " +

--- a/src/main/java/com/myce/reservation/service/Impl/ReservationServiceImpl.java
+++ b/src/main/java/com/myce/reservation/service/Impl/ReservationServiceImpl.java
@@ -13,6 +13,7 @@ import com.myce.member.entity.Guest;
 import com.myce.member.entity.Member;
 import com.myce.member.repository.GuestRepository;
 import com.myce.member.repository.MemberRepository;
+import com.myce.member.entity.MemberGrade;
 import com.myce.payment.entity.Payment;
 import com.myce.payment.entity.ReservationPaymentInfo;
 import com.myce.payment.entity.type.PaymentTargetType;
@@ -74,7 +75,20 @@ public class ReservationServiceImpl implements ReservationService {
 
         List<Reserver> reservers = reserverRepository.findByReservation(reservation);
         
-        return reservationDetailMapper.toResponseDto(reservation, reservers);
+        // 결제 정보 조회
+        ReservationPaymentInfo paymentInfo = reservationPaymentInfoRepository.findByReservationId(reservationId).orElse(null);
+        Payment payment = paymentRepository.findByTargetIdAndTargetType(reservationId, PaymentTargetType.RESERVATION).orElse(null);
+        
+        // 회원 등급 정보 조회 (회원인 경우만)
+        MemberGrade memberGrade = null;
+        if (reservation.getUserType() == UserType.MEMBER) {
+            Member member = memberRepository.findById(reservation.getUserId()).orElse(null);
+            if (member != null) {
+                memberGrade = member.getMemberGrade();
+            }
+        }
+        
+        return reservationDetailMapper.toResponseDto(reservation, reservers, paymentInfo, payment, memberGrade);
     }
     
     @Override

--- a/src/main/java/com/myce/reservation/service/mapper/ReservationDetailMapper.java
+++ b/src/main/java/com/myce/reservation/service/mapper/ReservationDetailMapper.java
@@ -1,5 +1,8 @@
 package com.myce.reservation.service.mapper;
 
+import com.myce.member.entity.MemberGrade;
+import com.myce.payment.entity.Payment;
+import com.myce.payment.entity.ReservationPaymentInfo;
 import com.myce.qrcode.entity.QrCode;
 import com.myce.qrcode.repository.QrCodeRepository;
 import com.myce.reservation.dto.ReservationDetailResponse;
@@ -27,6 +30,16 @@ public class ReservationDetailMapper {
                 .build();
     }
     
+    public ReservationDetailResponse toResponseDto(Reservation reservation, List<Reserver> reservers, 
+                                                  ReservationPaymentInfo paymentInfo, Payment payment, MemberGrade memberGrade) {
+        return ReservationDetailResponse.builder()
+                .expoInfo(buildExpoInfo(reservation))
+                .reservationInfo(buildReservationInfo(reservation))
+                .reserverInfos(buildReserverInfos(reservers))
+                .paymentInfo(buildPaymentInfo(paymentInfo, payment, memberGrade))
+                .build();
+    }
+    
     private ReservationDetailResponse.ExpoInfo buildExpoInfo(Reservation reservation) {
         return ReservationDetailResponse.ExpoInfo.builder()
                 .expoId(reservation.getExpo().getId())
@@ -34,6 +47,8 @@ public class ReservationDetailMapper {
                 .title(reservation.getExpo().getTitle())
                 .location(reservation.getExpo().getLocation())
                 .locationDetail(reservation.getExpo().getLocationDetail())
+                .startDate(reservation.getExpo().getStartDate())
+                .endDate(reservation.getExpo().getEndDate())
                 .displayStartDate(reservation.getExpo().getDisplayStartDate())
                 .displayEndDate(reservation.getExpo().getDisplayEndDate())
                 .startTime(reservation.getExpo().getStartTime())
@@ -77,5 +92,53 @@ public class ReservationDetailMapper {
                             .build();
                 })
                 .collect(Collectors.toList());
+    }
+    
+    private ReservationDetailResponse.PaymentInfo buildPaymentInfo(ReservationPaymentInfo paymentInfo, 
+                                                                   Payment payment, MemberGrade memberGrade) {
+        if (paymentInfo == null) {
+            return null;
+        }
+        
+        String paymentMethod = payment != null ? payment.getPaymentMethod().name() : null;
+        String paymentDetail = null;
+        
+        if (payment != null) {
+            // 카드 결제인 경우
+            if (payment.getCardCompany() != null && payment.getCardNumber() != null) {
+                paymentDetail = payment.getCardCompany() + " " + maskCardNumber(payment.getCardNumber());
+            }
+            // 계좌 이체인 경우
+            else if (payment.getAccountBank() != null && payment.getAccountNumber() != null) {
+                paymentDetail = payment.getAccountBank() + " " + maskAccountNumber(payment.getAccountNumber());
+            }
+        }
+        
+        return ReservationDetailResponse.PaymentInfo.builder()
+                .usedMileage(paymentInfo.getUsedMileage())
+                .savedMileage(paymentInfo.getSavedMileage())
+                .totalAmount(paymentInfo.getTotalAmount())
+                .paymentStatus(paymentInfo.getStatus().name())
+                .paymentMethod(paymentMethod)
+                .paymentDetail(paymentDetail)
+                .paidAt(payment != null ? payment.getPaidAt() : null)
+                .memberGrade(memberGrade != null ? memberGrade.getDescription() : null)
+                .mileageRate(memberGrade != null ? memberGrade.getMileageRate() : null)
+                .gradeDescription(memberGrade != null ? memberGrade.getDescription() : null)
+                .build();
+    }
+    
+    private String maskCardNumber(String cardNumber) {
+        if (cardNumber == null || cardNumber.length() < 4) {
+            return "****";
+        }
+        return "****-****-****-" + cardNumber.substring(cardNumber.length() - 4);
+    }
+    
+    private String maskAccountNumber(String accountNumber) {
+        if (accountNumber == null || accountNumber.length() < 4) {
+            return "****";
+        }
+        return "****" + accountNumber.substring(accountNumber.length() - 4);
     }
 }


### PR DESCRIPTION
ADVERTISEMENT 테이블 -> PENDING_PUBLSIEHD
ADVERTISEMENT_PAYMENT -> 전환
박람회 신청 광고 신청 화면 요금제 안내
박람회 취소됐을떄 CANCELLED일떄  상태값 뱃지
광고 결제 완료 시  메인페이지 - 박람회 상세 - 상세 정보 UI 수정 필요

꼬마관리자 로그인 대시보드 리다이렉트 기능 추가
티켓 정보 -> 판매 기간추가
티켓 구매 모달 -> 오늘날짜가 start_date랑 end_date 사이인거만출력

박람회 , 분기처리 고민
 환불 영수증 조회 기능 추가
PENDING_PUBLISH일떄 결제 영수증 조회 기능
광고 CANCELLED , PENDING_CANCEL 일떄 결제 정보

광고/박람회 STATUS 별 환불 영수증 조회 기능 추가

광고/박람회 환불 신청 영수증 좌우로 두탭으로 나누기

예매 내역 최신순 조회로 변경, 두개로 나눠지는거 버그픽스

박람회/광고 신청 내역에서 사진 꽉차게

광고/박람회 신청현황 페이지네이션 바 << >> 삭제

박람회 예매 상세내역 -> display date -> date 로 변경

박람화 예매 상세내역 -> QR코드 박람회 게시기간 외 조회 불가능하게 수정

실시간 혼잡도 표시 -> QR 코드 모달 안으로 이전

실시간 혼잡도 , QR코드 EXPO  STATUS 분기처리
예매 상세에서 포스터 클릭시 ->  박람회 상세 이동

예매내역 / 결제내역 통합
결제 내역 조회시에 마일리지 랑 결제 상세 정보  표시