### PR TITLE
fix: AWS SDK와 Spring AI BOM 버전 충돌 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-aop'
 	implementation 'com.google.zxing:core:3.5.3' // QR코드 생성 라이브러리
 	implementation 'com.google.zxing:javase:3.5.3' // QR코드 생성
-	implementation platform("software.amazon.awssdk:bom:2.25.23")
+	implementation platform("software.amazon.awssdk:bom:2.29.29")  // Spring Boot 3.4.x 호환 버전
 	implementation "software.amazon.awssdk:s3"
 	implementation "software.amazon.awssdk:bedrockruntime"
 	


### PR DESCRIPTION
- AWS SDK BOM 버전을 2.25.23에서 2.29.29로 업그레이드
- ClientEndpointProvider null 오류 해결
- S3 Presigned URL 생성 기능 정상화
- Spring AI BOM 1.0.0-M6과의 호환성 문제 해결
