### PR TITLE
[CRM-282] refactor : 박람회 관리자 권한 로직 리팩토링

### DIFF
--- a/src/main/java/com/myce/common/exception/CustomErrorCode.java
+++ b/src/main/java/com/myce/common/exception/CustomErrorCode.java
@@ -34,6 +34,8 @@ public enum CustomErrorCode {
 
     // 박람회 관리자 EAD
     ADMIN_CODE_NOT_FOUND(HttpStatus.NOT_FOUND, "EAD001", "존재하지 않는 박람회 관리자 코드입니다."),
+    INVALID_EXPO_ADMIN_PERMISSION_TYPE(HttpStatus.NOT_FOUND, "EAD002", "유효하지 않은 권한 타입입니다."),
+    EXPO_ADMIN_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "EAD003", "해당 기능에 대한 접근 권한이 없습니다."),
 
     // 관계자 정보 I
     BUSINESS_NOT_EXIST(HttpStatus.NOT_FOUND, "I001", "관계자 정보를 찾지 못했습니다"),
@@ -62,7 +64,7 @@ public enum CustomErrorCode {
     CATEGORY_NOT_EXIST(HttpStatus.NOT_FOUND, "E004", "카테고리가 존재하지 않습니다."),
     INVALID_EXPO_STATUS(HttpStatus.NOT_FOUND, "E005", "영수증을 조회 할 수 없습니다."),
     EXPO_NOT_PUBLISHED(HttpStatus.FORBIDDEN, "E006", "공개되지 않은 박람회입니다."),
-
+    EXPO_EDIT_DENIED(HttpStatus.FORBIDDEN, "E007","해당 박람회에 대한 수정 권한이 없습니다."),
 
     // 티켓 T
     TICKET_NOT_EXIST(HttpStatus.NOT_FOUND, "T001", "티켓이 존재하지 않습니다."),

--- a/src/main/java/com/myce/common/permission/ExpoAdminAccessValidate.java
+++ b/src/main/java/com/myce/common/permission/ExpoAdminAccessValidate.java
@@ -10,7 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 /*
-    박람회 관리자의 api 요청에 대한 조회/편집 권한 검증을 위한 메소드입니다.
+    박람회 관리자의 api 요청에 대한 페이지별 조회/편집 권한 검증 메소드입니다.
  */
 @Component
 @RequiredArgsConstructor
@@ -18,27 +18,54 @@ public class ExpoAdminAccessValidate {
 
     private final ExpoRepository expoRepository;
     private final AdminPermissionRepository adminPermissionRepository;
-    
-    //GET 요청에서 사용 : 조회 권한 검증
+
+    //GET 메서드에서 사용 : 조회 권한 검증
     public void ensureViewable(Long expoId, Long memberId, LoginType loginType, ExpoAdminPermission permission) {
 
         //기본 유효성 검사
-        if (memberId == null || loginType == null) {
-            throw new CustomException(CustomErrorCode.MEMBER_NOT_EXIST);
-        }
-        if (permission == null) {
-            throw new CustomException(CustomErrorCode.INVALID_EXPO_ADMIN_PERMISSION_TYPE);
-        }
+        basicValidate(memberId, loginType, permission);
 
         //해당 엑스포의 상태가 조회 가능한 상태인지 확인
         ExpoStatus status = expoRepository.findStatusById(expoId)
                 .orElseThrow(() -> new CustomException(CustomErrorCode.EXPO_NOT_EXIST));
 
         if(!ExpoStatus.ADMIN_VIEWABLE_STATUSES.contains(status)) {
-            throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
+            throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED); //조회 가능한 상태가 아니라면 예외 반환(*)
         }
         
-        //박람회 관리자가 해당 엑스포에 대한 권한이 있는지 확인
+        //박람회 관리자가 해당 엑스포 페이지에 대한 권한이 있는지 확인
+        expoAdminValidate(expoId, memberId, loginType, permission);
+    }
+    
+    //PUT, POST, DELETE 등의 메소드에서 사용 : 편집 권한 검증
+    public void ensureEditable(Long expoId, Long memberId, LoginType loginType, ExpoAdminPermission permission) {
+        
+        //기본 유효성 검사
+        basicValidate(memberId, loginType, permission);
+
+        //해당 엑스포가 편집 가능한 상태인지 확인
+        ExpoStatus status = expoRepository.findStatusById(expoId)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED));
+
+        if(!ExpoStatus.ADMIN_EDITABLE_STATUSES.contains(status)) {
+            throw new CustomException(CustomErrorCode.EXPO_EDIT_DENIED); //편집이 가능한 상태가 아니라면 예외 반환(*)
+        }
+        
+        //박람회 관리자가 해당 엑스포 페이지에 대한 권한이 있는지 확인
+        expoAdminValidate(expoId, memberId, loginType, permission);
+    }
+
+    private void basicValidate(Long memberId, LoginType loginType, ExpoAdminPermission permission) {
+        if (memberId == null || loginType == null) {
+            throw new CustomException(CustomErrorCode.MEMBER_NOT_EXIST);
+        }
+
+        if (permission == null) {
+            throw new CustomException(CustomErrorCode.INVALID_EXPO_ADMIN_PERMISSION_TYPE);
+        }
+    }
+
+    private void expoAdminValidate(Long expoId, Long memberId, LoginType loginType, ExpoAdminPermission permission) {
         switch (loginType){
             case MEMBER -> {
                 if(!expoRepository.existsByIdAndMemberId(expoId, memberId)){
@@ -56,46 +83,6 @@ public class ExpoAdminAccessValidate {
                             -> adminPermissionRepository.existsByAdminCodeIdAndAdminCodeExpoIdAndIsEmailLogViewTrue(memberId,expoId);
                     case INQUIRY_VIEW
                             -> adminPermissionRepository.existsByAdminCodeIdAndAdminCodeExpoIdAndIsInquiryViewTrue(memberId,expoId);
-                    default -> throw new CustomException(CustomErrorCode.INVALID_EXPO_ADMIN_PERMISSION_TYPE);
-                };
-
-                if (!allowed) {
-                    throw new CustomException(CustomErrorCode.EXPO_ADMIN_PERMISSION_DENIED);
-                }
-            }
-            default -> throw new CustomException(CustomErrorCode.INVALID_LOGIN_TYPE);
-        }
-    }
-    
-    //POST, PUT, DELETE 등의 요청에서 사용 : 편집 권한 검증
-    public void ensureEditable(Long expoId, Long memberId, LoginType loginType, ExpoAdminPermission permission) {
-        
-        //기본 유효성 검사
-        if (memberId == null || loginType == null) {
-            throw new CustomException(CustomErrorCode.MEMBER_NOT_EXIST);
-        }
-        if (permission == null) {
-            throw new CustomException(CustomErrorCode.INVALID_EXPO_ADMIN_PERMISSION_TYPE);
-        }
-
-        //해당 엑스포가 편집 가능한 상태인지 확인
-        ExpoStatus status = expoRepository.findStatusById(expoId)
-                .orElseThrow(() -> new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED));
-
-        if(!ExpoStatus.ADMIN_EDITABLE_STATUSES.contains(status)) {
-            throw new CustomException(CustomErrorCode.EXPO_EDIT_DENIED);
-        }
-        
-        //박람회 관리자가 해당 엑스포에 대한 편집 권한이 있는지 확인
-        switch (loginType) {
-            case MEMBER -> {
-                if (!expoRepository.existsByIdAndMemberId(expoId, memberId)) {
-                    throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
-                }
-            }
-
-            case ADMIN_CODE -> {
-                boolean allowed = switch(permission){
                     case EXPO_DETAIL_UPDATE
                             -> adminPermissionRepository.existsByAdminCodeIdAndAdminCodeExpoIdAndIsExpoDetailUpdateTrue(memberId,expoId);
                     case BOOTH_INFO_UPDATE
@@ -111,6 +98,7 @@ public class ExpoAdminAccessValidate {
                     throw new CustomException(CustomErrorCode.EXPO_ADMIN_PERMISSION_DENIED);
                 }
             }
+
             default -> throw new CustomException(CustomErrorCode.INVALID_LOGIN_TYPE);
         }
     }

--- a/src/main/java/com/myce/common/permission/ExpoAdminAccessValidate.java
+++ b/src/main/java/com/myce/common/permission/ExpoAdminAccessValidate.java
@@ -1,0 +1,117 @@
+package com.myce.common.permission;
+
+import com.myce.auth.dto.type.LoginType;
+import com.myce.common.exception.CustomErrorCode;
+import com.myce.common.exception.CustomException;
+import com.myce.expo.entity.type.ExpoStatus;
+import com.myce.expo.repository.AdminPermissionRepository;
+import com.myce.expo.repository.ExpoRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/*
+    박람회 관리자의 api 요청에 대한 조회/편집 권한 검증을 위한 메소드입니다.
+ */
+@Component
+@RequiredArgsConstructor
+public class ExpoAdminAccessValidate {
+
+    private final ExpoRepository expoRepository;
+    private final AdminPermissionRepository adminPermissionRepository;
+    
+    //GET 요청에서 사용 : 조회 권한 검증
+    public void ensureViewable(Long expoId, Long memberId, LoginType loginType, ExpoAdminPermission permission) {
+
+        //기본 유효성 검사
+        if (memberId == null || loginType == null) {
+            throw new CustomException(CustomErrorCode.MEMBER_NOT_EXIST);
+        }
+        if (permission == null) {
+            throw new CustomException(CustomErrorCode.INVALID_EXPO_ADMIN_PERMISSION_TYPE);
+        }
+
+        //해당 엑스포의 상태가 조회 가능한 상태인지 확인
+        ExpoStatus status = expoRepository.findStatusById(expoId)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.EXPO_NOT_EXIST));
+
+        if(!ExpoStatus.ADMIN_VIEWABLE_STATUSES.contains(status)) {
+            throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
+        }
+        
+        //박람회 관리자가 해당 엑스포에 대한 권한이 있는지 확인
+        switch (loginType){
+            case MEMBER -> {
+                if(!expoRepository.existsByIdAndMemberId(expoId, memberId)){
+                    throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
+                }
+            }
+
+            case ADMIN_CODE -> {
+                boolean allowed = switch(permission){
+                    case RESERVER_LIST_VIEW
+                            -> adminPermissionRepository.existsByAdminCodeIdAndAdminCodeExpoIdAndIsReserverListViewTrue(memberId,expoId);
+                    case PAYMENT_VIEW
+                            -> adminPermissionRepository.existsByAdminCodeIdAndAdminCodeExpoIdAndIsPaymentViewTrue(memberId,expoId);
+                    case EMAIL_LOG_VIEW
+                            -> adminPermissionRepository.existsByAdminCodeIdAndAdminCodeExpoIdAndIsEmailLogViewTrue(memberId,expoId);
+                    case INQUIRY_VIEW
+                            -> adminPermissionRepository.existsByAdminCodeIdAndAdminCodeExpoIdAndIsInquiryViewTrue(memberId,expoId);
+                    default -> throw new CustomException(CustomErrorCode.INVALID_EXPO_ADMIN_PERMISSION_TYPE);
+                };
+
+                if (!allowed) {
+                    throw new CustomException(CustomErrorCode.EXPO_ADMIN_PERMISSION_DENIED);
+                }
+            }
+            default -> throw new CustomException(CustomErrorCode.INVALID_LOGIN_TYPE);
+        }
+    }
+    
+    //POST, PUT, DELETE 등의 요청에서 사용 : 편집 권한 검증
+    public void ensureEditable(Long expoId, Long memberId, LoginType loginType, ExpoAdminPermission permission) {
+        
+        //기본 유효성 검사
+        if (memberId == null || loginType == null) {
+            throw new CustomException(CustomErrorCode.MEMBER_NOT_EXIST);
+        }
+        if (permission == null) {
+            throw new CustomException(CustomErrorCode.INVALID_EXPO_ADMIN_PERMISSION_TYPE);
+        }
+
+        //해당 엑스포가 편집 가능한 상태인지 확인
+        ExpoStatus status = expoRepository.findStatusById(expoId)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED));
+
+        if(!ExpoStatus.ADMIN_EDITABLE_STATUSES.contains(status)) {
+            throw new CustomException(CustomErrorCode.EXPO_EDIT_DENIED);
+        }
+        
+        //박람회 관리자가 해당 엑스포에 대한 편집 권한이 있는지 확인
+        switch (loginType) {
+            case MEMBER -> {
+                if (!expoRepository.existsByIdAndMemberId(expoId, memberId)) {
+                    throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
+                }
+            }
+
+            case ADMIN_CODE -> {
+                boolean allowed = switch(permission){
+                    case EXPO_DETAIL_UPDATE
+                            -> adminPermissionRepository.existsByAdminCodeIdAndAdminCodeExpoIdAndIsExpoDetailUpdateTrue(memberId,expoId);
+                    case BOOTH_INFO_UPDATE
+                            -> adminPermissionRepository.existsByAdminCodeIdAndAdminCodeExpoIdAndIsBoothInfoUpdateTrue(memberId,expoId);
+                    case SCHEDULE_UPDATE
+                            -> adminPermissionRepository.existsByAdminCodeIdAndAdminCodeExpoIdAndIsScheduleUpdateTrue(memberId,expoId);
+                    case OPERATIONS_CONFIG_UPDATE
+                            -> adminPermissionRepository.existsByAdminCodeIdAndAdminCodeExpoIdAndIsOperationsConfigUpdateTrue(memberId,expoId);
+                    default -> throw new CustomException(CustomErrorCode.INVALID_EXPO_ADMIN_PERMISSION_TYPE);
+                };
+
+                if (!allowed) {
+                    throw new CustomException(CustomErrorCode.EXPO_ADMIN_PERMISSION_DENIED);
+                }
+            }
+            default -> throw new CustomException(CustomErrorCode.INVALID_LOGIN_TYPE);
+        }
+    }
+}

--- a/src/main/java/com/myce/common/permission/ExpoAdminPermission.java
+++ b/src/main/java/com/myce/common/permission/ExpoAdminPermission.java
@@ -8,14 +8,14 @@ public enum ExpoAdminPermission {
         DB 필드명을 기준으로 작성했습니다.
         UPDATE, VIEW 와 상관없이 탭별, 즉 페이지 기준 권한으로 정의합니다.
      */
-    EXPO_DETAIL_UPDATE,
-    BOOTH_INFO_UPDATE,
-    SCHEDULE_UPDATE,
-    OPERATIONS_CONFIG_UPDATE,
-    RESERVER_LIST_VIEW,
-    PAYMENT_VIEW,
-    EMAIL_LOG_VIEW,
-    INQUIRY_VIEW;
+    EXPO_DETAIL_UPDATE, //박람회 상세
+    BOOTH_INFO_UPDATE, //참가 부스
+    SCHEDULE_UPDATE, //행사 일정
+    PAYMENT_VIEW, //예약 내역
+    RESERVER_LIST_VIEW, //예약자 리스트
+    EMAIL_LOG_VIEW, //이메일 전송 이력
+    OPERATIONS_CONFIG_UPDATE, //운영 설정
+    INQUIRY_VIEW; //문의
 
     public static ExpoAdminPermission fromValue(String value) {
         for (ExpoAdminPermission p : ExpoAdminPermission.values()) {

--- a/src/main/java/com/myce/common/permission/ExpoAdminPermission.java
+++ b/src/main/java/com/myce/common/permission/ExpoAdminPermission.java
@@ -1,0 +1,22 @@
+package com.myce.common.permission;
+
+import com.myce.common.exception.CustomErrorCode;
+import com.myce.common.exception.CustomException;
+
+public enum ExpoAdminPermission {
+    EXPO_DETAIL_UPDATE,
+    BOOTH_INFO_UPDATE,
+    SCHEDULE_UPDATE,
+    RESERVER_LIST_VIEW,
+    PAYMENT_VIEW,
+    EMAIL_LOG_VIEW,
+    OPERATIONS_CONFIG_UPDATE,
+    INQUIRY_VIEW;
+
+    public static ExpoAdminPermission fromValue(String value) {
+        for (ExpoAdminPermission p : ExpoAdminPermission.values()) {
+            if (p.name().equalsIgnoreCase(value)) return p;
+        }
+        throw new CustomException(CustomErrorCode.INVALID_EXPO_ADMIN_PERMISSION_TYPE);
+    }
+}

--- a/src/main/java/com/myce/common/permission/ExpoAdminPermission.java
+++ b/src/main/java/com/myce/common/permission/ExpoAdminPermission.java
@@ -4,13 +4,17 @@ import com.myce.common.exception.CustomErrorCode;
 import com.myce.common.exception.CustomException;
 
 public enum ExpoAdminPermission {
+    /*
+        DB 필드명을 기준으로 작성했습니다.
+        UPDATE, VIEW 와 상관없이 탭별, 즉 페이지 기준 권한으로 정의합니다.
+     */
     EXPO_DETAIL_UPDATE,
     BOOTH_INFO_UPDATE,
     SCHEDULE_UPDATE,
+    OPERATIONS_CONFIG_UPDATE,
     RESERVER_LIST_VIEW,
     PAYMENT_VIEW,
     EMAIL_LOG_VIEW,
-    OPERATIONS_CONFIG_UPDATE,
     INQUIRY_VIEW;
 
     public static ExpoAdminPermission fromValue(String value) {

--- a/src/main/java/com/myce/common/service/impl/ExpoAdminBusinessProfileServiceImpl.java
+++ b/src/main/java/com/myce/common/service/impl/ExpoAdminBusinessProfileServiceImpl.java
@@ -7,6 +7,8 @@ import com.myce.common.entity.BusinessProfile;
 import com.myce.common.entity.type.TargetType;
 import com.myce.common.exception.CustomErrorCode;
 import com.myce.common.exception.CustomException;
+import com.myce.common.permission.ExpoAdminAccessValidate;
+import com.myce.common.permission.ExpoAdminPermission;
 import com.myce.common.repository.BusinessProfileRepository;
 import com.myce.common.service.ExpoAdminBusinessProfileService;
 import com.myce.common.service.mapper.ExpoAdminBusinessProfileMapper;
@@ -20,14 +22,13 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ExpoAdminBusinessProfileServiceImpl implements ExpoAdminBusinessProfileService {
 
-    private final ExpoRepository expoRepository;
+    private final ExpoAdminAccessValidate expoAdminAccessValidate;
     private final BusinessProfileRepository businessProfileRepository;
-    private final AdminPermissionRepository adminPermissionRepository;
     private final ExpoAdminBusinessProfileMapper mapper;
 
     @Override
     public ExpoAdminBusinessProfileResponseDto getMyBusinessProfile(Long expoId, Long memberId, LoginType loginType) {
-        validateMyAccess(expoId, memberId, loginType);
+        expoAdminAccessValidate.ensureViewable(expoId, memberId, loginType, ExpoAdminPermission.OPERATIONS_CONFIG_UPDATE);
         BusinessProfile profile = getMyBusinessProfile(expoId);
 
         return mapper.toDto(profile);
@@ -39,7 +40,7 @@ public class ExpoAdminBusinessProfileServiceImpl implements ExpoAdminBusinessPro
                                         Long memberId,
                                         LoginType loginType,
                                         ExpoAdminBusinessProfileRequestDto dto) {
-        validateMyAccess(expoId, memberId, loginType);
+        expoAdminAccessValidate.ensureEditable(expoId, memberId, loginType, ExpoAdminPermission.OPERATIONS_CONFIG_UPDATE);
         BusinessProfile profile = getMyBusinessProfile(expoId);
 
         profile.updateProfileInfo(
@@ -58,25 +59,5 @@ public class ExpoAdminBusinessProfileServiceImpl implements ExpoAdminBusinessPro
     private BusinessProfile getMyBusinessProfile(Long expoId){
         return businessProfileRepository.findByTargetIdAndTargetType(expoId,TargetType.EXPO)
                 .orElseThrow(() -> new CustomException(CustomErrorCode.BUSINESS_NOT_EXIST));
-    }
-
-    private void validateMyAccess(Long expoId, Long memberId, LoginType loginType) {
-        if(memberId == null || loginType == null){
-            throw new CustomException(CustomErrorCode.MEMBER_NOT_EXIST);
-        }
-
-        switch(loginType){
-            case MEMBER -> {
-                if (!expoRepository.existsByIdAndMemberId(expoId, memberId)) {
-                    throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
-                }
-            }
-            case ADMIN_CODE -> {
-                if(!adminPermissionRepository.existsByAdminCodeIdAndAdminCodeExpoIdAndIsOperationsConfigUpdateTrue(memberId, expoId)){
-                    throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
-                }
-            }
-            default -> throw new CustomException(CustomErrorCode.INVALID_LOGIN_TYPE);
-        }
     }
 }

--- a/src/main/java/com/myce/expo/entity/type/ExpoStatus.java
+++ b/src/main/java/com/myce/expo/entity/type/ExpoStatus.java
@@ -39,4 +39,21 @@ public enum ExpoStatus {
             COMPLETED,
             CANCELLED
     );
+
+    //박람회 관리자가 조회 가능한 상태
+    public static final List<ExpoStatus> ADMIN_VIEWABLE_STATUSES = List.of(
+            PENDING_PUBLISH,
+            PENDING_CANCEL,
+            PUBLISHED,
+            PUBLISH_ENDED,
+            SETTLEMENT_REQUESTED,
+            COMPLETED
+    );
+
+    //박람회 관리자가 편집 가능한 상태(편집 가능 상태 ⊂ 조회 가능 상태)
+    public static final List<ExpoStatus> ADMIN_EDITABLE_STATUSES = List.of(
+            PENDING_PUBLISH,
+            PUBLISHED,
+            SETTLEMENT_REQUESTED
+    );
 }

--- a/src/main/java/com/myce/expo/entity/type/ExpoStatus.java
+++ b/src/main/java/com/myce/expo/entity/type/ExpoStatus.java
@@ -54,6 +54,7 @@ public enum ExpoStatus {
     public static final List<ExpoStatus> ADMIN_EDITABLE_STATUSES = List.of(
             PENDING_PUBLISH,
             PUBLISHED,
+            PUBLISH_ENDED,
             SETTLEMENT_REQUESTED
     );
 }

--- a/src/main/java/com/myce/expo/repository/ExpoRepository.java
+++ b/src/main/java/com/myce/expo/repository/ExpoRepository.java
@@ -10,7 +10,6 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -46,7 +45,11 @@ public interface ExpoRepository extends JpaRepository<Expo, Long> {
 
     List<Expo> findByMemberIdOrderByCreatedAtDesc(Long memberId);
     Page<Expo> findByMemberIdOrderByCreatedAtDesc(Long memberId, Pageable pageable);
-    Boolean existsByIdAndMemberId(Long id, Long memberId);
+
+    @Query("select e.status from Expo e where e.id = :expoId")
+    Optional<ExpoStatus> findStatusById(@Param("expoId") Long expoId);
+
+    Boolean existsByIdAndMemberId(Long expoId, Long memberId);
     
     // QR코드 일괄 생성용 - 시작일이 특정 날짜이고 게시된 박람회 조회
     List<Expo> findByStartDateAndStatus(LocalDate startDate, ExpoStatus status);

--- a/src/main/java/com/myce/expo/service/impl/ExpoAdminManagerServiceImpl.java
+++ b/src/main/java/com/myce/expo/service/impl/ExpoAdminManagerServiceImpl.java
@@ -3,13 +3,13 @@ package com.myce.expo.service.impl;
 import com.myce.auth.dto.type.LoginType;
 import com.myce.common.exception.CustomErrorCode;
 import com.myce.common.exception.CustomException;
+import com.myce.common.permission.ExpoAdminAccessValidate;
+import com.myce.common.permission.ExpoAdminPermission;
 import com.myce.expo.dto.ExpoAdminManagerRequest;
 import com.myce.expo.dto.ExpoAdminManagerResponse;
 import com.myce.expo.entity.AdminCode;
 import com.myce.expo.entity.AdminPermission;
 import com.myce.expo.repository.AdminCodeRepository;
-import com.myce.expo.repository.AdminPermissionRepository;
-import com.myce.expo.repository.ExpoRepository;
 import com.myce.expo.service.ExpoAdminManagerService;
 import com.myce.expo.service.mapper.ExpoAdminMangerMapper;
 import lombok.RequiredArgsConstructor;
@@ -24,14 +24,13 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class ExpoAdminManagerServiceImpl implements ExpoAdminManagerService {
 
+    private final ExpoAdminAccessValidate expoAdminAccessValidate;
     private final AdminCodeRepository adminCodeRepository;
-    private final AdminPermissionRepository adminPermissionRepository;
-    private final ExpoRepository expoRepository;
     private final ExpoAdminMangerMapper mapper;
 
     @Override
     public List<ExpoAdminManagerResponse> getMyExpoManagers(Long expoId, Long memberId, LoginType loginType) {
-        validateMyAccess(expoId, memberId, loginType);
+        expoAdminAccessValidate.ensureViewable(expoId, memberId, loginType, ExpoAdminPermission.OPERATIONS_CONFIG_UPDATE);
         List<AdminCode> adminCodes = adminCodeRepository.findAllWithAdminPermissionByExpoId(expoId);
 
         return adminCodes.stream()
@@ -47,7 +46,7 @@ public class ExpoAdminManagerServiceImpl implements ExpoAdminManagerService {
             LoginType loginType,
             List<ExpoAdminManagerRequest> dtos) {
 
-        validateMyAccess(expoId, memberId, loginType);
+        expoAdminAccessValidate.ensureEditable(expoId, memberId, loginType, ExpoAdminPermission.OPERATIONS_CONFIG_UPDATE);
 
         List<Long> ids = dtos.stream()
                 .map(ExpoAdminManagerRequest::getId)
@@ -75,25 +74,5 @@ public class ExpoAdminManagerServiceImpl implements ExpoAdminManagerService {
         return adminCodes.stream()
                 .map(mapper::toDto)
                 .toList();
-    }
-
-    private void validateMyAccess(Long expoId, Long memberId, LoginType loginType) {
-        if(memberId == null || loginType == null){
-            throw new CustomException(CustomErrorCode.MEMBER_NOT_EXIST);
-        }
-
-        switch(loginType){
-            case MEMBER -> {
-                if (!expoRepository.existsByIdAndMemberId(expoId, memberId)) {
-                    throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
-                }
-            }
-            case ADMIN_CODE -> {
-                if(!adminPermissionRepository.existsByAdminCodeIdAndAdminCodeExpoIdAndIsOperationsConfigUpdateTrue(memberId, expoId)){
-                    throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
-                }
-            }
-            default -> throw new CustomException(CustomErrorCode.INVALID_LOGIN_TYPE);
-        }
     }
 }

--- a/src/main/java/com/myce/expo/service/impl/ExpoAdminTicketServiceImpl.java
+++ b/src/main/java/com/myce/expo/service/impl/ExpoAdminTicketServiceImpl.java
@@ -3,12 +3,13 @@ package com.myce.expo.service.impl;
 import com.myce.auth.dto.type.LoginType;
 import com.myce.common.exception.CustomErrorCode;
 import com.myce.common.exception.CustomException;
+import com.myce.common.permission.ExpoAdminAccessValidate;
+import com.myce.common.permission.ExpoAdminPermission;
 import com.myce.expo.dto.ExpoAdminTicketRequestDto;
 import com.myce.expo.dto.ExpoAdminTicketResponseDto;
 import com.myce.expo.entity.Expo;
 import com.myce.expo.entity.Ticket;
 import com.myce.expo.entity.type.TicketType;
-import com.myce.expo.repository.AdminPermissionRepository;
 import com.myce.expo.repository.ExpoRepository;
 import com.myce.expo.repository.TicketRepository;
 import com.myce.expo.service.ExpoAdminTicketService;
@@ -23,14 +24,14 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ExpoAdminTicketServiceImpl implements ExpoAdminTicketService {
 
+    private final ExpoAdminAccessValidate expoAdminAccessValidate;
     private final TicketRepository ticketRepository;
     private final ExpoRepository expoRepository;
     private final ExpoAdminTicketMapper mapper;
-    private final AdminPermissionRepository adminPermissionRepository;
 
     @Override
     public List<ExpoAdminTicketResponseDto> getMyExpoTickets(Long expoId, Long memberId, LoginType loginType) {
-        validateMyAccess(expoId, memberId, loginType);
+        expoAdminAccessValidate.ensureViewable(expoId, memberId, loginType, ExpoAdminPermission.EXPO_DETAIL_UPDATE);
         List<Ticket> tickets = ticketRepository.findByExpoId(expoId);
         return tickets.stream()
                 .map(mapper::toDto)
@@ -40,7 +41,7 @@ public class ExpoAdminTicketServiceImpl implements ExpoAdminTicketService {
     @Override
     @Transactional
     public void deleteMyExpoTicket(Long expoId, Long memberId, LoginType loginType, Long ticketId) {
-        validateMyAccess(expoId, memberId, loginType);
+        expoAdminAccessValidate.ensureEditable(expoId, memberId, loginType, ExpoAdminPermission.EXPO_DETAIL_UPDATE);
 
         Ticket ticket = ticketRepository.findById(ticketId)
                 .orElseThrow(()-> new CustomException(CustomErrorCode.TICKET_NOT_EXIST));
@@ -58,7 +59,7 @@ public class ExpoAdminTicketServiceImpl implements ExpoAdminTicketService {
                                                        Long memberId,
                                                        LoginType loginType,
                                                        ExpoAdminTicketRequestDto dto) {
-        validateMyAccess(expoId, memberId, loginType);
+        expoAdminAccessValidate.ensureEditable(expoId, memberId, loginType, ExpoAdminPermission.EXPO_DETAIL_UPDATE);
 
         Expo expo =  getMyExpo(expoId);
         Ticket ticket = mapper.toEntity(dto,expo);
@@ -74,7 +75,7 @@ public class ExpoAdminTicketServiceImpl implements ExpoAdminTicketService {
                                                          LoginType loginType,
                                                          Long ticketId,
                                                          ExpoAdminTicketRequestDto dto) {
-        validateMyAccess(expoId, memberId, loginType);
+        expoAdminAccessValidate.ensureEditable(expoId, memberId, loginType, ExpoAdminPermission.EXPO_DETAIL_UPDATE);
 
         Ticket ticket = ticketRepository.findById(ticketId)
                 .orElseThrow(()-> new CustomException(CustomErrorCode.TICKET_NOT_EXIST));
@@ -102,25 +103,5 @@ public class ExpoAdminTicketServiceImpl implements ExpoAdminTicketService {
     private Expo getMyExpo(Long expoId) {
         return expoRepository.findById(expoId)
                 .orElseThrow(() -> new CustomException(CustomErrorCode.EXPO_NOT_EXIST));
-    }
-
-    private void validateMyAccess(Long expoId, Long memberId, LoginType loginType) {
-        if(memberId == null || loginType == null){
-            throw new CustomException(CustomErrorCode.MEMBER_NOT_EXIST);
-        }
-
-        switch(loginType){
-            case MEMBER -> {
-                if (!expoRepository.existsByIdAndMemberId(expoId, memberId)) {
-                    throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
-                }
-            }
-            case ADMIN_CODE -> {
-                if(!adminPermissionRepository.existsByAdminCodeIdAndAdminCodeExpoIdAndIsExpoDetailUpdateTrue(memberId, expoId)){
-                    throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
-                }
-            }
-            default -> throw new CustomException(CustomErrorCode.INVALID_LOGIN_TYPE);
-        }
     }
 }

--- a/src/main/java/com/myce/expo/service/impl/MyExpoServiceImpl.java
+++ b/src/main/java/com/myce/expo/service/impl/MyExpoServiceImpl.java
@@ -47,7 +47,7 @@ public class MyExpoServiceImpl implements MyExpoService {
 
         switch (loginType) {
             case MEMBER -> {
-                List<Long> expoIds = expoRepository.findIdsByMemberIdAndStatusIn(memberId, ExpoStatus.ACTIVE_STATUSES);
+                List<Long> expoIds = expoRepository.findIdsByMemberIdAndStatusIn(memberId, ExpoStatus.ADMIN_VIEWABLE_STATUSES);
                 return expoAdminPermissionMapper.toDto(expoIds, null);
             }
             case ADMIN_CODE -> {

--- a/src/main/java/com/myce/qrcode/service/impl/ExpoAdminQrServiceImpl.java
+++ b/src/main/java/com/myce/qrcode/service/impl/ExpoAdminQrServiceImpl.java
@@ -3,8 +3,8 @@ package com.myce.qrcode.service.impl;
 import com.myce.auth.dto.type.LoginType;
 import com.myce.common.exception.CustomErrorCode;
 import com.myce.common.exception.CustomException;
-import com.myce.expo.repository.AdminPermissionRepository;
-import com.myce.expo.repository.ExpoRepository;
+import com.myce.common.permission.ExpoAdminAccessValidate;
+import com.myce.common.permission.ExpoAdminPermission;
 import com.myce.qrcode.dto.ExpoAdminQrReissueRequest;
 import com.myce.qrcode.entity.QrCode;
 import com.myce.qrcode.entity.code.QrCodeStatus;
@@ -19,16 +19,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class ExpoAdminQrServiceImpl implements ExpoAdminQrService {
 
-    private final ExpoRepository expoRepository;
-    private final AdminPermissionRepository adminPermissionRepository;
+    private final ExpoAdminAccessValidate expoAdminAccessValidate;
     private final QrCodeRepository  qrCodeRepository;
     private final ReserverRepository reserverRepository;
     private final QrCodeService qrCodeService;
@@ -39,7 +35,7 @@ public class ExpoAdminQrServiceImpl implements ExpoAdminQrService {
                                                                              Long memberId,
                                                                              LoginType loginType,
                                                                              Long reserverId) {
-        validateMyAccess(expoId, memberId, loginType);
+        expoAdminAccessValidate.ensureEditable(expoId, memberId, loginType, ExpoAdminPermission.RESERVER_LIST_VIEW);
 
         QrCode qrCode = qrCodeRepository.findByReserverId(reserverId).orElse(null);
 
@@ -69,7 +65,7 @@ public class ExpoAdminQrServiceImpl implements ExpoAdminQrService {
                                                               String reservationCode,
                                                               String ticketName) {
 
-        validateMyAccess(expoId, memberId, loginType);
+        expoAdminAccessValidate.ensureEditable(expoId, memberId, loginType, ExpoAdminPermission.RESERVER_LIST_VIEW);
 
         if ("입장 만료".equals(entranceStatus) || "티켓 만료".equals(entranceStatus) || "발급 대기".equals(entranceStatus)) {
             throw new CustomException(CustomErrorCode.QR_INVALID_STATUS);
@@ -95,25 +91,5 @@ public class ExpoAdminQrServiceImpl implements ExpoAdminQrService {
         }
 
         return reserverRepository.findResponsesByReserverIds(reserverIds,expoId);
-    }
-
-    private void validateMyAccess(Long expoId, Long memberId, LoginType loginType) {
-        if(memberId == null || loginType == null){
-            throw new CustomException(CustomErrorCode.MEMBER_NOT_EXIST);
-        }
-
-        switch(loginType){
-            case MEMBER -> {
-                if (!expoRepository.existsByIdAndMemberId(expoId, memberId)) {
-                    throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
-                }
-            }
-            case ADMIN_CODE -> {
-                if(!adminPermissionRepository.existsByAdminCodeIdAndAdminCodeExpoIdAndIsReserverListViewTrue(memberId, expoId)){
-                    throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
-                }
-            }
-            default -> throw new CustomException(CustomErrorCode.INVALID_LOGIN_TYPE);
-        }
     }
 }

--- a/src/main/java/com/myce/reservation/service/Impl/ExpoAdminExcelDownloadServiceImpl.java
+++ b/src/main/java/com/myce/reservation/service/Impl/ExpoAdminExcelDownloadServiceImpl.java
@@ -3,8 +3,8 @@ package com.myce.reservation.service.Impl;
 import com.myce.auth.dto.type.LoginType;
 import com.myce.common.exception.CustomErrorCode;
 import com.myce.common.exception.CustomException;
-import com.myce.expo.repository.AdminPermissionRepository;
-import com.myce.expo.repository.ExpoRepository;
+import com.myce.common.permission.ExpoAdminAccessValidate;
+import com.myce.common.permission.ExpoAdminPermission;
 import com.myce.member.entity.type.Gender;
 import com.myce.reservation.dto.ExcelReservationInfoData;
 import com.myce.reservation.repository.ReserverRepository;
@@ -28,8 +28,7 @@ import java.util.stream.Stream;
 @RequiredArgsConstructor
 public class ExpoAdminExcelDownloadServiceImpl implements ExpoAdminExcelDownloadService {
 
-    private final ExpoRepository expoRepository;
-    private final AdminPermissionRepository adminPermissionRepository;
+    private final ExpoAdminAccessValidate expoAdminAccessValidate;
     private final ReserverRepository reserverRepository;
 
     private final String[] HEADERS = {"번호", "예약 코드", "이름", "성별", "생년월일", "전화번호", "이메일", "티켓 이름"};
@@ -39,7 +38,7 @@ public class ExpoAdminExcelDownloadServiceImpl implements ExpoAdminExcelDownload
     @Transactional(readOnly = true)
     public void downloadMyReservationExcelFile(Long expoId, Long memberId, LoginType loginType, OutputStream outputStream) {
 
-        validateMyAccess(expoId, memberId, loginType);
+        expoAdminAccessValidate.ensureEditable(expoId, memberId, loginType, ExpoAdminPermission.RESERVER_LIST_VIEW);
 
         SXSSFWorkbook workbook = new SXSSFWorkbook(100);
 
@@ -164,30 +163,10 @@ public class ExpoAdminExcelDownloadServiceImpl implements ExpoAdminExcelDownload
 
     // 고정 컬럼 폭 적용
     private void applyFixedWidths(Sheet sheet) {
-        int[] widths = {5, 20, 12, 6, 12, 16, 28, 50};
+        int[] widths = {10, 25, 12, 6, 12, 16, 28, 50};
         for (int i = 0; i < widths.length; i++) {
             int width = Math.min((widths[i] + 2) * 256, 255 * 256);
             sheet.setColumnWidth(i, width);
-        }
-    }
-    
-    //권한 설정
-    private void validateMyAccess(Long expoId, Long memberId, LoginType loginType) {
-        if (memberId == null || loginType == null) {
-            throw new CustomException(CustomErrorCode.MEMBER_NOT_EXIST);
-        }
-        switch (loginType) {
-            case MEMBER -> {
-                if (!expoRepository.existsByIdAndMemberId(expoId, memberId)) {
-                    throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
-                }
-            }
-            case ADMIN_CODE -> {
-                if (!adminPermissionRepository.existsByAdminCodeIdAndAdminCodeExpoIdAndIsReserverListViewTrue(memberId, expoId)) {
-                    throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
-                }
-            }
-            default -> throw new CustomException(CustomErrorCode.INVALID_LOGIN_TYPE);
         }
     }
 }

--- a/src/main/java/com/myce/reservation/service/Impl/ExpoAdminPaymentServiceImpl.java
+++ b/src/main/java/com/myce/reservation/service/Impl/ExpoAdminPaymentServiceImpl.java
@@ -1,14 +1,11 @@
 package com.myce.reservation.service.Impl;
 
 import com.myce.auth.dto.type.LoginType;
-import com.myce.common.exception.CustomErrorCode;
-import com.myce.common.exception.CustomException;
-import com.myce.expo.repository.AdminPermissionRepository;
-import com.myce.expo.repository.ExpoRepository;
+import com.myce.common.permission.ExpoAdminAccessValidate;
+import com.myce.common.permission.ExpoAdminPermission;
 import com.myce.reservation.dto.ExpoAdminPaymentBasicResponse;
 import com.myce.reservation.dto.ExpoAdminPaymentDetailResponse;
 import com.myce.reservation.dto.ExpoAdminPaymentResponse;
-import com.myce.reservation.entity.Reserver;
 import com.myce.reservation.entity.code.ReservationStatus;
 import com.myce.reservation.repository.ReservationRepository;
 import com.myce.reservation.repository.ReserverRepository;
@@ -25,10 +22,9 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ExpoAdminPaymentServiceImpl implements ExpoAdminPaymentService {
 
-    private final ExpoRepository expoRepository;
+    private final ExpoAdminAccessValidate expoAdminAccessValidate;
     private final ReservationRepository reservationRepository;
     private final ReserverRepository reserverRepository;
-    private final AdminPermissionRepository adminPermissionRepository;
     private final ExpoAdminPaymentMapper mapper;
 
     @Override
@@ -40,7 +36,7 @@ public class ExpoAdminPaymentServiceImpl implements ExpoAdminPaymentService {
                                                             String phone,
                                                             Pageable pageable) {
 
-        validateMyAccess(expoId, memberId, loginType);
+        expoAdminAccessValidate.ensureViewable(expoId, memberId, loginType, ExpoAdminPermission.PAYMENT_VIEW);
 
         Page<ExpoAdminPaymentBasicResponse> responses =
                 reservationRepository.findAllResponsesByExpoId(expoId, status, name, phone, pageable);
@@ -50,28 +46,8 @@ public class ExpoAdminPaymentServiceImpl implements ExpoAdminPaymentService {
 
     @Override
     public List<ExpoAdminPaymentDetailResponse> getPaymentDetail(Long expoId, Long memberId, LoginType loginType, Long paymentId) {
-        validateMyAccess(expoId, memberId, loginType);
+        expoAdminAccessValidate.ensureViewable(expoId, memberId, loginType, ExpoAdminPermission.PAYMENT_VIEW);
 
         return reserverRepository.findDetailById(paymentId);
-    }
-
-    private void validateMyAccess(Long expoId, Long memberId, LoginType loginType) {
-        if(memberId == null || loginType == null){
-            throw new CustomException(CustomErrorCode.MEMBER_NOT_EXIST);
-        }
-
-        switch(loginType){
-            case MEMBER -> {
-                if (!expoRepository.existsByIdAndMemberId(expoId, memberId)) {
-                    throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
-                }
-            }
-            case ADMIN_CODE -> {
-                if(!adminPermissionRepository.existsByAdminCodeIdAndAdminCodeExpoIdAndIsPaymentViewTrue(memberId, expoId)){
-                    throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
-                }
-            }
-            default -> throw new CustomException(CustomErrorCode.INVALID_LOGIN_TYPE);
-        }
     }
 }

--- a/src/main/java/com/myce/reservation/service/Impl/ExpoAdminReservationServiceImpl.java
+++ b/src/main/java/com/myce/reservation/service/Impl/ExpoAdminReservationServiceImpl.java
@@ -1,8 +1,8 @@
 package com.myce.reservation.service.Impl;
 
 import com.myce.auth.dto.type.LoginType;
-import com.myce.common.exception.CustomErrorCode;
-import com.myce.common.exception.CustomException;
+import com.myce.common.permission.ExpoAdminAccessValidate;
+import com.myce.common.permission.ExpoAdminPermission;
 import com.myce.expo.entity.Ticket;
 import com.myce.expo.repository.AdminPermissionRepository;
 import com.myce.expo.repository.ExpoRepository;
@@ -21,14 +21,13 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ExpoAdminReservationServiceImpl implements ExpoAdminReservationService {
 
-    private final ExpoRepository expoRepository;
+    private final ExpoAdminAccessValidate expoAdminAccessValidate;
     private final TicketRepository ticketRepository;
-    private final AdminPermissionRepository adminPermissionRepository;
     private final ReserverRepository reserverRepository;
 
     @Override
     public List<String> getExpoTicketNames(Long expoId, Long memberId, LoginType loginType) {
-        validateMyAccess(expoId,memberId,loginType);
+        expoAdminAccessValidate.ensureViewable(expoId,memberId,loginType, ExpoAdminPermission.RESERVER_LIST_VIEW);
         List<Ticket> tickets = ticketRepository.findByExpoId(expoId);
 
         return tickets.stream().map(Ticket::getName).toList();
@@ -40,29 +39,9 @@ public class ExpoAdminReservationServiceImpl implements ExpoAdminReservationServ
             String entranceStatus, String name, String phone, String reservationCode, String ticketName,
             Pageable pageable) {
 
-        validateMyAccess(expoId, memberId, loginType);
+        expoAdminAccessValidate.ensureViewable(expoId,memberId,loginType, ExpoAdminPermission.RESERVER_LIST_VIEW);
 
         return reserverRepository.findAllResponsesByExpoIdAndStatus(
                 expoId, entranceStatus, name, phone, reservationCode, ticketName, pageable);
-    }
-
-    private void validateMyAccess(Long expoId, Long memberId, LoginType loginType) {
-        if(memberId == null || loginType == null){
-            throw new CustomException(CustomErrorCode.MEMBER_NOT_EXIST);
-        }
-
-        switch(loginType){
-            case MEMBER -> {
-                if (!expoRepository.existsByIdAndMemberId(expoId, memberId)) {
-                    throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
-                }
-            }
-            case ADMIN_CODE -> {
-                if(!adminPermissionRepository.existsByAdminCodeIdAndAdminCodeExpoIdAndIsReserverListViewTrue(memberId, expoId)){
-                    throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
-                }
-            }
-            default -> throw new CustomException(CustomErrorCode.INVALID_LOGIN_TYPE);
-        }
     }
 }

--- a/src/main/java/com/myce/system/service/email/Impl/ExpoAdminEmailDetailServiceImpl.java
+++ b/src/main/java/com/myce/system/service/email/Impl/ExpoAdminEmailDetailServiceImpl.java
@@ -3,8 +3,8 @@ package com.myce.system.service.email.Impl;
 import com.myce.auth.dto.type.LoginType;
 import com.myce.common.exception.CustomErrorCode;
 import com.myce.common.exception.CustomException;
-import com.myce.expo.repository.AdminPermissionRepository;
-import com.myce.expo.repository.ExpoRepository;
+import com.myce.common.permission.ExpoAdminAccessValidate;
+import com.myce.common.permission.ExpoAdminPermission;
 import com.myce.system.dto.email.ExpoAdminEmailDetailResponse;
 import com.myce.system.dto.email.ExpoAdminEmailResponse;
 import com.myce.system.repository.EmailLogRepository;
@@ -19,8 +19,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class ExpoAdminEmailDetailServiceImpl implements ExpoAdminEmailDetailService {
 
-    private final ExpoRepository expoRepository;
-    private final AdminPermissionRepository adminPermissionRepository;
+    private final ExpoAdminAccessValidate expoAdminAccessValidate;
     private final EmailLogRepository emailLogRepository;
     private final ExpoAdminEmailMapper mapper;
 
@@ -31,7 +30,7 @@ public class ExpoAdminEmailDetailServiceImpl implements ExpoAdminEmailDetailServ
                                                    String keyword,
                                                    Pageable pageable) {
 
-        validateMyAccess(expoId,memberId,loginType);
+        expoAdminAccessValidate.ensureViewable(expoId,memberId,loginType, ExpoAdminPermission.EMAIL_LOG_VIEW);
 
         boolean hasKeyword = keyword != null && !keyword.isBlank();
 
@@ -49,30 +48,10 @@ public class ExpoAdminEmailDetailServiceImpl implements ExpoAdminEmailDetailServ
 
     @Override
     public ExpoAdminEmailDetailResponse getMyMailDetail(Long expoId, Long memberId, LoginType loginType, String emailId) {
-        validateMyAccess(expoId, memberId, loginType);
+        expoAdminAccessValidate.ensureViewable(expoId,memberId,loginType, ExpoAdminPermission.EMAIL_LOG_VIEW);
 
         return emailLogRepository.findById(emailId)
                 .map(mapper::toDetailDto)
                 .orElseThrow(() -> new CustomException(CustomErrorCode.INVALID_EMAIL_LOG));
-    }
-
-    private void validateMyAccess(Long expoId, Long memberId, LoginType loginType) {
-        if(memberId == null || loginType == null){
-            throw new CustomException(CustomErrorCode.MEMBER_NOT_EXIST);
-        }
-
-        switch(loginType){
-            case MEMBER -> {
-                if (!expoRepository.existsByIdAndMemberId(expoId, memberId)) {
-                    throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
-                }
-            }
-            case ADMIN_CODE -> {
-                if(!adminPermissionRepository.existsByAdminCodeIdAndAdminCodeExpoIdAndIsEmailLogViewTrue(memberId, expoId)){
-                    throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
-                }
-            }
-            default -> throw new CustomException(CustomErrorCode.INVALID_LOGIN_TYPE);
-        }
     }
 }

--- a/src/main/java/com/myce/system/service/email/Impl/ExpoAdminEmailServiceImpl.java
+++ b/src/main/java/com/myce/system/service/email/Impl/ExpoAdminEmailServiceImpl.java
@@ -5,9 +5,10 @@ import com.myce.common.entity.BusinessProfile;
 import com.myce.common.entity.type.TargetType;
 import com.myce.common.exception.CustomErrorCode;
 import com.myce.common.exception.CustomException;
+import com.myce.common.permission.ExpoAdminAccessValidate;
+import com.myce.common.permission.ExpoAdminPermission;
 import com.myce.common.repository.BusinessProfileRepository;
 import com.myce.expo.entity.Expo;
-import com.myce.expo.repository.AdminPermissionRepository;
 import com.myce.expo.repository.ExpoRepository;
 import com.myce.notification.service.EmailSendService;
 import com.myce.reservation.repository.ReserverRepository;
@@ -30,9 +31,9 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class ExpoAdminEmailServiceImpl implements ExpoAdminEmailService {
 
+    private final ExpoAdminAccessValidate expoAdminAccessValidate;
     private final ExpoRepository expoRepository;
     private final BusinessProfileRepository businessProfileRepository;
-    private final AdminPermissionRepository adminPermissionRepository;
 
     private final ReserverRepository reserverRepository;
     private final EmailLogRepository emailLogRepository;
@@ -57,7 +58,7 @@ public class ExpoAdminEmailServiceImpl implements ExpoAdminEmailService {
                          String reservationCode,
                          String ticketName) {
 
-        validateMyAccess(expoId, memberId, loginType);
+        expoAdminAccessValidate.ensureEditable(expoId, memberId, loginType, ExpoAdminPermission.RESERVER_LIST_VIEW);
         String html = renderEmailHtml(expoId,dto);
 
         List<EmailLog.RecipientInfo> recipientInfos;
@@ -112,26 +113,5 @@ public class ExpoAdminEmailServiceImpl implements ExpoAdminEmailService {
         if (html == null) return "";
         String text = html.replaceAll("<[^>]+>", " ").replaceAll("\\s+", " ").trim();
         return text.length() > maxLen ? text.substring(0, maxLen) + "…" : text;
-    }
-
-    //TODO: 1차 구현 이후 유틸메소드화(중복 코드들 제거 및 유지보수 용이하도록) 및 권한 로직 수정
-    private void validateMyAccess(Long expoId, Long memberId, LoginType loginType) {
-        if(memberId == null || loginType == null){
-            throw new CustomException(CustomErrorCode.MEMBER_NOT_EXIST);
-        }
-
-        switch(loginType){
-            case MEMBER -> {
-                if (!expoRepository.existsByIdAndMemberId(expoId, memberId)) {
-                    throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
-                }
-            }
-            case ADMIN_CODE -> {
-                if(!adminPermissionRepository.existsByAdminCodeIdAndAdminCodeExpoIdAndIsReserverListViewTrue(memberId, expoId)){
-                    throw new CustomException(CustomErrorCode.EXPO_ACCESS_DENIED);
-                }
-            }
-            default -> throw new CustomException(CustomErrorCode.INVALID_LOGIN_TYPE);
-        }
     }
 }


### PR DESCRIPTION
@catapillar0505 @PG1tHub 필독해주세요!!

### 주요 변경 사항
- ExpoStatus에서 박람회 관리자가 **조회 가능한 상태**와 **편집 가능한 상태**를 정의하였습니다. 
- 조회 가능한 상태값 변경에 맞춰, 프론트로 전달하는 expoId 목록을 반환하는 service 로직도 수정했습니다.
- 이제 service에서는 위에서 정의한 조회 가능한 상태에 해당하는 expoId만 반환하도록 동작합니다. 
- `common > permission` 폴더에 ExpoAdminAccessValidate 클래스를 추가하였습니다.
- `ensureViewable() , ensureEditable()` 메소드를 제공합니다.

### 사용 방식
- service 단에서 `private final ExpoAdminAccessValidate`를 주입합니다.
- 조회 메소드 (get)에서는 `ensureViewable()`을 호출하여 권한을 검증합니다.
- 편집 메소드 (post, put, delete)에서는 `ensureEditable()`을 호출하여 권한을 검증합니다.
- ExpoAdminPermission enum 값을 정의하여 박람회 하위 관리자의 권한을 페이지 단위로 매핑할 수 있도록 했습니다.
- **서비스 메소드 호출 시, 해당 서비스가 속한 페이지 권한에 대응하는 enum 값을 파라미터로 전달**하시면 됩니다.
- 구체적인 사용 방법은 아래 코드 변경 사항을 참고해주세요.

### 주요 전달 사항
(진아님 @catapillar0505 ) 필독!
EXPO_DETAIL_UPDATE 같은 이름 때문에 VIEW/UPDATE로 오해할 수 있는데,  
**실제 필드명과 상관없이 ‘페이지 단위’로 권한을 관리**하기로 했습니다.  

이유는, 하나의 페이지 안에도 여러 개의 update 권한이 섞여 있어서  필드 단위로 나누면 너무 대공사가 되기 때문입니다.  
→ 팀장님과 협의 끝에 페이지 단위로 관리하기로 확정했습니다.  

아래 enum 값에 각 페이지별 매핑을 주석으로 달아두었으니 참고해주세요!