### PR TITLE
[CRM-297] refactor : 조회 가능한 박람회 상태 변경 및 티켓 판매일 이후 수정/삭제 처리

### DIFF
--- a/src/main/java/com/myce/common/exception/CustomErrorCode.java
+++ b/src/main/java/com/myce/common/exception/CustomErrorCode.java
@@ -71,6 +71,7 @@ public enum CustomErrorCode {
     TICKET_NOT_BELONG_TO_EXPO(HttpStatus.FORBIDDEN, "T002", "해당 티켓은 현재 박람회에 속하지 않습니다."),
     TICKET_TYPE_INVALID(HttpStatus.BAD_REQUEST, "T003", "유효하지 않은 티켓 타입입니다."),
     TICKET_SOLD_OUT(HttpStatus.CONFLICT, "T004", "티켓이 매진되었습니다."),
+    TICKET_EDIT_DENIED(HttpStatus.FORBIDDEN, "T005", "판매 시작일 이후에는 티켓을 수정할 수 없습니다."),
 
     // 채팅 C
     CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "C001", "채팅방을 찾을 수 없습니다."),

--- a/src/main/java/com/myce/expo/entity/type/ExpoStatus.java
+++ b/src/main/java/com/myce/expo/entity/type/ExpoStatus.java
@@ -43,7 +43,6 @@ public enum ExpoStatus {
     //박람회 관리자가 조회 가능한 상태
     public static final List<ExpoStatus> ADMIN_VIEWABLE_STATUSES = List.of(
             PENDING_PUBLISH,
-            PENDING_CANCEL,
             PUBLISHED,
             PUBLISH_ENDED,
             SETTLEMENT_REQUESTED,

--- a/src/main/java/com/myce/expo/service/impl/ExpoAdminTicketServiceImpl.java
+++ b/src/main/java/com/myce/expo/service/impl/ExpoAdminTicketServiceImpl.java
@@ -18,9 +18,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.Clock;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 
 @Service
@@ -31,7 +30,7 @@ public class ExpoAdminTicketServiceImpl implements ExpoAdminTicketService {
     private final TicketRepository ticketRepository;
     private final ExpoRepository expoRepository;
     private final ExpoAdminTicketMapper mapper;
-    private final Clock clock;
+    private static final ZoneId APP_ZONE = ZoneId.of("Asia/Seoul");
 
     @Override
     public List<ExpoAdminTicketResponseDto> getMyExpoTickets(Long expoId, Long memberId, LoginType loginType) {
@@ -46,7 +45,6 @@ public class ExpoAdminTicketServiceImpl implements ExpoAdminTicketService {
     @Transactional
     public void deleteMyExpoTicket(Long expoId, Long memberId, LoginType loginType, Long ticketId) {
         expoAdminAccessValidate.ensureEditable(expoId, memberId, loginType, ExpoAdminPermission.EXPO_DETAIL_UPDATE);
-        ensureTicketEditable(ticketId);
 
         Ticket ticket = ticketRepository.findById(ticketId)
                 .orElseThrow(()-> new CustomException(CustomErrorCode.TICKET_NOT_EXIST));
@@ -54,6 +52,8 @@ public class ExpoAdminTicketServiceImpl implements ExpoAdminTicketService {
         if(!ticket.getExpo().getId().equals(expoId)){
             throw new CustomException(CustomErrorCode.TICKET_NOT_BELONG_TO_EXPO);
         }
+
+        ensureTicketEditable(ticket);
 
         ticketRepository.delete(ticket);
     }
@@ -81,14 +81,16 @@ public class ExpoAdminTicketServiceImpl implements ExpoAdminTicketService {
                                                          Long ticketId,
                                                          ExpoAdminTicketRequestDto dto) {
         expoAdminAccessValidate.ensureEditable(expoId, memberId, loginType, ExpoAdminPermission.EXPO_DETAIL_UPDATE);
-        ensureTicketEditable(ticketId);
         
         Ticket ticket = ticketRepository.findById(ticketId)
                 .orElseThrow(()-> new CustomException(CustomErrorCode.TICKET_NOT_EXIST));
 
         if(!ticket.getExpo().getId().equals(expoId)){
             throw new CustomException(CustomErrorCode.TICKET_NOT_BELONG_TO_EXPO);
+
         }
+
+        ensureTicketEditable(ticket);
 
         ticket.updateTicketInfo(
                 dto.getName(),
@@ -111,13 +113,10 @@ public class ExpoAdminTicketServiceImpl implements ExpoAdminTicketService {
                 .orElseThrow(() -> new CustomException(CustomErrorCode.EXPO_NOT_EXIST));
     }
 
-    private void ensureTicketEditable(Long ticketId) {
-        Ticket ticket = ticketRepository.findById(ticketId)
-                .orElseThrow(() -> new CustomException(CustomErrorCode.TICKET_NOT_EXIST));
-
+    private void ensureTicketEditable(Ticket ticket) {
         LocalDate saleStart = ticket.getSaleStartDate();
 
-        LocalDate today = LocalDate.now(clock);
+        LocalDate today = LocalDate.now(APP_ZONE);
         if (!today.isBefore(saleStart)) {
             throw new CustomException(CustomErrorCode.TICKET_EDIT_DENIED);
         }

--- a/src/main/java/com/myce/expo/service/impl/ExpoAdminTicketServiceImpl.java
+++ b/src/main/java/com/myce/expo/service/impl/ExpoAdminTicketServiceImpl.java
@@ -18,6 +18,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -28,6 +31,7 @@ public class ExpoAdminTicketServiceImpl implements ExpoAdminTicketService {
     private final TicketRepository ticketRepository;
     private final ExpoRepository expoRepository;
     private final ExpoAdminTicketMapper mapper;
+    private final Clock clock;
 
     @Override
     public List<ExpoAdminTicketResponseDto> getMyExpoTickets(Long expoId, Long memberId, LoginType loginType) {
@@ -42,6 +46,7 @@ public class ExpoAdminTicketServiceImpl implements ExpoAdminTicketService {
     @Transactional
     public void deleteMyExpoTicket(Long expoId, Long memberId, LoginType loginType, Long ticketId) {
         expoAdminAccessValidate.ensureEditable(expoId, memberId, loginType, ExpoAdminPermission.EXPO_DETAIL_UPDATE);
+        ensureTicketEditable(ticketId);
 
         Ticket ticket = ticketRepository.findById(ticketId)
                 .orElseThrow(()-> new CustomException(CustomErrorCode.TICKET_NOT_EXIST));
@@ -76,7 +81,8 @@ public class ExpoAdminTicketServiceImpl implements ExpoAdminTicketService {
                                                          Long ticketId,
                                                          ExpoAdminTicketRequestDto dto) {
         expoAdminAccessValidate.ensureEditable(expoId, memberId, loginType, ExpoAdminPermission.EXPO_DETAIL_UPDATE);
-
+        ensureTicketEditable(ticketId);
+        
         Ticket ticket = ticketRepository.findById(ticketId)
                 .orElseThrow(()-> new CustomException(CustomErrorCode.TICKET_NOT_EXIST));
 
@@ -103,5 +109,17 @@ public class ExpoAdminTicketServiceImpl implements ExpoAdminTicketService {
     private Expo getMyExpo(Long expoId) {
         return expoRepository.findById(expoId)
                 .orElseThrow(() -> new CustomException(CustomErrorCode.EXPO_NOT_EXIST));
+    }
+
+    private void ensureTicketEditable(Long ticketId) {
+        Ticket ticket = ticketRepository.findById(ticketId)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.TICKET_NOT_EXIST));
+
+        LocalDate saleStart = ticket.getSaleStartDate();
+
+        LocalDate today = LocalDate.now(clock);
+        if (!today.isBefore(saleStart)) {
+            throw new CustomException(CustomErrorCode.TICKET_EDIT_DENIED);
+        }
     }
 }

--- a/src/main/java/com/myce/reservation/service/Impl/ExpoAdminReservationServiceImpl.java
+++ b/src/main/java/com/myce/reservation/service/Impl/ExpoAdminReservationServiceImpl.java
@@ -4,8 +4,6 @@ import com.myce.auth.dto.type.LoginType;
 import com.myce.common.permission.ExpoAdminAccessValidate;
 import com.myce.common.permission.ExpoAdminPermission;
 import com.myce.expo.entity.Ticket;
-import com.myce.expo.repository.AdminPermissionRepository;
-import com.myce.expo.repository.ExpoRepository;
 import com.myce.expo.repository.TicketRepository;
 import com.myce.reservation.dto.ExpoAdminReservationResponse;
 import com.myce.reservation.repository.ReserverRepository;


### PR DESCRIPTION
- PENDING_CANCEL 상태에서도 박람회 관리자 페이지 조회가 불가능하도록 수정하였습니다. (URL 직입 방지)
- 티켓 판매일 이후로는 해당 티켓이 수정 및 삭제가 불가하도록 검증 하는 로직을 추가하였습니다.