### PR TITLE
[CRM-295] feat: reservation 환불 및 기능 보완

### DIFF
--- a/src/main/java/com/myce/common/exception/CustomErrorCode.java
+++ b/src/main/java/com/myce/common/exception/CustomErrorCode.java
@@ -141,6 +141,8 @@ public enum CustomErrorCode {
     REFUND_NOT_FOUND(HttpStatus.NOT_FOUND, "RF001", "환불 정보가 존재하지 않습니다."),
     ALREADY_REFUND_REQUESTED(HttpStatus.CONFLICT, "RF002", "이미 환불 신청이 접수되었습니다."),
     REFUND_SEVEN_DAY_RULE_VIOLATION(HttpStatus.BAD_REQUEST, "RF003", "개최 7일 전에는 환불이 불가능합니다."),
+    ALREADY_REFUNDED(HttpStatus.NOT_FOUND, "RF001", "이미 환불이 완료된 결제 입니다."),
+    REFUND_NOT_ALLOWED( HttpStatus.NOT_ACCEPTABLE, "RF004", "환불이 불가능한 날짜입니다"),
 
     // 시스템 설정 에러
     NOT_EXIST_MESSAGE_TEMPLATE(HttpStatus.NOT_FOUND, "SY001", "메시지 템플릿이 존재하지 않습니다."),

--- a/src/main/java/com/myce/expo/controller/ExpoController.java
+++ b/src/main/java/com/myce/expo/controller/ExpoController.java
@@ -58,6 +58,7 @@ public class ExpoController {
     public ResponseEntity<List<ExpoCardResponse>> getExpoCards(
         @RequestParam(required=false) String keyword,   // 검색
         @RequestParam(required=false) String category,  // 카테고리
+        @RequestParam(required=false) String status,    // 박람회 상태 (PUBLISHED, PENDING_PUBLISH 등)
         @RequestParam(required=false) Integer period,   // 기간(1,3,6,12개월)
         @RequestParam(required = false)
         @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,  // 사용자 지정 시작일
@@ -76,7 +77,7 @@ public class ExpoController {
             to   = end;
         }
 
-        List<ExpoCardResponse> expoCards = expoService.getExpoCardsFiltered(memberId, category, from, to, keyword, pageable);
+        List<ExpoCardResponse> expoCards = expoService.getExpoCardsFiltered(memberId, category, status, from, to, keyword, pageable);
         return ResponseEntity.ok(expoCards);
     }
 

--- a/src/main/java/com/myce/expo/entity/Ticket.java
+++ b/src/main/java/com/myce/expo/entity/Ticket.java
@@ -115,4 +115,5 @@ public class Ticket {
     public void updateRemainingQuantity(Integer quantity){
         this.remainingQuantity = quantity;
     }
+
 }

--- a/src/main/java/com/myce/expo/service/ExpoService.java
+++ b/src/main/java/com/myce/expo/service/ExpoService.java
@@ -28,6 +28,6 @@ public interface ExpoService {
 
     // 박람회 카드 리스트 조회
     List<ExpoCardResponse> getExpoCardsFiltered(
-            Long memberId, String categoryName, LocalDate from, LocalDate to, String keyword, Pageable pageable);
+            Long memberId, String categoryName, String status, LocalDate from, LocalDate to, String keyword, Pageable pageable);
 }
 

--- a/src/main/java/com/myce/expo/service/impl/ExpoServiceImpl.java
+++ b/src/main/java/com/myce/expo/service/impl/ExpoServiceImpl.java
@@ -146,6 +146,7 @@ public class ExpoServiceImpl implements ExpoService {
     @Override
     public List<ExpoCardResponse> getExpoCardsFiltered(Long memberId,
         String categoryName,
+        String status,
         LocalDate from,
         LocalDate to,
         String keyword,
@@ -161,9 +162,20 @@ public class ExpoServiceImpl implements ExpoService {
         }
 
         String keyWord = (keyword != null && !keyword.isBlank()) ? keyword.trim() : null;
+        
+        // status 파라미터 처리 - 기본값은 PUBLISHED
+        ExpoStatus expoStatus = ExpoStatus.PUBLISHED;
+        if (status != null && !status.isBlank()) {
+            try {
+                expoStatus = ExpoStatus.valueOf(status.toUpperCase());
+            } catch (IllegalArgumentException e) {
+                log.warn("Invalid status parameter: {}, using default PUBLISHED", status);
+                expoStatus = ExpoStatus.PUBLISHED;
+            }
+        }
 
         Page<Expo> exposPage = expoRepository.findPublishedExposFiltered(
-            ExpoStatus.PUBLISHED,
+            expoStatus,
             categoryId,
             keyWord,
             from,
@@ -200,7 +212,7 @@ public class ExpoServiceImpl implements ExpoService {
         Expo expo = expoRepository.findById(expoId)
                 .orElseThrow(() -> new CustomException(CustomErrorCode.EXPO_NOT_FOUND));
 
-        if (expo.getStatus() != ExpoStatus.PUBLISHED) {
+        if (expo.getStatus() == ExpoStatus.PENDING_APPROVAL || expo.getStatus() == ExpoStatus.PENDING_PAYMENT) {
             throw new CustomException(CustomErrorCode.EXPO_NOT_PUBLISHED);
         }
 

--- a/src/main/java/com/myce/member/dto/MileageUpdateRequest.java
+++ b/src/main/java/com/myce/member/dto/MileageUpdateRequest.java
@@ -15,4 +15,7 @@ public class MileageUpdateRequest {
   @NotNull
   @Min(0)
   private Integer savedMileage;
+
+  public MileageUpdateRequest(Integer usedMileage, Integer savedMileage) {
+  }
 }

--- a/src/main/java/com/myce/member/service/MemberMileageService.java
+++ b/src/main/java/com/myce/member/service/MemberMileageService.java
@@ -4,4 +4,7 @@ import com.myce.member.dto.MileageUpdateRequest;
 
 public interface MemberMileageService {
   void updateMileageForReservation(Long userId, MileageUpdateRequest request);
+  
+  // 예매 환불 시 마일리지 복원/차감
+  void revertMileageForReservationRefund(Long memberId, MileageUpdateRequest request);
 }

--- a/src/main/java/com/myce/member/service/impl/MemberMileageServiceImpl.java
+++ b/src/main/java/com/myce/member/service/impl/MemberMileageServiceImpl.java
@@ -21,7 +21,28 @@ public class MemberMileageServiceImpl implements MemberMileageService {
     Member member = memberRepository.findById(memberId)
         .orElseThrow(()-> new CustomException(CustomErrorCode.MEMBER_NOT_EXIST));
 
-    member.updateMileage(member.getMileage() - request.getUsedMileage() + request.getSavedMileage());
+    Integer usedMileage = request.getUsedMileage() != null ? request.getUsedMileage() : 0;
+    Integer savedMileage = request.getSavedMileage() != null ? request.getSavedMileage() : 0;
+    member.updateMileage(member.getMileage() - usedMileage + savedMileage);
+  }
+
+  @Transactional
+  @Override
+  public void revertMileageForReservationRefund(Long memberId, MileageUpdateRequest request) {
+    Member member = memberRepository.findById(memberId)
+        .orElseThrow(() -> new CustomException(CustomErrorCode.MEMBER_NOT_EXIST));
+
+    Integer currentMileage = member.getMileage();
+    Integer usedMileage = request.getUsedMileage() != null ? request.getUsedMileage() : 0;
+    Integer savedMileage = request.getSavedMileage() != null ? request.getSavedMileage() : 0;
+    Integer newMileage = currentMileage + usedMileage - savedMileage;
+
+    // 음수 방지
+    if (newMileage < 0) {
+      newMileage = 0;
+    }
+
+    member.updateMileage(newMileage);
   }
 
 }

--- a/src/main/java/com/myce/payment/entity/ReservationPaymentInfo.java
+++ b/src/main/java/com/myce/payment/entity/ReservationPaymentInfo.java
@@ -70,4 +70,6 @@ public class ReservationPaymentInfo {
         this.totalAmount = totalAmount;
         this.status = status;
     }
+
+
 }

--- a/src/main/java/com/myce/payment/repository/ReservationPaymentInfoRepository.java
+++ b/src/main/java/com/myce/payment/repository/ReservationPaymentInfoRepository.java
@@ -3,6 +3,7 @@ package com.myce.payment.repository;
 import com.myce.payment.entity.ReservationPaymentInfo;
 import com.myce.reservation.entity.Reservation;
 import io.lettuce.core.dynamic.annotation.Param;
+
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -77,4 +78,5 @@ public interface ReservationPaymentInfoRepository extends JpaRepository<Reservat
 
     @Query("SELECT SUM(rpi.totalAmount) FROM ReservationPaymentInfo rpi WHERE rpi.reservation IN :reservations")
     Optional<Integer> findTotalAmountByReservations(@Param("reservations") List<Reservation> reservations);
+
 }

--- a/src/main/java/com/myce/payment/service/portone/impl/PortOneApiServiceImpl.java
+++ b/src/main/java/com/myce/payment/service/portone/impl/PortOneApiServiceImpl.java
@@ -98,6 +98,7 @@ public class PortOneApiServiceImpl implements PortOneApiService {
         String jsonBody;
         try {
             jsonBody = objectMapper.writeValueAsString(body);
+            log.info("[포트원 환불 요청 바디] {}", jsonBody);
         } catch (JsonProcessingException e) {
             throw new CustomException(CustomErrorCode.PORTONE_REQUEST_SERIALIZATION_FAILED);
         }
@@ -107,13 +108,23 @@ public class PortOneApiServiceImpl implements PortOneApiService {
         ResponseEntity<Map> response;
         try {
             response = restTemplate.exchange(url, HttpMethod.POST, requestEntity, Map.class);
+            log.info("[포트원 환불 응답 전체] {}", response.getBody());
         } catch (Exception e) {
+            log.error("[포트원 환불 API 호출 실패] {}", e.getMessage());
             throw new CustomException(CustomErrorCode.PORTONE_REFUND_FAILED);
         }
 
-        Map<String, Object> responseBody = (Map<String, Object>) response.getBody().get("response");
-        if (responseBody == null || !("cancelled".equals(responseBody.get("status"))
-                || "paid".equals(responseBody.get("status")))) {
+        Map<String, Object> fullResponse = response.getBody();
+        Map<String, Object> responseBody = (Map<String, Object>) fullResponse.get("response");
+        
+        if (responseBody == null) {
+            log.error("[포트원 환불 응답 오류] response 필드가 없음. 전체 응답: {}", fullResponse);
+            throw new CustomException(CustomErrorCode.PORTONE_REFUND_FAILED);
+        }
+        
+        String status = (String) responseBody.get("status");
+        if (!("cancelled".equals(status) || "paid".equals(status))) {
+            log.error("[포트원 환불 상태 오류] 예상: cancelled/paid, 실제: {}. 전체 응답: {}", status, responseBody);
             throw new CustomException(CustomErrorCode.PORTONE_REFUND_FAILED);
         }
         return responseBody;
@@ -132,12 +143,12 @@ public class PortOneApiServiceImpl implements PortOneApiService {
             body.put("reason", request.getReason());
         }
 
-        if (request.getCancelAmount() != null) {
-            if (request.getCancelAmount() > originalPaidAmount) {
-                throw new CustomException(CustomErrorCode.REFUND_AMOUNT_EXCEEDS_PAID);
-            }
-            body.put("amount", request.getCancelAmount());
+        // 환불 금액 설정 (부분 환불이면 해당 금액, 전체 환불이면 원본 금액)
+        Integer refundAmount = request.getCancelAmount() != null ? request.getCancelAmount() : originalPaidAmount;
+        if (refundAmount > originalPaidAmount) {
+            throw new CustomException(CustomErrorCode.REFUND_AMOUNT_EXCEEDS_PAID);
         }
+        body.put("amount", refundAmount);
         body.put("checksum", originalPaidAmount);
 
         if (request.getRefundHolder() != null) {

--- a/src/main/java/com/myce/qrcode/service/impl/QrCodeServiceImpl.java
+++ b/src/main/java/com/myce/qrcode/service/impl/QrCodeServiceImpl.java
@@ -119,14 +119,15 @@ public class QrCodeServiceImpl implements QrCodeService {
         validateAdminPermission(adminMemberId, qr.getReserver(), loginType);
 
         // ACTIVE인 경우만 상태 변경
-        if (qr.getStatus() == QrCodeStatus.ACTIVE) {
+        boolean wasActive = qr.getStatus() == QrCodeStatus.ACTIVE;
+        if (wasActive) {
             qr.markAsUsed();
         }
-        log.info("QR 코드 사용 처리 완료 - QR ID: {}, 예약자 ID: {}", 
-                qr.getId(), qr.getReserver().getId());
+        log.info("QR 코드 사용 처리 완료 - QR ID: {}, 예약자 ID: {}, 사용처리됨: {}", 
+                qr.getId(), qr.getReserver().getId(), wasActive);
 
-        // 매퍼를 통해 성공 응답 생성
-        return qrResponseMapper.toUseResponse(qr);
+        // 매퍼를 통해 응답 생성 (사용 처리 성공/실패 구분)
+        return qrResponseMapper.toUseResponse(qr, wasActive);
     }
 
     @Override
@@ -213,12 +214,18 @@ public class QrCodeServiceImpl implements QrCodeService {
             // 티켓 정보를 통해 QR 코드 활성화/만료 시간 계산
             LocalDateTime activatedAt = calculateActivatedAt(reserver);
             LocalDateTime expiredAt = calculateExpiredAt(reserver);
+            
+            // 현재 시간이 티켓 사용 기간 내인지 확인하여 상태 결정
+            LocalDateTime now = LocalDateTime.now();
+            QrCodeStatus initialStatus = (now.isAfter(activatedAt) || now.isEqual(activatedAt)) && now.isBefore(expiredAt) 
+                    ? QrCodeStatus.ACTIVE 
+                    : QrCodeStatus.APPROVED;
 
             QrCode qr = QrCode.builder()
                     .reserver(reserver)
                     .qrToken(token)
                     .qrImageUrl(imageUrl)
-                    .status(QrCodeStatus.APPROVED)
+                    .status(initialStatus)
                     .activatedAt(activatedAt)
                     .expiredAt(expiredAt)
                     .build();
@@ -367,15 +374,15 @@ public class QrCodeServiceImpl implements QrCodeService {
             
             String imageUrl = uploadToStorage(image, token);
             
-            // 티켓 use_start_date와 현재 날짜 비교하여 상태 결정
-            LocalDate today = LocalDate.now();
-            LocalDate ticketUseStartDate = reserver.getReservation().getTicket().getUseStartDate();
-            
-            QrCodeStatus status = today.isBefore(ticketUseStartDate) ? QrCodeStatus.APPROVED : QrCodeStatus.ACTIVE;
-            
             // 티켓 정보를 통해 QR 코드 활성화/만료 시간 계산
             LocalDateTime activatedAt = calculateActivatedAt(reserver);
             LocalDateTime expiredAt = calculateExpiredAt(reserver);
+            
+            // 현재 시간이 티켓 사용 기간 내인지 확인하여 상태 결정
+            LocalDateTime now = LocalDateTime.now();
+            QrCodeStatus status = (now.isAfter(activatedAt) || now.isEqual(activatedAt)) && now.isBefore(expiredAt) 
+                    ? QrCodeStatus.ACTIVE 
+                    : QrCodeStatus.APPROVED;
             
             QrCode qr = QrCode.builder()
                     .reserver(reserver)

--- a/src/main/java/com/myce/qrcode/service/mapper/QrResponseMapper.java
+++ b/src/main/java/com/myce/qrcode/service/mapper/QrResponseMapper.java
@@ -17,15 +17,28 @@ public class QrResponseMapper {
     /**
      * QR 사용 응답 생성 (성공/실패 모두 처리)
      */
+    public QrUseResponse toUseResponse(QrCode qrCode, boolean wasSuccessfullyUsed) {
+
+        if (wasSuccessfullyUsed) {
+            // 성공적으로 사용 처리된 경우
+            Reserver reserver = qrCode.getReserver();
+            return QrUseResponse.success(SUCCESS_MESSAGE, reserver.getReservation().getTicket().getName());
+        } else {
+            // 사용 처리되지 않은 경우 (APPROVED, EXPIRED, USED 등)
+            QrCodeStatus status = qrCode.getStatus();
+            return QrUseResponse.fail(status.getMessage());
+        }
+    }
+
+    /**
+     * QR 사용 응답 생성 (기존 호환성 유지)
+     */
     public QrUseResponse toUseResponse(QrCode qrCode) {
-
         QrCodeStatus status = qrCode.getStatus();
-
         return switch (status) {
             case ACTIVE -> {
                 Reserver reserver = qrCode.getReserver();
                 yield QrUseResponse.success(SUCCESS_MESSAGE, reserver.getReservation().getTicket().getName());
-
             }
             case USED, EXPIRED, APPROVED -> QrUseResponse.fail(status.getMessage());
         };

--- a/src/main/java/com/myce/refund/controller/RefundController.java
+++ b/src/main/java/com/myce/refund/controller/RefundController.java
@@ -1,0 +1,42 @@
+package com.myce.refund.controller;
+
+import com.myce.auth.dto.CustomUserDetails;
+import com.myce.refund.dto.ReservationRefundCalculation;
+import com.myce.refund.service.RefundRequestService;
+import com.myce.refund.service.ReservationRefundCalculationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/refund")
+@RequiredArgsConstructor
+public class RefundController {
+
+    private final RefundRequestService refundRequestService;
+    private final ReservationRefundCalculationService refundCalculationService;
+
+    @PostMapping("/reservation/{reservationId}")
+    public ResponseEntity<String> refundReservation(
+            @PathVariable Long reservationId,
+            @RequestParam String reason,
+            @AuthenticationPrincipal CustomUserDetails currentUser) {
+        
+        refundRequestService.createReservationRefund(currentUser.getMemberId(), reservationId, reason);
+        
+        return ResponseEntity.ok("예매가 성공적으로 환불되었습니다.");
+    }
+
+    @GetMapping("/reservation/{reservationId}/preview")
+    public ResponseEntity<ReservationRefundCalculation> getRefundPreview(
+            @PathVariable Long reservationId,
+            @AuthenticationPrincipal CustomUserDetails currentUser) {
+        
+        ReservationRefundCalculation calculation = refundCalculationService.calculateRefundAmount(reservationId);
+        
+        return ResponseEntity.ok(calculation);
+    }
+}

--- a/src/main/java/com/myce/refund/dto/ReservationRefundCalculation.java
+++ b/src/main/java/com/myce/refund/dto/ReservationRefundCalculation.java
@@ -1,0 +1,16 @@
+package com.myce.refund.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ReservationRefundCalculation {
+    
+    private final Integer originalAmount;      // 원본 결제 금액
+    private final Integer refundFee;          // 환불 수수료
+    private final Integer actualRefundAmount; // 실제 환불 금액
+    private final Integer restoreMileage;     // 복원할 마일리지 (사용한 것)
+    private final Integer deductMileage;      // 차감할 마일리지 (적립된 것)
+    private final String feeDescription;     // 수수료 산정 근거
+}

--- a/src/main/java/com/myce/refund/service/RefundRequestService.java
+++ b/src/main/java/com/myce/refund/service/RefundRequestService.java
@@ -4,7 +4,10 @@ import com.myce.refund.dto.RefundRequestDto;
 
 public interface RefundRequestService {
     
-    // 환불 신청
+    // 박람회 환불 신청
     void createRefundRequest(Long memberId, Long expoId, RefundRequestDto requestDto);
+    
+    // 개인 예매 환불 (즉시 처리)
+    void createReservationRefund(Long memberId, Long reservationId, String reason);
     
 }

--- a/src/main/java/com/myce/refund/service/ReservationRefundCalculationService.java
+++ b/src/main/java/com/myce/refund/service/ReservationRefundCalculationService.java
@@ -1,0 +1,9 @@
+package com.myce.refund.service;
+
+import com.myce.refund.dto.ReservationRefundCalculation;
+
+public interface ReservationRefundCalculationService {
+    
+    // 예매 환불 금액 계산
+    ReservationRefundCalculation calculateRefundAmount(Long reservationId);
+}

--- a/src/main/java/com/myce/refund/service/impl/RefundRequestServiceImpl.java
+++ b/src/main/java/com/myce/refund/service/impl/RefundRequestServiceImpl.java
@@ -5,14 +5,29 @@ import com.myce.expo.entity.type.ExpoStatus;
 import com.myce.expo.repository.ExpoRepository;
 import com.myce.common.exception.CustomException;
 import com.myce.common.exception.CustomErrorCode;
+import com.myce.member.dto.MileageUpdateRequest;
 import com.myce.payment.entity.Payment;
 import com.myce.payment.entity.Refund;
+import com.myce.payment.entity.ReservationPaymentInfo;
+import com.myce.payment.entity.type.PaymentStatus;
 import com.myce.payment.entity.type.PaymentTargetType;
 import com.myce.payment.entity.type.RefundStatus;
 import com.myce.payment.repository.PaymentRepository;
 import com.myce.payment.repository.RefundRepository;
+import com.myce.payment.repository.ReservationPaymentInfoRepository;
+import com.myce.payment.service.refund.PaymentRefundService;
+import com.myce.payment.dto.PaymentRefundRequest;
+import com.myce.reservation.dto.ReservationDetailResponse;
+import com.myce.reservation.entity.Reservation;
+import com.myce.reservation.entity.code.ReservationStatus;
+import com.myce.reservation.repository.ReservationRepository;
 import com.myce.refund.dto.RefundRequestDto;
+import com.myce.refund.dto.ReservationRefundCalculation;
 import com.myce.refund.service.RefundRequestService;
+import com.myce.refund.service.ReservationRefundCalculationService;
+import com.myce.member.service.MemberMileageService;
+import com.myce.expo.entity.Ticket;
+import com.myce.expo.repository.TicketRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,6 +43,12 @@ public class RefundRequestServiceImpl implements RefundRequestService {
     private final RefundRepository refundRepository;
     private final PaymentRepository paymentRepository;
     private final ExpoRepository expoRepository;
+    private final ReservationRepository reservationRepository;
+    private final PaymentRefundService paymentRefundService;
+    private final ReservationRefundCalculationService refundCalculationService;
+    private final MemberMileageService memberMileageService;
+    private final ReservationPaymentInfoRepository reservationPaymentInfoRepository;
+    private final TicketRepository ticketRepository;
 
     @Override
     public void createRefundRequest(Long memberId, Long expoId, RefundRequestDto requestDto) {
@@ -64,6 +85,72 @@ public class RefundRequestServiceImpl implements RefundRequestService {
                 .build();
 
         refundRepository.save(refund);
+    }
+    
+    @Override
+    public void createReservationRefund(Long memberId, Long reservationId, String reason) {
+
+        // 1. 예매 정보 조회 및 검증
+        Reservation reservation = reservationRepository.findById(reservationId)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.RESERVATION_NOT_FOUND));
+
+        ReservationPaymentInfo reservationInfo = reservationPaymentInfoRepository.findByReservationId(reservationId)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.RESERVATION_NOT_FOUND));
+        
+        // 2. 예매 소유자 확인
+        if (!reservation.getUserId().equals(memberId)) {
+            throw new CustomException(CustomErrorCode.RESERVATION_NOT_FOUND);
+        }
+        
+        // 3. 예매 상태 확인
+        if (reservation.getStatus() != ReservationStatus.CONFIRMED) {
+            throw new CustomException(CustomErrorCode.RESERVATION_STATUS_INVALID);
+        }
+        
+        // 4. 결제 정보 조회
+        Payment payment = paymentRepository.findByTargetIdAndTargetType(
+                reservationId, PaymentTargetType.RESERVATION)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.PAYMENT_INFO_NOT_FOUND));
+        
+        // 5. 이미 환불된 결제인지 확인
+        if (refundRepository.existsByPaymentAndStatus(payment, RefundStatus.REFUNDED)) {
+            throw new CustomException(CustomErrorCode.ALREADY_REFUNDED);
+        }
+        
+        // 6. 환불 금액 계산 (수수료, 마일리지 등)
+        ReservationRefundCalculation calculation = refundCalculationService.calculateRefundAmount(reservationId);
+        
+        // 7. 환불 불가 조건 확인 (실제 환불 금액이 0원 이하)
+        if (calculation.getActualRefundAmount() <= 0) {
+            throw new CustomException(CustomErrorCode.REFUND_NOT_ALLOWED);
+        }
+        
+        // 8. 환불 처리 (즉시 실행)
+        PaymentRefundRequest refundRequest = PaymentRefundRequest.builder()
+                .impUid(payment.getImpUid())
+                .cancelAmount(calculation.getActualRefundAmount())
+                .reason(reason)
+                .build();
+                
+        paymentRefundService.refundPayment(refundRequest);
+        
+        // 9. 마일리지 처리 (복원/차감)
+        MileageUpdateRequest mileageRequest = new MileageUpdateRequest(
+            reservationInfo.getUsedMileage(),   // usedMileage (복원할 마일리지)
+            reservationInfo.getSavedMileage()     // savedMileage (차감할 마일리지)
+        );
+
+        memberMileageService.revertMileageForReservationRefund(memberId, mileageRequest);
+        
+        // 10. 티켓 수량 복원
+        Ticket ticket = reservation.getTicket();
+        ticket.restoreQuantity(reservation.getQuantity());
+        ticketRepository.save(ticket);
+        
+        // 11. 예매 상태 변경
+        reservation.updateStatus(ReservationStatus.CANCELLED);
+        reservationRepository.save(reservation);
+
     }
     
     /**

--- a/src/main/java/com/myce/refund/service/impl/ReservationRefundCalculationServiceImpl.java
+++ b/src/main/java/com/myce/refund/service/impl/ReservationRefundCalculationServiceImpl.java
@@ -1,0 +1,92 @@
+package com.myce.refund.service.impl;
+
+import com.myce.common.exception.CustomErrorCode;
+import com.myce.common.exception.CustomException;
+import com.myce.payment.entity.ReservationPaymentInfo;
+import com.myce.payment.repository.ReservationPaymentInfoRepository;
+import com.myce.refund.dto.ReservationRefundCalculation;
+import com.myce.refund.service.ReservationRefundCalculationService;
+import com.myce.reservation.entity.Reservation;
+import com.myce.reservation.repository.ReservationRepository;
+import com.myce.system.entity.RefundFeeSetting;
+import com.myce.system.entity.type.StandardType;
+import com.myce.system.repository.RefundFeeSettingRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ReservationRefundCalculationServiceImpl implements ReservationRefundCalculationService {
+
+    private final ReservationRepository reservationRepository;
+    private final ReservationPaymentInfoRepository reservationPaymentInfoRepository;
+    private final RefundFeeSettingRepository refundFeeSettingRepository;
+
+    @Override
+    public ReservationRefundCalculation calculateRefundAmount(Long reservationId) {
+        // 1. 예매 정보 조회
+        Reservation reservation = reservationRepository.findById(reservationId)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.RESERVATION_NOT_FOUND));
+
+        // 2. 결제 정보 조회
+        ReservationPaymentInfo paymentInfo = reservationPaymentInfoRepository.findByReservationId(reservationId)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.PAYMENT_INFO_NOT_FOUND));
+
+        // 3. 박람회 시작일까지 남은 일수 계산
+        long daysUntilExpo = ChronoUnit.DAYS.between(LocalDateTime.now(), reservation.getExpo().getStartDate().atStartOfDay());
+
+        // 4. 적용 가능한 환불 수수료 설정 조회 (BEFORE_EXPO_START만 사용)
+        RefundFeeSetting feeSetting = getApplicableRefundFeeSetting(daysUntilExpo);
+
+        // 5. 환불 수수료 계산
+        Integer refundFee = calculateRefundFee(paymentInfo.getTotalAmount(), feeSetting);
+
+        // 6. 실제 환불 금액 계산
+        Integer actualRefundAmount = paymentInfo.getTotalAmount() - refundFee;
+
+        return ReservationRefundCalculation.builder()
+                .originalAmount(paymentInfo.getTotalAmount())
+                .refundFee(refundFee)
+                .actualRefundAmount(actualRefundAmount)
+                .restoreMileage(paymentInfo.getUsedMileage())
+                .deductMileage(paymentInfo.getSavedMileage())
+                .feeDescription(String.format("%s (%.1f%% 수수료)", 
+                    feeSetting.getName(), feeSetting.getFeeRate()))
+                .build();
+    }
+
+    private RefundFeeSetting getApplicableRefundFeeSetting(long daysUntilExpo) {
+        // 박람회 시작일 기준으로만 환불 수수료 적용
+        return refundFeeSettingRepository.findAll().stream()
+                .filter(RefundFeeSetting::isActive)
+                .filter(setting -> setting.getStandardType() == StandardType.BEFORE_EXPO_START)
+                .filter(setting -> daysUntilExpo <= setting.getStandardDayCount())
+                .min((s1, s2) -> Integer.compare(s1.getStandardDayCount(), s2.getStandardDayCount()))
+                .orElse(getDefaultRefundFeeSetting());
+    }
+
+    private RefundFeeSetting getDefaultRefundFeeSetting() {
+        // 기본 환불 수수료 설정 (환불 불가 - 100% 수수료)
+        return RefundFeeSetting.builder()
+                .standardType(StandardType.BEFORE_EXPO_START)
+                .standardDayCount(0)
+                .feeRate(BigDecimal.valueOf(100))
+                .description("환불 불가 기간")
+                .validFrom(LocalDateTime.now().minusDays(1))
+                .validUntil(LocalDateTime.now().plusDays(1))
+                .build();
+    }
+
+    private Integer calculateRefundFee(Integer totalAmount, RefundFeeSetting feeSetting) {
+        BigDecimal amount = BigDecimal.valueOf(totalAmount);
+        BigDecimal fee = amount.multiply(feeSetting.getFeeRate().divide(BigDecimal.valueOf(100)));
+        return fee.setScale(0, RoundingMode.HALF_UP).intValue();
+    }
+}

--- a/src/main/java/com/myce/reservation/repository/ReserverRepository.java
+++ b/src/main/java/com/myce/reservation/repository/ReserverRepository.java
@@ -23,10 +23,11 @@ public interface ReserverRepository extends JpaRepository<Reserver, Long> {
 
     List<Reserver> findByReservation(Reservation reservation);
 
-    // QR코드 일괄 생성용 - 특정 박람회의 모든 예약자 조회
+    // QR코드 일괄 생성용 - 특정 박람회의 CONFIRMED 예약자만 조회
     @Query("SELECT r FROM Reserver r " +
             "JOIN r.reservation res " +
-            "WHERE res.expo.id = :expoId ")
+            "WHERE res.expo.id = :expoId " +
+            "AND res.status = 'CONFIRMED'")
     List<Reserver> findReserversByExpo(@Param("expoId") Long expoId);
 
     @Query("""


### PR DESCRIPTION
feat: QR 찍었을떄 USED 되놓고 QR 처리가 활성화 되지 않았습니다

개최기간 운영시간 장소 상세위치 입장권에서 삭제

박람회 결제 완료 시 -> 광고 상세로 리다이렉트됨

승인대기,결제대기 일대 -->> 페이지 접근 비활성화

나머지 --> 페이지 접근 허용

게시 대기일떄 --> 상세정보 뺴고 비활성화시키고 게시일에 오픈 예정입니다 문구 출력

재발급/발급 했을떄 STATUS 처리 고민

홈화면 아래 게시대기 리스트 PENDING_PUBLISH 상태 박람회들 데이터 렌더링

개인 예매 환불 로직 처리