### PR TITLE
[CRM-292] feat: 플랫폼 정산 내역 조회 및 다운로드 기능

### DIFF
--- a/src/main/java/com/myce/payment/controller/PaymentInfoPlatformController.java
+++ b/src/main/java/com/myce/payment/controller/PaymentInfoPlatformController.java
@@ -1,0 +1,31 @@
+package com.myce.payment.controller;
+
+import com.myce.common.dto.PageResponse;
+import com.myce.payment.dto.PaymentInfoResponse;
+import com.myce.payment.service.PaymentInfoPlatformService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/platform/payment-info")
+@RequiredArgsConstructor
+public class PaymentInfoPlatformController {
+    private final PaymentInfoPlatformService platformService;
+
+    @GetMapping
+    public PageResponse<PaymentInfoResponse> getPaymentInfoPage(
+            @RequestParam(defaultValue = "true") boolean latestFirst) {
+        return platformService.getPaymentInfoPage(1, 10, latestFirst);
+    }
+
+    @GetMapping("/filter")
+    public PageResponse<PaymentInfoResponse> filterPaymentInfoPage(
+            @RequestParam(defaultValue = "true") boolean latestFirst,
+            @RequestParam(required = false) String status,
+            @RequestParam(required = false) String keyword) {
+        return platformService.filterPaymentInfoPage(1, 10, latestFirst, status, keyword);
+    }
+}

--- a/src/main/java/com/myce/payment/controller/PaymentInfoPlatformController.java
+++ b/src/main/java/com/myce/payment/controller/PaymentInfoPlatformController.java
@@ -4,28 +4,37 @@ import com.myce.common.dto.PageResponse;
 import com.myce.payment.dto.PaymentInfoResponse;
 import com.myce.payment.service.PaymentInfoPlatformService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
 
 @RestController
 @RequestMapping("/api/platform/payment-info")
 @RequiredArgsConstructor
 public class PaymentInfoPlatformController {
     private final PaymentInfoPlatformService platformService;
+    private final int PAGE_SIZE = 10;
 
     @GetMapping
     public PageResponse<PaymentInfoResponse> getPaymentInfoPage(
+            @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "true") boolean latestFirst) {
-        return platformService.getPaymentInfoPage(1, 10, latestFirst);
+        return platformService.getPaymentInfoPage(page, PAGE_SIZE, latestFirst);
     }
 
     @GetMapping("/filter")
     public PageResponse<PaymentInfoResponse> filterPaymentInfoPage(
+            @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "true") boolean latestFirst,
-            @RequestParam(required = false) String status,
-            @RequestParam(required = false) String keyword) {
-        return platformService.filterPaymentInfoPage(1, 10, latestFirst, status, keyword);
+            @RequestParam(required = false) String type,
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate startDate,
+            @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate endDate) {
+        return platformService.filterPaymentInfoPage(page, PAGE_SIZE, latestFirst, keyword, type,
+                startDate, endDate);
     }
 }

--- a/src/main/java/com/myce/payment/controller/PaymentInfoPlatformExcelDownloadController.java
+++ b/src/main/java/com/myce/payment/controller/PaymentInfoPlatformExcelDownloadController.java
@@ -1,0 +1,46 @@
+package com.myce.payment.controller;
+
+import com.myce.payment.service.PaymentInfoPlatformExcelDownloadService;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/platform/payment-info/excel-download")
+@RequiredArgsConstructor
+public class PaymentInfoPlatformExcelDownloadController {
+    private final PaymentInfoPlatformExcelDownloadService service;
+    private final String EXCEL_FILE_NAME = "payment_info_xlsx";
+
+    @GetMapping
+    public void downloadExcel(
+            HttpServletResponse response,
+            @RequestParam(required = false) String type,
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate startDate,
+            @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate endDate)
+            throws IOException {
+
+        response.setContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+        response.setHeader("Content-Disposition", "attachment; filename=\"" + EXCEL_FILE_NAME + "\"");
+
+        try {
+            service.downloadExcel(response.getOutputStream(), type, keyword, startDate, endDate);
+        } catch (IOException e) {
+            log.error("Failed to write to OutputStream", e);
+            response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            response.getWriter().write("Failed to generate and download file.");
+        }
+    }
+}

--- a/src/main/java/com/myce/payment/dto/PaymentInfoResponse.java
+++ b/src/main/java/com/myce/payment/dto/PaymentInfoResponse.java
@@ -17,27 +17,25 @@ public class PaymentInfoResponse {
     private LocalDate serviceStartAt;
     private LocalDate serviceEndAt;
     private LocalDateTime createdAt;
-    private Integer totalDays;
-    private Integer totalPrice;
-    private BigDecimal ticketFee;
-    private BigDecimal totalRevenue;
+    private Integer deposit;
+    private BigDecimal ticketBenefit;
+    private BigDecimal totalBenefit;
     private String status;
     @Builder
     public PaymentInfoResponse(Long id, String title, String type,
                                LocalDate serviceStartAt, LocalDate serviceEndAt,
                                LocalDateTime createdAt,
-                               Integer totalDays, Integer totalPrice, BigDecimal ticketFee,
-                               BigDecimal totalRevenue, String status) {
+                               Integer deposit, BigDecimal ticketBenefit,
+                               BigDecimal totalBenefit, String status) {
         this.id = id;
         this.title = title;
         this.type = type;
         this.serviceStartAt = serviceStartAt;
         this.serviceEndAt = serviceEndAt;
         this.createdAt = createdAt;
-        this.totalDays = totalDays;
-        this.totalPrice = totalPrice;
-        this.ticketFee = ticketFee;
-        this.totalRevenue = totalRevenue;
+        this.deposit = deposit;
+        this.ticketBenefit = ticketBenefit;
+        this.totalBenefit = totalBenefit;
         this.status = status;
     }
 }

--- a/src/main/java/com/myce/payment/dto/PaymentInfoResponse.java
+++ b/src/main/java/com/myce/payment/dto/PaymentInfoResponse.java
@@ -1,0 +1,43 @@
+package com.myce.payment.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class PaymentInfoResponse {
+    private Long id;
+    private String title;
+    private String type;
+    private LocalDate serviceStartAt;
+    private LocalDate serviceEndAt;
+    private LocalDateTime createdAt;
+    private Integer totalDays;
+    private Integer totalPrice;
+    private BigDecimal ticketFee;
+    private BigDecimal totalRevenue;
+    private String status;
+    @Builder
+    public PaymentInfoResponse(Long id, String title, String type,
+                               LocalDate serviceStartAt, LocalDate serviceEndAt,
+                               LocalDateTime createdAt,
+                               Integer totalDays, Integer totalPrice, BigDecimal ticketFee,
+                               BigDecimal totalRevenue, String status) {
+        this.id = id;
+        this.title = title;
+        this.type = type;
+        this.serviceStartAt = serviceStartAt;
+        this.serviceEndAt = serviceEndAt;
+        this.createdAt = createdAt;
+        this.totalDays = totalDays;
+        this.totalPrice = totalPrice;
+        this.ticketFee = ticketFee;
+        this.totalRevenue = totalRevenue;
+        this.status = status;
+    }
+}

--- a/src/main/java/com/myce/payment/service/PaymentInfoPlatformExcelDownloadService.java
+++ b/src/main/java/com/myce/payment/service/PaymentInfoPlatformExcelDownloadService.java
@@ -1,0 +1,10 @@
+package com.myce.payment.service;
+
+
+import java.io.OutputStream;
+import java.time.LocalDate;
+
+public interface PaymentInfoPlatformExcelDownloadService {
+    void downloadExcel(OutputStream outputStream, String type, String keyword,
+                       LocalDate startDate, LocalDate endDate);
+}

--- a/src/main/java/com/myce/payment/service/PaymentInfoPlatformService.java
+++ b/src/main/java/com/myce/payment/service/PaymentInfoPlatformService.java
@@ -3,10 +3,17 @@ package com.myce.payment.service;
 import com.myce.common.dto.PageResponse;
 import com.myce.payment.dto.PaymentInfoResponse;
 
+import java.time.LocalDate;
+import java.util.List;
+import java.util.function.Predicate;
+
 public interface PaymentInfoPlatformService {
     PageResponse<PaymentInfoResponse> getPaymentInfoPage(Integer page, Integer size,
-            boolean latestFirst);
+                                                         boolean latestFirst);
 
     PageResponse<PaymentInfoResponse> filterPaymentInfoPage(Integer page, Integer size,
-            boolean latestFirst, String status, String keyword);
+                                                            boolean latestFirst, String status, String keyword, LocalDate startDate, LocalDate endDate);
+
+    List<PaymentInfoResponse> fetchAndSortAllPayments(boolean latestFirst,
+                                                      Predicate<PaymentInfoResponse> filterPredicate);
 }

--- a/src/main/java/com/myce/payment/service/PaymentInfoPlatformService.java
+++ b/src/main/java/com/myce/payment/service/PaymentInfoPlatformService.java
@@ -1,0 +1,12 @@
+package com.myce.payment.service;
+
+import com.myce.common.dto.PageResponse;
+import com.myce.payment.dto.PaymentInfoResponse;
+
+public interface PaymentInfoPlatformService {
+    PageResponse<PaymentInfoResponse> getPaymentInfoPage(Integer page, Integer size,
+            boolean latestFirst);
+
+    PageResponse<PaymentInfoResponse> filterPaymentInfoPage(Integer page, Integer size,
+            boolean latestFirst, String status, String keyword);
+}

--- a/src/main/java/com/myce/payment/service/impl/PaymentInfoPlatformExcelDownloadServiceImpl.java
+++ b/src/main/java/com/myce/payment/service/impl/PaymentInfoPlatformExcelDownloadServiceImpl.java
@@ -1,0 +1,155 @@
+package com.myce.payment.service.impl;
+
+import com.myce.payment.dto.PaymentInfoResponse;
+import com.myce.payment.service.PaymentInfoPlatformExcelDownloadService;
+import com.myce.payment.service.PaymentInfoPlatformService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.poi.ss.usermodel.*;
+import org.apache.poi.xssf.streaming.SXSSFWorkbook;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.function.Predicate;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PaymentInfoPlatformExcelDownloadServiceImpl
+        implements PaymentInfoPlatformExcelDownloadService {
+    private final PaymentInfoPlatformService paymentInfoPlatformService;
+
+    private final String[] HEADERS = {"번호", "제목", "종류", "이용 시작", "이용 종료",
+            "신청 일자", "등록금", "티켓 수익", "총 수익", "상태"};
+    private final String SHEET_NAME = "결제_정보";
+
+    @Override
+    public void downloadExcel(OutputStream outputStream, String type, String keyword, LocalDate startDate, LocalDate endDate) {
+
+        Predicate<PaymentInfoResponse> filterPredicate = paymentInfo ->
+                (keyword == null || paymentInfo.getTitle().contains(keyword)) &&
+                        (type == null || paymentInfo.getType().equalsIgnoreCase(type)) &&
+                        (startDate == null || !paymentInfo.getCreatedAt().toLocalDate().isBefore(startDate)) &&
+                        (endDate == null || !paymentInfo.getCreatedAt().toLocalDate().isAfter(endDate));
+
+        List<PaymentInfoResponse> allPayments = paymentInfoPlatformService
+                .fetchAndSortAllPayments(true, filterPredicate);
+        log.info("allPayments size: {}", allPayments.size());
+
+        try (Workbook workbook = new SXSSFWorkbook()) {
+            Sheet sheet = workbook.createSheet(SHEET_NAME);
+
+            applyFixedWidths(sheet);
+
+            // 스타일 생성
+            CellStyle headerStyle = createHeaderStyle(workbook);
+            CellStyle bodyStyle = createBodyCellStyle(workbook);
+            CellStyle dateStyle = createDateCellStyle(workbook);
+            CellStyle currencyStyle = createCurrencyStyle(workbook);
+
+            // 헤더 생성 및 스타일 적용
+            Row headerRow = sheet.createRow(0);
+            for (int i = 0; i < HEADERS.length; i++) {
+                Cell cell = headerRow.createCell(i);
+                cell.setCellValue(HEADERS[i]);
+                cell.setCellStyle(headerStyle);
+            }
+
+            // 본문 데이터 생성 및 스타일 적용
+            int rowNum = 1;
+            for (PaymentInfoResponse payment : allPayments) {
+                Row row = sheet.createRow(rowNum++);
+
+                // 각 셀에 스타일 적용
+                row.createCell(0).setCellValue(payment.getId() != null ? payment.getId() : 0);
+                row.getCell(0).setCellStyle(bodyStyle);
+                row.createCell(1).setCellValue(payment.getTitle() != null ? payment.getTitle() : "-");
+                row.getCell(1).setCellStyle(bodyStyle);
+                row.createCell(2).setCellValue(payment.getType() != null ? payment.getType() : "-");
+                row.getCell(2).setCellStyle(bodyStyle);
+
+                // 날짜 셀은 날짜 스타일 적용
+                Cell serviceStartAtCell = row.createCell(3);
+                serviceStartAtCell.setCellValue(payment.getServiceStartAt() != null ? payment.getServiceStartAt().toString() : "-");
+                serviceStartAtCell.setCellStyle(dateStyle);
+
+                Cell serviceEndAtCell = row.createCell(4);
+                serviceEndAtCell.setCellValue(payment.getServiceEndAt() != null ? payment.getServiceEndAt().toString() : "-");
+                serviceEndAtCell.setCellStyle(dateStyle);
+
+                Cell createdAtCell = row.createCell(5);
+                createdAtCell.setCellValue(payment.getCreatedAt() != null ? payment.getCreatedAt().toLocalDate().toString() : "-");
+                createdAtCell.setCellStyle(dateStyle);
+
+                row.createCell(6).setCellValue(payment.getDeposit() != null ? payment.getDeposit() : 0);
+                row.getCell(6).setCellStyle(currencyStyle);
+                row.createCell(7).setCellValue(payment.getTicketBenefit() != null ? payment.getTicketBenefit().doubleValue() : 0.0);
+                row.getCell(7).setCellStyle(currencyStyle);
+                row.createCell(8).setCellValue(payment.getTotalBenefit() != null ? payment.getTotalBenefit().doubleValue() : 0.0);
+                row.getCell(8).setCellStyle(currencyStyle);
+
+                row.createCell(9).setCellValue(payment.getStatus() != null ? payment.getStatus() : "-");
+                row.getCell(9).setCellStyle(bodyStyle);
+            }
+
+            workbook.write(outputStream);
+            outputStream.flush();
+        } catch (IOException e) {
+            log.error("Failed to download excel file: ", e);
+            throw new RuntimeException("Excel 다운로드 실패", e);
+        }
+    }
+
+    private CellStyle createCurrencyStyle(Workbook workbook) {
+        CellStyle style = workbook.createCellStyle();
+        DataFormat format = workbook.createDataFormat();
+        style.setDataFormat(format.getFormat("#,##0.00"));
+        style.setAlignment(HorizontalAlignment.CENTER);
+
+        return style;
+    }
+
+    // 헤더 스타일 생성
+    private CellStyle createHeaderStyle(Workbook workbook) {
+        CellStyle style = workbook.createCellStyle();
+        style.setFillForegroundColor(IndexedColors.GREY_25_PERCENT.getIndex());
+        style.setFillPattern(FillPatternType.SOLID_FOREGROUND);
+        style.setAlignment(HorizontalAlignment.CENTER);
+
+        Font font = workbook.createFont();
+        font.setBold(true);
+        style.setFont(font);
+
+        return style;
+    }
+
+    // 고정 컬럼 폭 적용
+    private void applyFixedWidths(Sheet sheet) {
+        int[] widths = {5, 50, 12, 12, 12, 16, 18, 18, 18, 10};
+        for (int i = 0; i < widths.length; i++) {
+            int width = Math.min((widths[i] + 2) * 256, 255 * 256);
+            sheet.setColumnWidth(i, width);
+        }
+    }
+
+    // 본문 스타일 생성
+    private CellStyle createBodyCellStyle(Workbook workbook) {
+        CellStyle style = workbook.createCellStyle();
+        style.setAlignment(HorizontalAlignment.CENTER);
+
+        return style;
+    }
+
+    // 날짜 스타일 생성
+    private CellStyle createDateCellStyle(Workbook workbook) {
+        CellStyle style = workbook.createCellStyle();
+        CreationHelper createHelper = workbook.getCreationHelper();
+        style.setDataFormat(createHelper.createDataFormat().getFormat("yyyy-mm-dd"));
+        style.setAlignment(HorizontalAlignment.CENTER);
+
+        return style;
+    }
+}

--- a/src/main/java/com/myce/payment/service/impl/PaymentInfoPlatformServiceImpl.java
+++ b/src/main/java/com/myce/payment/service/impl/PaymentInfoPlatformServiceImpl.java
@@ -1,0 +1,108 @@
+package com.myce.payment.service.impl;
+
+import com.myce.common.dto.PageResponse;
+import com.myce.expo.entity.Expo;
+import com.myce.payment.dto.PaymentInfoResponse;
+import com.myce.payment.repository.AdPaymentInfoRepository;
+import com.myce.payment.repository.ExpoPaymentInfoRepository;
+import com.myce.payment.service.PaymentInfoPlatformService;
+import com.myce.payment.service.mapper.PaymentInfoMapper;
+import com.myce.reservation.repository.ReservationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentInfoPlatformServiceImpl implements PaymentInfoPlatformService {
+    private final ExpoPaymentInfoRepository expoPaymentInfoRepository;
+    private final ReservationRepository reservationRepository;
+    private final AdPaymentInfoRepository adPaymentInfoRepository;
+
+    @Override
+    public PageResponse<PaymentInfoResponse> getPaymentInfoPage(Integer page, Integer size, boolean latestFirst) {
+        List<PaymentInfoResponse> expoPayments = expoPaymentInfoRepository.findAll()
+                .stream()
+                .map((paymentInfo) -> {
+                    Expo expo = paymentInfo.getExpo();
+                    BigDecimal commissionRate = paymentInfo.getCommissionRate();
+
+                    BigDecimal totalRevenue = reservationRepository.sumTotalRevenueByExpoId(expo.getId());
+
+                    BigDecimal platformRevenue = totalRevenue.multiply(commissionRate)
+                            .divide(new BigDecimal("100"), 2, RoundingMode.HALF_UP);
+
+                    return PaymentInfoMapper.expoPaymentInfoToResponse(paymentInfo, platformRevenue);
+                })
+                .toList();
+
+        List<PaymentInfoResponse> adPayments = adPaymentInfoRepository.findAll()
+                .stream()
+                .map(PaymentInfoMapper::adPaymentInfoToResponse)
+                .toList();
+
+        Comparator<PaymentInfoResponse> comparator = Comparator.comparing(PaymentInfoResponse::getCreatedAt);
+
+        if (latestFirst) {
+            comparator = comparator.reversed();
+        }
+
+        List<PaymentInfoResponse> allPayments = Stream.concat(expoPayments.stream(), adPayments.stream())
+                .sorted(comparator)
+                .collect(Collectors.toList());
+
+        int start = page * size;
+        int end = Math.min(start + size, allPayments.size());
+
+        if (start > allPayments.size()) {
+            return PageResponse.from(Page.empty(PageRequest.of(page, size)));
+        }
+
+        List<PaymentInfoResponse> pagedPayments = allPayments.subList(start, end);
+
+        Pageable pageable = PageRequest.of(page, size);
+        Page<PaymentInfoResponse> paymentPage = new PageImpl<>(pagedPayments, pageable, allPayments.size());
+
+        return PageResponse.from(paymentPage);
+    }
+
+    @Override
+    public PageResponse<PaymentInfoResponse> filterPaymentInfoPage(Integer page, Integer size,
+                                                                   boolean latestFirst,
+                                                                   String keyword, String type) {
+        List<PaymentInfoResponse> expoPayments = expoPaymentInfoRepository.findAll()
+                .stream()
+                .map((paymentInfo) -> {
+                    Expo expo = paymentInfo.getExpo();
+                    BigDecimal commissionRate = paymentInfo.getCommissionRate();
+
+                    BigDecimal totalRevenue = reservationRepository.sumTotalRevenueByExpoId(expo.getId());
+
+                    BigDecimal platformRevenue = totalRevenue.multiply(commissionRate)
+                            .divide(new BigDecimal("100"), 2, RoundingMode.HALF_UP);
+
+                    return PaymentInfoMapper.expoPaymentInfoToResponse(paymentInfo, platformRevenue);
+                })
+                .toList();
+
+        List<PaymentInfoResponse> adPayments = adPaymentInfoRepository.findAll()
+                .stream()
+                .map(PaymentInfoMapper::adPaymentInfoToResponse)
+                .toList();
+
+        adPayments.stream().filter(payment -> payment.getTitle().contains(keyword));
+
+
+        return null;
+    }
+}

--- a/src/main/java/com/myce/payment/service/impl/PaymentInfoPlatformServiceImpl.java
+++ b/src/main/java/com/myce/payment/service/impl/PaymentInfoPlatformServiceImpl.java
@@ -3,12 +3,14 @@ package com.myce.payment.service.impl;
 import com.myce.common.dto.PageResponse;
 import com.myce.expo.entity.Expo;
 import com.myce.payment.dto.PaymentInfoResponse;
+import com.myce.payment.entity.AdPaymentInfo;
 import com.myce.payment.repository.AdPaymentInfoRepository;
 import com.myce.payment.repository.ExpoPaymentInfoRepository;
 import com.myce.payment.service.PaymentInfoPlatformService;
 import com.myce.payment.service.mapper.PaymentInfoMapper;
 import com.myce.reservation.repository.ReservationRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -17,13 +19,16 @@ import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.List;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class PaymentInfoPlatformServiceImpl implements PaymentInfoPlatformService {
     private final ExpoPaymentInfoRepository expoPaymentInfoRepository;
     private final ReservationRepository reservationRepository;
@@ -31,17 +36,33 @@ public class PaymentInfoPlatformServiceImpl implements PaymentInfoPlatformServic
 
     @Override
     public PageResponse<PaymentInfoResponse> getPaymentInfoPage(Integer page, Integer size, boolean latestFirst) {
+        List<PaymentInfoResponse> allPayments = fetchAndSortAllPayments(latestFirst, null);
+        return paginatePayments(allPayments, page, size);
+    }
+
+    @Override
+    public PageResponse<PaymentInfoResponse> filterPaymentInfoPage(Integer page, Integer size,
+            boolean latestFirst,
+            String keyword, String type,
+            LocalDate startDate, LocalDate endDate) {
+        Predicate<PaymentInfoResponse> filterPredicate = paymentInfo ->
+                (keyword == null || paymentInfo.getTitle().contains(keyword)) &&
+                (type == null || paymentInfo.getType().equalsIgnoreCase(type)) &&
+                (startDate == null || !paymentInfo.getCreatedAt().toLocalDate().isBefore(startDate)) &&
+                (endDate == null || !paymentInfo.getCreatedAt().toLocalDate().isAfter(endDate));
+        List<PaymentInfoResponse> allPayments = fetchAndSortAllPayments(latestFirst, filterPredicate);
+        return paginatePayments(allPayments, page, size);
+    }
+
+    public List<PaymentInfoResponse> fetchAndSortAllPayments(boolean latestFirst, Predicate<PaymentInfoResponse> filterPredicate) {
         List<PaymentInfoResponse> expoPayments = expoPaymentInfoRepository.findAll()
                 .stream()
-                .map((paymentInfo) -> {
+                .map(paymentInfo -> {
                     Expo expo = paymentInfo.getExpo();
                     BigDecimal commissionRate = paymentInfo.getCommissionRate();
-
                     BigDecimal totalRevenue = reservationRepository.sumTotalRevenueByExpoId(expo.getId());
-
                     BigDecimal platformRevenue = totalRevenue.multiply(commissionRate)
                             .divide(new BigDecimal("100"), 2, RoundingMode.HALF_UP);
-
                     return PaymentInfoMapper.expoPaymentInfoToResponse(paymentInfo, platformRevenue);
                 })
                 .toList();
@@ -52,15 +73,21 @@ public class PaymentInfoPlatformServiceImpl implements PaymentInfoPlatformServic
                 .toList();
 
         Comparator<PaymentInfoResponse> comparator = Comparator.comparing(PaymentInfoResponse::getCreatedAt);
-
         if (latestFirst) {
             comparator = comparator.reversed();
         }
 
-        List<PaymentInfoResponse> allPayments = Stream.concat(expoPayments.stream(), adPayments.stream())
-                .sorted(comparator)
-                .collect(Collectors.toList());
+        Stream<PaymentInfoResponse> combinedStream = Stream.concat(expoPayments.stream(), adPayments.stream())
+                .sorted(comparator);
 
+        if (filterPredicate != null) {
+            combinedStream = combinedStream.filter(filterPredicate);
+        }
+
+        return combinedStream.collect(Collectors.toList());
+    }
+
+    private PageResponse<PaymentInfoResponse> paginatePayments(List<PaymentInfoResponse> allPayments, Integer page, Integer size) {
         int start = page * size;
         int end = Math.min(start + size, allPayments.size());
 
@@ -69,40 +96,9 @@ public class PaymentInfoPlatformServiceImpl implements PaymentInfoPlatformServic
         }
 
         List<PaymentInfoResponse> pagedPayments = allPayments.subList(start, end);
-
         Pageable pageable = PageRequest.of(page, size);
         Page<PaymentInfoResponse> paymentPage = new PageImpl<>(pagedPayments, pageable, allPayments.size());
 
         return PageResponse.from(paymentPage);
-    }
-
-    @Override
-    public PageResponse<PaymentInfoResponse> filterPaymentInfoPage(Integer page, Integer size,
-                                                                   boolean latestFirst,
-                                                                   String keyword, String type) {
-        List<PaymentInfoResponse> expoPayments = expoPaymentInfoRepository.findAll()
-                .stream()
-                .map((paymentInfo) -> {
-                    Expo expo = paymentInfo.getExpo();
-                    BigDecimal commissionRate = paymentInfo.getCommissionRate();
-
-                    BigDecimal totalRevenue = reservationRepository.sumTotalRevenueByExpoId(expo.getId());
-
-                    BigDecimal platformRevenue = totalRevenue.multiply(commissionRate)
-                            .divide(new BigDecimal("100"), 2, RoundingMode.HALF_UP);
-
-                    return PaymentInfoMapper.expoPaymentInfoToResponse(paymentInfo, platformRevenue);
-                })
-                .toList();
-
-        List<PaymentInfoResponse> adPayments = adPaymentInfoRepository.findAll()
-                .stream()
-                .map(PaymentInfoMapper::adPaymentInfoToResponse)
-                .toList();
-
-        adPayments.stream().filter(payment -> payment.getTitle().contains(keyword));
-
-
-        return null;
     }
 }

--- a/src/main/java/com/myce/payment/service/mapper/PaymentInfoMapper.java
+++ b/src/main/java/com/myce/payment/service/mapper/PaymentInfoMapper.java
@@ -1,0 +1,41 @@
+package com.myce.payment.service.mapper;
+
+import com.myce.payment.dto.PaymentInfoResponse;
+import com.myce.payment.entity.AdPaymentInfo;
+import com.myce.payment.entity.ExpoPaymentInfo;
+import com.myce.payment.entity.type.PaymentTargetType;
+
+import java.math.BigDecimal;
+
+public class PaymentInfoMapper {
+    public static PaymentInfoResponse expoPaymentInfoToResponse(ExpoPaymentInfo paymentInfo,
+                                                                BigDecimal ticketBenefit) {
+        return PaymentInfoResponse.builder()
+                .id(paymentInfo.getId())
+                .title(paymentInfo.getExpo().getTitle())
+                .type(PaymentTargetType.EXPO.name())
+                .serviceStartAt(paymentInfo.getExpo().getDisplayStartDate())
+                .serviceEndAt(paymentInfo.getExpo().getDisplayEndDate())
+                .createdAt(paymentInfo.getCreatedAt())
+                .totalDays(paymentInfo.getTotalDay())
+                .ticketFee(ticketBenefit)
+                .totalPrice(paymentInfo.getTotalAmount())
+                .status(paymentInfo.getStatus().name())
+                .build();
+    }
+
+    public static PaymentInfoResponse adPaymentInfoToResponse(AdPaymentInfo paymentInfo){
+
+        return PaymentInfoResponse.builder()
+                .id(paymentInfo.getId())
+                .title(paymentInfo.getAdvertisement().getTitle())
+                .type(PaymentTargetType.AD.name())
+                .serviceStartAt(paymentInfo.getAdvertisement().getDisplayStartDate())
+                .serviceEndAt(paymentInfo.getAdvertisement().getDisplayEndDate())
+                .createdAt(paymentInfo.getCreatedAt())
+                .totalDays(paymentInfo.getTotalDay())
+                .totalPrice(paymentInfo.getTotalAmount())
+                .status(paymentInfo.getStatus().name())
+                .build();
+    }
+}

--- a/src/main/java/com/myce/payment/service/mapper/PaymentInfoMapper.java
+++ b/src/main/java/com/myce/payment/service/mapper/PaymentInfoMapper.java
@@ -17,9 +17,9 @@ public class PaymentInfoMapper {
                 .serviceStartAt(paymentInfo.getExpo().getDisplayStartDate())
                 .serviceEndAt(paymentInfo.getExpo().getDisplayEndDate())
                 .createdAt(paymentInfo.getCreatedAt())
-                .totalDays(paymentInfo.getTotalDay())
-                .ticketFee(ticketBenefit)
-                .totalPrice(paymentInfo.getTotalAmount())
+                .deposit(paymentInfo.getDeposit() + paymentInfo.getPremiumDeposit())
+                .ticketBenefit(ticketBenefit)
+                .totalBenefit(BigDecimal.valueOf(paymentInfo.getTotalAmount() + ticketBenefit.doubleValue()))
                 .status(paymentInfo.getStatus().name())
                 .build();
     }
@@ -33,8 +33,8 @@ public class PaymentInfoMapper {
                 .serviceStartAt(paymentInfo.getAdvertisement().getDisplayStartDate())
                 .serviceEndAt(paymentInfo.getAdvertisement().getDisplayEndDate())
                 .createdAt(paymentInfo.getCreatedAt())
-                .totalDays(paymentInfo.getTotalDay())
-                .totalPrice(paymentInfo.getTotalAmount())
+                .deposit(paymentInfo.getTotalAmount())
+                .totalBenefit(BigDecimal.valueOf(paymentInfo.getTotalAmount()))
                 .status(paymentInfo.getStatus().name())
                 .build();
     }


### PR DESCRIPTION
### 구현 기능
* 정산 내역(박람회 정산, 광고 정산) 통합 조회
* 제목 검색 기능 및 카테고리 필터링, 페이징, 날짜 지정
* 같은 필터링을 적용한 엑셀 파일 다운로드 api

### 논의가 필요한 부분
* settlement 테이블을 사용 안함..
* ad_payment_info와 expo_payment_info를 사용하는데 명칭을 바꿔야 할지