### PR TITLE
[CRM-298] fix: 배너 취소 거절 시 상태 로직 수정

### DIFF
--- a/src/main/java/com/myce/advertisement/entity/Advertisement.java
+++ b/src/main/java/com/myce/advertisement/entity/Advertisement.java
@@ -120,7 +120,13 @@ public class Advertisement {
         if (this.status != AdvertisementStatus.PENDING_CANCEL) {
             throw new CustomException(CustomErrorCode.INVALID_ADVERTISEMENT_STATUS);
         }
-        this.status = AdvertisementStatus.PUBLISHED;
+        if (this.displayEndDate.isBefore(LocalDate.now())) {
+            this.status = AdvertisementStatus.COMPLETED;
+        }else if(this.displayStartDate.isBefore(LocalDate.now())){
+            this.status = AdvertisementStatus.PUBLISHED;
+        }else{
+            this.status = AdvertisementStatus.PENDING_PUBLISH;
+        }
     }
 
     public void complete() {

--- a/src/main/java/com/myce/advertisement/service/impl/PlatformCurrentAdServiceImpl.java
+++ b/src/main/java/com/myce/advertisement/service/impl/PlatformCurrentAdServiceImpl.java
@@ -57,13 +57,7 @@ public class PlatformCurrentAdServiceImpl implements PlatformCurrentAdService {
                 .findByTargetIdAndTargetType(ad.getId(), PaymentTargetType.AD)
                 .orElseThrow(() -> new CustomException(CustomErrorCode.PAYMENT_INFO_NOT_FOUND));
 
-        if(ad.getDisplayEndDate().isBefore(LocalDate.now())){
-            ad.complete();
-        }else if(ad.getDisplayStartDate().isBefore(LocalDate.now())){
-            ad.approve();
-        }else{
-            ad.denyCancel();
-        }
+        ad.denyCancel();
 
         refundRepository.deleteByPayment(payment);
     }


### PR DESCRIPTION
### 구현 기능
* Advertisement의 denyCancel() 메서드에 상태 정보 처리하도록 메서드 이동