### PR TITLE
[CRM-300] refactor: sse 타임아웃 추가, reservation 중복 공지 문제 해결

### DIFF
--- a/src/main/java/com/myce/notification/repository/EmitterRepository.java
+++ b/src/main/java/com/myce/notification/repository/EmitterRepository.java
@@ -9,4 +9,5 @@ public interface EmitterRepository {
     SseEmitter save(String emitterId, SseEmitter sseEmitter);
     void removeSseEmitter(String memberId);
     List<SseEmitter> findAllSseEmitterByMemberId(String memberId);
+    Iterable<SseEmitter> findAll();
 }

--- a/src/main/java/com/myce/notification/repository/impl/EmitterRepositoryImpl.java
+++ b/src/main/java/com/myce/notification/repository/impl/EmitterRepositoryImpl.java
@@ -31,4 +31,9 @@ public class EmitterRepositoryImpl implements EmitterRepository {
                 .map(sseEmitters::get)
                 .toList();
     }
+
+    @Override
+    public Iterable<SseEmitter> findAll() {
+        return sseEmitters.values();
+    }
 }

--- a/src/main/java/com/myce/notification/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/myce/notification/service/impl/NotificationServiceImpl.java
@@ -25,7 +25,6 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static com.myce.system.entity.type.MessageTemplateCode.QR_ISSUED;
@@ -170,7 +169,7 @@ public class NotificationServiceImpl implements NotificationService {
                     .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_EXIST_MESSAGE_TEMPLATE));
 
             // 해당 박람회 예약자들 조회
-            List<Reservation> reservations = reservationRepository.findByExpoId(expoId);
+            List<Reservation> reservations = reservationRepository.findByExpoIdWithDistinctMemberId(expoId);
             
             if (reservations.isEmpty()) {
                 log.info("알림 전송 대상이 없습니다 - 박람회 ID: {}", expoId);

--- a/src/main/java/com/myce/notification/service/impl/SseServiceImpl.java
+++ b/src/main/java/com/myce/notification/service/impl/SseServiceImpl.java
@@ -7,6 +7,7 @@ import com.myce.reservation.entity.code.UserType;
 import com.myce.reservation.repository.ReservationRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -19,7 +20,7 @@ import java.util.List;
 public class SseServiceImpl implements SseService {
     private final EmitterRepository emitterRepository;
     private final ReservationRepository reservationRepository;
-    private static final Long DEFAULT_TIMEOUT = 60L * 1000 * 3;
+    private static final Long DEFAULT_TIMEOUT = 60L * 1000 * 30;
 
     public SseEmitter subscribe(Long memberId) {
         String emitterId = memberId + "_" + System.currentTimeMillis();
@@ -36,7 +37,7 @@ public class SseServiceImpl implements SseService {
             emitterRepository.removeSseEmitter(emitterId);
         });
 
-        sendMessage(sseEmitter, "SSE connected, emitterId: " + emitterId);
+        sendMessage(sseEmitter,"", "SSE connected, emitterId: " + emitterId);
 
         return sseEmitter;
     }
@@ -56,14 +57,24 @@ public class SseServiceImpl implements SseService {
         List<SseEmitter> emitters = emitterRepository
                 .findAllSseEmitterByMemberId(String.valueOf(memberId));
         emitters.forEach(sseEmitter -> {
-            sendMessage(sseEmitter, content);
+            sendMessage(sseEmitter,"", content);
         });
     }
 
-    private void sendMessage(SseEmitter sseEmitter, String content) {
+    @Scheduled(fixedRate = 10000)
+    public void sendKeepAlive() {
+        log.info("Sending keep-alive to all SseEmitter");
+
+        emitterRepository.findAll().forEach((emitter) -> {
+            sendMessage(emitter, "", "keep-alive");
+        });
+    }
+
+    private void sendMessage(SseEmitter sseEmitter, String eventName, String data) {
         try {
             sseEmitter.send(SseEmitter.event()
-                    .data(content));
+                    .name(eventName) // 이벤트 이름 추가
+                    .data(data));
         } catch (IOException e) {
             log.error("Failed to send SSE message, sseEmitter complete with error.", e);
             sseEmitter.completeWithError(e);

--- a/src/main/java/com/myce/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/myce/reservation/repository/ReservationRepository.java
@@ -134,6 +134,11 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 
     List<Reservation> findByExpoId(Long expoId);
 
+    @Query("SELECT r FROM Reservation r " +
+            "WHERE r.expo.id = :expoId AND r.userType = 'MEMBER' " +
+            "GROUP BY r.userId")
+    List<Reservation> findByExpoIdWithDistinctMemberId(Long expoId);
+
     // === 대시보드 통계용 쿼리 메서드들 ===
 
     // 특정 박람회의 누적 판매 개수 (현재 존재하는 티켓의 확정된 예약 수량 총합)


### PR DESCRIPTION
### 구현 기능
* 클라이언트의 sse 타임아웃을 2분으로 조정
* 서버의 sse 타임아웃을 30분으로 조정, keep-alive 핑 추가 -> 응답 없을경우 삭제되도록
* 메인페이지의 알림 뱃지 숫자를 sse와 연동