### PR TITLE
[CRM-113] feat: 비회원 예매 내역 조회

### DIFF
--- a/src/main/java/com/myce/auth/security/config/SecurityConfig.java
+++ b/src/main/java/com/myce/auth/security/config/SecurityConfig.java
@@ -85,7 +85,7 @@ public class SecurityConfig {
                         .permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/ads", "/api/auth/**",
                             "/api/categories", "/api/expos/**", "/api/reservations/**",
-                            "/api/expo/fees/active", "/api/ad/fees/active",
+                            "/api/reservations/non-member", "/api/expo/fees/active", "/api/ad/fees/active",
                             "/api/members/expos/*/payment", "/api/members/ads/*/payment",
                             "/api/reviews/expo/*", "/api/reviews/*/")
                         .permitAll()

--- a/src/main/java/com/myce/reservation/controller/ReservationController.java
+++ b/src/main/java/com/myce/reservation/controller/ReservationController.java
@@ -94,4 +94,15 @@ public class ReservationController {
         reservationService.deletePendingReservation(reservationId);
         return ResponseEntity.noContent().build();
     }
+
+    // 비회원 예매 조회 (이메일 + 예매번호)
+    @GetMapping("/non-member")
+    public ResponseEntity<ReservationDetailResponse> getNonMemberReservation(
+            @RequestParam String email,
+            @RequestParam String reservationCode) {
+        
+        ReservationDetailResponse reservationDetail = reservationService.getNonMemberReservationDetail(email, reservationCode);
+        
+        return ResponseEntity.ok(reservationDetail);
+    }
 }

--- a/src/main/java/com/myce/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/myce/reservation/repository/ReservationRepository.java
@@ -206,4 +206,19 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     List<Reservation> findByUserIdAndUserTypeAndStatus(Long userId, UserType userType, ReservationStatus status);
 
     Long countAllByCreatedAtBetween(LocalDateTime createdAtAfter, LocalDateTime createdAtBefore);
+
+    @Query("""
+            SELECT r FROM Reservation r 
+            JOIN FETCH r.expo e 
+            JOIN FETCH r.ticket t 
+            LEFT JOIN Guest g ON r.userType = com.myce.reservation.entity.code.UserType.GUEST AND r.userId = g.id 
+            LEFT JOIN Member m ON r.userType = com.myce.reservation.entity.code.UserType.MEMBER AND r.userId = m.id 
+            WHERE r.reservationCode = :reservationCode 
+            AND (
+                (r.userType = com.myce.reservation.entity.code.UserType.GUEST AND g.email = :email) OR 
+                (r.userType = com.myce.reservation.entity.code.UserType.MEMBER AND m.email = :email)
+            )
+            """)
+    Optional<Reservation> findByReservationCodeAndEmail(@Param("reservationCode") String reservationCode, 
+                                                        @Param("email") String email);
 }

--- a/src/main/java/com/myce/reservation/service/Impl/ReservationServiceImpl.java
+++ b/src/main/java/com/myce/reservation/service/Impl/ReservationServiceImpl.java
@@ -237,4 +237,35 @@ public class ReservationServiceImpl implements ReservationService {
         return reservationMapper.toPendingResponse(payment, reservationPaymentInfo.getTotalAmount(),
             formattedDueDate);
     }
+
+    @Override
+    public ReservationDetailResponse getNonMemberReservationDetail(String email, String reservationCode) {
+        Reservation reservation = reservationRepository.findByReservationCodeAndEmail(reservationCode, email)
+            .orElseThrow(() -> new CustomException(CustomErrorCode.RESERVATION_NOT_FOUND));
+
+        // 예매자 정보 조회
+        List<Reserver> reservers = reserverRepository.findByReservationId(reservation.getId());
+
+        // 결제 정보 조회
+        ReservationPaymentInfo paymentInfo = reservationPaymentInfoRepository.findByReservationId(reservation.getId())
+            .orElse(null);
+
+        // 결제 완료된 경우 Payment 정보와 Member 등급 조회
+        if (paymentInfo != null) {
+            Payment payment = paymentRepository.findByTargetIdAndTargetType(reservation.getId(), PaymentTargetType.RESERVATION)
+                .orElse(null);
+            
+            MemberGrade memberGrade = null;
+            if (reservation.getUserType() == UserType.MEMBER) {
+                Member member = memberRepository.findById(reservation.getUserId())
+                    .orElseThrow(() -> new CustomException(CustomErrorCode.MEMBER_NOT_EXIST));
+                memberGrade = member.getMemberGrade();
+            }
+            
+            return reservationDetailMapper.toResponseDto(reservation, reservers, paymentInfo, payment, memberGrade);
+        } else {
+            // 결제 정보가 없는 경우 (예: 대기 상태)
+            return reservationDetailMapper.toResponseDto(reservation, reservers);
+        }
+    }
 }

--- a/src/main/java/com/myce/reservation/service/ReservationService.java
+++ b/src/main/java/com/myce/reservation/service/ReservationService.java
@@ -26,4 +26,6 @@ public interface ReservationService {
     void deletePendingReservation(Long reservationId);
 
     ReservationPendingResponse getVirtualAccountInfo(Long reservationId);
+
+    ReservationDetailResponse getNonMemberReservationDetail(String email, String reservationCode);
 }


### PR DESCRIPTION
* ReservationController: /api/reservations/non-member 엔드포인트 추가
* ReservationRepository: 이메일 + 예매번호 기반 예매 조회 쿼리 구현
* SecurityConfig: 비회원 예매 조회 엔드포인트 permitAll 설정