### PR TITLE
[CRM-117] fix: 박람회 결제 통합 API 구현

### DIFF
--- a/src/main/java/com/myce/auth/security/config/SecurityConfig.java
+++ b/src/main/java/com/myce/auth/security/config/SecurityConfig.java
@@ -17,7 +17,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.ProviderManager;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -85,7 +84,7 @@ public class SecurityConfig {
                         .permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/ads", "/api/auth/**",
                             "/api/categories", "/api/expos/**", "/api/reservations/**",
-                            "/api/reservations/non-member", "/api/expo/fees/active", "/api/ad/fees/active",
+                            "/api/reservations/guest", "/api/expo/fees/active", "/api/ad/fees/active",
                             "/api/members/expos/*/payment", "/api/members/ads/*/payment",
                             "/api/reviews/expo/*", "/api/reviews/*/", "/api/reviews/best",
                             "/api/settings/refund-fee/public")

--- a/src/main/java/com/myce/member/dto/MileageUpdateRequest.java
+++ b/src/main/java/com/myce/member/dto/MileageUpdateRequest.java
@@ -17,5 +17,7 @@ public class MileageUpdateRequest {
   private Integer savedMileage;
 
   public MileageUpdateRequest(Integer usedMileage, Integer savedMileage) {
+    this.usedMileage = usedMileage;
+    this.savedMileage = savedMileage;
   }
 }

--- a/src/main/java/com/myce/payment/controller/PaymentController.java
+++ b/src/main/java/com/myce/payment/controller/PaymentController.java
@@ -7,7 +7,9 @@ import com.myce.payment.dto.PaymentVerifyResponse;
 import com.myce.payment.dto.PaymentRefundRequest;
 import com.myce.payment.dto.PortOneWebhookRequest;
 import com.myce.payment.dto.AdRefundRequest;
+import com.myce.payment.dto.ReservationPaymentVerifyRequest;
 import com.myce.payment.service.PaymentService;
+import com.myce.payment.service.ReservationPaymentService;
 import com.myce.payment.service.refund.PaymentRefundService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,6 +25,7 @@ import java.util.Map;
 public class PaymentController {
   private final PaymentService paymentService;
   private final PaymentRefundService paymentRefundService;
+  private final ReservationPaymentService reservationPaymentService;
 
   // 결제 검증 API (POST 방식)
   @PostMapping("/verify")
@@ -78,6 +81,24 @@ public class PaymentController {
   public ResponseEntity<Map<String, Object>> processAdRefund(
       @RequestBody AdRefundRequest request) {
     Map<String, Object> response = paymentRefundService.processAdRefund(request);
+    return ResponseEntity.status(HttpStatus.OK).body(response);
+  }
+  
+  // 박람회 통합 결제 검증 API - 결제 검증 + 예약 처리 + 마일리지 + 등급 업데이트를 한번에 처리
+  @PostMapping("/reservation/verify")
+  public ResponseEntity<PaymentVerifyResponse> verifyReservationPayment(
+      @RequestBody ReservationPaymentVerifyRequest request) {
+    log.info("박람회 통합 결제 검증 시작 - reservationId: {}", request.getTargetId());
+    PaymentVerifyResponse response = reservationPaymentService.verifyAndCompleteReservationPayment(request);
+    return ResponseEntity.status(HttpStatus.OK).body(response);
+  }
+  
+  // 박람회 가상계좌 통합 결제 검증 API
+  @PostMapping("/reservation/verify-vbank")
+  public ResponseEntity<PaymentVerifyResponse> verifyReservationVbankPayment(
+      @RequestBody ReservationPaymentVerifyRequest request) {
+    log.info("박람회 가상계좌 통합 결제 검증 시작 - reservationId: {}", request.getTargetId());
+    PaymentVerifyResponse response = reservationPaymentService.verifyAndCompleteVbankReservationPayment(request);
     return ResponseEntity.status(HttpStatus.OK).body(response);
   }
 }

--- a/src/main/java/com/myce/payment/dto/ReservationPaymentVerifyRequest.java
+++ b/src/main/java/com/myce/payment/dto/ReservationPaymentVerifyRequest.java
@@ -1,0 +1,27 @@
+package com.myce.payment.dto;
+
+import com.myce.payment.entity.type.PaymentTargetType;
+import com.myce.reservation.dto.ReserverBulkSaveRequest;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ReservationPaymentVerifyRequest {
+    private String impUid;
+    private String merchantUid;
+    private Integer amount;
+    private PaymentTargetType targetType;
+    private Long targetId;
+    private Integer usedMileage;
+    private Integer savedMileage;
+    
+    // 박람회 결제 시 추가 정보
+    private List<ReserverBulkSaveRequest.ReserverSaveInfo> reserverInfos;
+    private Long ticketId;
+    private Integer quantity;
+}

--- a/src/main/java/com/myce/payment/service/ReservationPaymentService.java
+++ b/src/main/java/com/myce/payment/service/ReservationPaymentService.java
@@ -1,0 +1,25 @@
+package com.myce.payment.service;
+
+import com.myce.payment.dto.PaymentVerifyResponse;
+import com.myce.payment.dto.ReservationPaymentVerifyRequest;
+
+public interface ReservationPaymentService {
+    
+    /**
+     * 박람회 예약 결제 검증 및 통합 처리
+     * - 결제 검증
+     * - 예약 상태 변경 (PENDING -> CONFIRMED)
+     * - 예약자 정보 저장
+     * - 티켓 수량 감소
+     * - 마일리지 처리 (사용/적립)
+     * - 회원 등급 업데이트
+     * - QR 코드 생성
+     * 모든 작업을 하나의 트랜잭션으로 처리
+     */
+    PaymentVerifyResponse verifyAndCompleteReservationPayment(ReservationPaymentVerifyRequest request);
+    
+    /**
+     * 가상계좌 박람회 예약 결제 검증 및 처리
+     */
+    PaymentVerifyResponse verifyAndCompleteVbankReservationPayment(ReservationPaymentVerifyRequest request);
+}

--- a/src/main/java/com/myce/payment/service/impl/ReservationPaymentServiceImpl.java
+++ b/src/main/java/com/myce/payment/service/impl/ReservationPaymentServiceImpl.java
@@ -1,0 +1,262 @@
+package com.myce.payment.service.impl;
+
+import com.myce.common.exception.CustomErrorCode;
+import com.myce.common.exception.CustomException;
+import com.myce.expo.dto.TicketQuantityRequest;
+import com.myce.expo.service.TicketService;
+import com.myce.member.dto.MileageUpdateRequest;
+import com.myce.member.service.MemberGradeService;
+import com.myce.member.service.MemberMileageService;
+import com.myce.notification.service.NotificationService;
+import com.myce.payment.dto.PaymentVerifyRequest;
+import com.myce.payment.dto.PaymentVerifyResponse;
+import com.myce.payment.dto.ReservationPaymentVerifyRequest;
+import com.myce.payment.entity.Payment;
+import com.myce.payment.entity.ReservationPaymentInfo;
+import com.myce.payment.entity.type.PaymentStatus;
+import com.myce.payment.repository.PaymentRepository;
+import com.myce.payment.repository.ReservationPaymentInfoRepository;
+import com.myce.payment.service.ReservationPaymentService;
+import com.myce.payment.service.mapper.PaymentMapper;
+import com.myce.payment.service.portone.PortOneApiService;
+import com.myce.qrcode.service.QrCodeService;
+import com.myce.reservation.entity.Reservation;
+import com.myce.reservation.entity.code.UserType;
+import com.myce.reservation.repository.ReservationRepository;
+import com.myce.reservation.service.ReservationService;
+import com.myce.reservation.service.ReserverService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ReservationPaymentServiceImpl implements ReservationPaymentService {
+
+    private final PortOneApiService portOneApiService;
+    private final PaymentRepository paymentRepository;
+    private final ReservationPaymentInfoRepository reservationPaymentInfoRepository;
+    private final ReservationRepository reservationRepository;
+    private final PaymentMapper paymentMapper;
+    private final ReservationService reservationService;
+    private final ReserverService reserverService;
+    private final TicketService ticketService;
+    private final MemberMileageService memberMileageService;
+    private final MemberGradeService memberGradeService;
+    private final QrCodeService qrCodeService;
+    private final NotificationService notificationService;
+
+    @Override
+    @Transactional
+    public PaymentVerifyResponse verifyAndCompleteReservationPayment(ReservationPaymentVerifyRequest request) {
+        log.info("박람회 결제 통합 처리 시작 - reservationId: {}", request.getTargetId());
+        
+        // 1. 기존 결제 검증 로직
+        String accessToken = portOneApiService.getAccessToken();
+        Map<String, Object> portOnePayment = portOneApiService.getPaymentInfo(request.getImpUid(), accessToken);
+        Integer paidAmount = verifyPaymentDetails(request, portOnePayment);
+        
+        // 2. 예약 정보 조회
+        Reservation reservation = reservationRepository.findById(request.getTargetId())
+                .orElseThrow(() -> new CustomException(CustomErrorCode.RESERVATION_NOT_FOUND));
+        
+        // 3. 비회원 적립금 지급 방지
+        if (reservation.getUserType() == UserType.GUEST) {
+            log.info("비회원 예매이므로 적립금을 0으로 설정 ReservationId: {}", reservation.getId());
+            request.setSavedMileage(0);
+        }
+        
+        try {
+            // 4. Payment 엔티티 저장
+            String payMethod = (String) portOnePayment.get("pay_method");
+            Payment payment;
+            if ("card".equals(payMethod)) {
+                payment = paymentMapper.toEntity(convertToPaymentVerifyRequest(request), portOnePayment);
+            } else {
+                payment = paymentMapper.toEntityTransfer(convertToPaymentVerifyRequest(request), portOnePayment);
+            }
+            paymentRepository.save(payment);
+            
+            // 5. ReservationPaymentInfo 저장
+            ReservationPaymentInfo paymentInfo = paymentMapper.toReservationPaymentInfo(
+                    convertToPaymentVerifyRequest(request), reservation, paidAmount, PaymentStatus.SUCCESS);
+            reservationPaymentInfoRepository.save(paymentInfo);
+            
+            // 6. 예약 상태를 CONFIRMED로 변경
+            reservationService.updateStatusToConfirm(request.getTargetId());
+            
+            // 7. 예약자 정보 저장
+            if (request.getReserverInfos() != null && !request.getReserverInfos().isEmpty()) {
+                reserverService.saveReservers(request.getTargetId(), request.getReserverInfos());
+            }
+            
+            // 8. 티켓 수량 감소
+            if (request.getTicketId() != null && request.getQuantity() != null) {
+                TicketQuantityRequest ticketRequest = TicketQuantityRequest.builder()
+                        .ticketId(request.getTicketId())
+                        .quantity(request.getQuantity())
+                        .build();
+                ticketService.updateRemainingQuantity(ticketRequest);
+            }
+            
+            // 9. 마일리지 처리 (회원만)
+            if (reservation.getUserType() == UserType.MEMBER) {
+                Integer usedMileage = request.getUsedMileage() != null ? request.getUsedMileage() : 0;
+                Integer savedMileage = request.getSavedMileage() != null ? request.getSavedMileage() : 0;
+                MileageUpdateRequest mileageRequest = new MileageUpdateRequest(usedMileage, savedMileage);
+                
+                if (usedMileage > 0 || savedMileage > 0) {
+                    memberMileageService.updateMileageForReservation(reservation.getUserId(), mileageRequest);
+                    log.info("마일리지 처리 완료 - 회원ID: {}, 사용: {}, 적립: {}", 
+                            reservation.getUserId(), usedMileage, savedMileage);
+                }
+                
+                // 10. 회원 등급 업데이트
+                memberGradeService.udpateGrade(reservation.getUserId());
+            }
+            
+            // 11. QR 코드 생성 시도 (실패해도 계속 진행)
+            try {
+                qrCodeService.issueQrForReservation(request.getTargetId());
+                log.info("QR 코드 생성 완료 - reservationId: {}", request.getTargetId());
+            } catch (Exception qrError) {
+                log.warn("QR 코드 생성 실패 (스케줄러에서 재시도) - reservationId: {}, 오류: {}", 
+                        request.getTargetId(), qrError.getMessage());
+            }
+            
+            // 12. 결제 완료 알림 발송 (회원만)
+            if (reservation.getUserType() == UserType.MEMBER) {
+                try {
+                    String expoTitle = reservation.getExpo().getTitle();
+                    String paymentAmount = String.format("%,d원", paidAmount);
+                    notificationService.sendPaymentCompleteNotification(
+                        reservation.getUserId(),
+                        reservation.getId(),
+                        expoTitle,
+                        paymentAmount
+                    );
+                    log.info("결제 완료 알림 발송 - 예약 ID: {}, 회원 ID: {}, 금액: {}", 
+                            reservation.getId(), reservation.getUserId(), paymentAmount);
+                } catch (Exception e) {
+                    log.error("결제 완료 알림 발송 실패 - 예약 ID: {}, 오류: {}", 
+                            reservation.getId(), e.getMessage());
+                }
+            }
+            
+            log.info("박람회 결제 통합 처리 완료 - reservationId: {}", request.getTargetId());
+            return paymentMapper.toPaymentVerifyResponse(payment, paymentInfo);
+            
+        } catch (Exception e) {
+            log.error("박람회 결제 통합 처리 실패 - reservationId: {}, 오류: {}", request.getTargetId(), e.getMessage(), e);
+            throw new CustomException(CustomErrorCode.PAYMENT_NOT_PAID);
+        }
+    }
+
+    @Override
+    @Transactional
+    public PaymentVerifyResponse verifyAndCompleteVbankReservationPayment(ReservationPaymentVerifyRequest request) {
+        log.info("박람회 가상계좌 결제 통합 처리 시작 - reservationId: {}", request.getTargetId());
+        
+        // 1. 기존 가상계좌 검증 로직
+        String accessToken = portOneApiService.getAccessToken();
+        Map<String, Object> portOnePayment = portOneApiService.getPaymentInfo(request.getImpUid(), accessToken);
+        Integer paidAmount = verifyVbankDetails(request, portOnePayment);
+        
+        // 2. 예약 정보 조회
+        Reservation reservation = reservationRepository.findById(request.getTargetId())
+                .orElseThrow(() -> new CustomException(CustomErrorCode.RESERVATION_NOT_FOUND));
+        
+        // 3. 비회원 적립금 지급 방지
+        if (reservation.getUserType() == UserType.GUEST) {
+            log.info("비회원 예매이므로 적립금을 0으로 설정 ReservationId: {}", reservation.getId());
+            request.setSavedMileage(0);
+        }
+        
+        try {
+            // 4. Payment 엔티티 저장 (PENDING 상태)
+            Payment payment = paymentMapper.toEntity(convertToPaymentVerifyRequest(request), portOnePayment);
+            paymentRepository.save(payment);
+            
+            // 5. ReservationPaymentInfo 저장 (PENDING 상태)
+            ReservationPaymentInfo paymentInfo = paymentMapper.toReservationPaymentInfo(
+                    convertToPaymentVerifyRequest(request), reservation, paidAmount, PaymentStatus.PENDING);
+            reservationPaymentInfoRepository.save(paymentInfo);
+            
+            // 6. 예약자 정보 저장
+            if (request.getReserverInfos() != null && !request.getReserverInfos().isEmpty()) {
+                reserverService.saveReservers(request.getTargetId(), request.getReserverInfos());
+            }
+            
+            // 7. 티켓 수량 감소
+            if (request.getTicketId() != null && request.getQuantity() != null) {
+                TicketQuantityRequest ticketRequest = TicketQuantityRequest.builder()
+                        .ticketId(request.getTicketId())
+                        .quantity(request.getQuantity())
+                        .build();
+                ticketService.updateRemainingQuantity(ticketRequest);
+            }
+            
+            // 가상계좌는 입금 완료 시 웹훅에서 나머지 처리 (마일리지, 등급, QR 등)
+            
+            log.info("박람회 가상계좌 결제 처리 완료 - reservationId: {}", request.getTargetId());
+            return paymentMapper.toPaymentVerifyResponse(payment, paymentInfo);
+            
+        } catch (Exception e) {
+            log.error("박람회 가상계좌 결제 처리 실패 - reservationId: {}, 오류: {}", request.getTargetId(), e.getMessage(), e);
+            throw new CustomException(CustomErrorCode.PAYMENT_NOT_READY_OR_PAID);
+        }
+    }
+    
+    private PaymentVerifyRequest convertToPaymentVerifyRequest(ReservationPaymentVerifyRequest request) {
+        PaymentVerifyRequest converted = new PaymentVerifyRequest();
+        converted.setImpUid(request.getImpUid());
+        converted.setMerchantUid(request.getMerchantUid());
+        converted.setAmount(request.getAmount());
+        converted.setTargetType(request.getTargetType());
+        converted.setTargetId(request.getTargetId());
+        converted.setUsedMileage(request.getUsedMileage());
+        converted.setSavedMileage(request.getSavedMileage());
+        return converted;
+    }
+    
+    private Integer verifyPaymentDetails(ReservationPaymentVerifyRequest request, Map<String, Object> portOnePayment) {
+        String status = (String) portOnePayment.get("status");
+        Integer paidAmount = (Integer) portOnePayment.get("amount");
+        String merchantUid = (String) portOnePayment.get("merchant_uid");
+
+        if (!"paid".equalsIgnoreCase(status)) {
+            throw new CustomException(CustomErrorCode.PAYMENT_NOT_PAID);
+        }
+        if (!paidAmount.equals(request.getAmount())) {
+            throw new CustomException(CustomErrorCode.PAYMENT_AMOUNT_MISMATCH);
+        }
+        if (!merchantUid.equals(request.getMerchantUid())) {
+            throw new CustomException(CustomErrorCode.PAYMENT_MERCHANT_UID_MISMATCH);
+        }
+        return paidAmount;
+    }
+    
+    private Integer verifyVbankDetails(ReservationPaymentVerifyRequest request, Map<String, Object> portOnePayment) {
+        String status = (String) portOnePayment.get("status");
+        Integer paidAmount = (Integer) portOnePayment.get("amount");
+        String merchantUid = (String) portOnePayment.get("merchant_uid");
+
+        if (!"ready".equalsIgnoreCase(status) && !"paid".equalsIgnoreCase(status)) {
+            log.error("[가상계좌 검증 실패] 포트원 결제 상태가 'ready' 또는 'paid'가 아님: {}", status);
+            throw new CustomException(CustomErrorCode.PAYMENT_NOT_READY_OR_PAID);
+        }
+        if (!paidAmount.equals(request.getAmount())) {
+            log.error("[가상계좌 검증 실패] 결제 금액 불일치. 요청 금액: {}, 실제 금액: {}", request.getAmount(), paidAmount);
+            throw new CustomException(CustomErrorCode.PAYMENT_AMOUNT_MISMATCH);
+        }
+        if (!merchantUid.equals(request.getMerchantUid())) {
+            log.error("[가상계좌 검증 실패] 상점 UID 불일치. 요청 UID: {}, 실제 UID: {}", request.getMerchantUid(), merchantUid);
+            throw new CustomException(CustomErrorCode.PAYMENT_MERCHANT_UID_MISMATCH);
+        }
+        return paidAmount;
+    }
+}

--- a/src/main/java/com/myce/payment/service/verification/impl/PaymentVerificationServiceImpl.java
+++ b/src/main/java/com/myce/payment/service/verification/impl/PaymentVerificationServiceImpl.java
@@ -6,7 +6,16 @@ import com.myce.common.exception.CustomErrorCode;
 import com.myce.common.exception.CustomException;
 import com.myce.member.service.MemberAdService;
 import com.myce.member.service.MemberExpoService;
+import com.myce.member.service.MemberMileageService;
+import com.myce.member.service.MemberGradeService;
+import com.myce.member.dto.MileageUpdateRequest;
 import com.myce.notification.service.NotificationService;
+import com.myce.reservation.service.ReservationService;
+import com.myce.reservation.service.ReserverService;
+import com.myce.reservation.dto.ReserverBulkSaveRequest;
+import com.myce.expo.service.TicketService;
+import com.myce.expo.dto.TicketQuantityRequest;
+import com.myce.qrcode.service.QrCodeService;
 import com.myce.payment.dto.PaymentVerifyRequest;
 import com.myce.payment.dto.PaymentVerifyResponse;
 import com.myce.payment.dto.UserIdentifier;
@@ -53,6 +62,12 @@ public class PaymentVerificationServiceImpl implements PaymentVerificationServic
     private final MemberExpoService memberExpoService;
     private final MemberAdService memberAdService;
     private final NotificationService notificationService;
+    private final MemberMileageService memberMileageService;
+    private final MemberGradeService memberGradeService;
+    private final ReservationService reservationService;
+    private final ReserverService reserverService;
+    private final TicketService ticketService;
+    private final QrCodeService qrCodeService;
 
     // 카드 결제 검증 및 저장
     @Override

--- a/src/main/java/com/myce/payment/service/webhook/impl/PaymentWebhookServiceImpl.java
+++ b/src/main/java/com/myce/payment/service/webhook/impl/PaymentWebhookServiceImpl.java
@@ -16,7 +16,13 @@ import com.myce.payment.service.portone.PortOneApiService;
 import com.myce.payment.service.webhook.PaymentWebhookService;
 import com.myce.reservation.entity.Reservation;
 import com.myce.reservation.entity.code.ReservationStatus;
+import com.myce.reservation.entity.code.UserType;
 import com.myce.reservation.repository.ReservationRepository;
+import com.myce.member.dto.MileageUpdateRequest;
+import com.myce.member.service.MemberMileageService;
+import com.myce.member.service.MemberGradeService;
+import com.myce.qrcode.service.QrCodeService;
+import com.myce.notification.service.NotificationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -37,6 +43,10 @@ public class PaymentWebhookServiceImpl implements PaymentWebhookService {
     private final ExpoPaymentInfoRepository expoPaymentInfoRepository;
     private final ReservationPaymentInfoRepository reservationPaymentInfoRepository;
     private final ReservationRepository reservationRepository;
+    private final MemberMileageService memberMileageService;
+    private final MemberGradeService memberGradeService;
+    private final QrCodeService qrCodeService;
+    private final NotificationService notificationService;
 
     // 가상계좌 입금 처리 웹훅
     @Override
@@ -85,6 +95,58 @@ public class PaymentWebhookServiceImpl implements PaymentWebhookService {
                     .orElseThrow(() -> new CustomException(CustomErrorCode.RESERVATION_NOT_FOUND));
 
                 reservation.updateStatus(ReservationStatus.CONFIRMED);
+                
+                // 가상계좌 입금 완료 시 마일리지 및 등급 업데이트 (회원만)
+                if (reservation.getUserType() == UserType.MEMBER) {
+                    try {
+                        // 마일리지 처리
+                        Integer usedMileage = rpi.getUsedMileage() != null ? rpi.getUsedMileage() : 0;
+                        Integer savedMileage = rpi.getSavedMileage() != null ? rpi.getSavedMileage() : 0;
+                        MileageUpdateRequest mileageRequest = new MileageUpdateRequest(usedMileage, savedMileage);
+                        
+                        if (usedMileage > 0 || savedMileage > 0) {
+                            memberMileageService.updateMileageForReservation(reservation.getUserId(), mileageRequest);
+                            log.info("가상계좌 마일리지 처리 완룼 - 회원ID: {}, 사용: {}, 적립: {}", 
+                                    reservation.getUserId(), usedMileage, savedMileage);
+                        }
+                        
+                        // 회원 등급 업데이트
+                        memberGradeService.udpateGrade(reservation.getUserId());
+                        log.info("가상계좌 회원 등급 업데이트 완료 - 회원ID: {}", reservation.getUserId());
+                        
+                    } catch (Exception e) {
+                        log.error("가상계좌 마일리지/등급 업데이트 실패 - 예약 ID: {}, 오류: {}", 
+                                reservation.getId(), e.getMessage());
+                    }
+                }
+                
+                // QR 코드 생성 시도
+                try {
+                    qrCodeService.issueQrForReservation(reservation.getId());
+                    log.info("가상계좌 QR 코드 생성 완료 - reservationId: {}", reservation.getId());
+                } catch (Exception qrError) {
+                    log.warn("가상계좌 QR 코드 생성 실패 (스케줄러에서 재시도) - reservationId: {}, 오류: {}", 
+                            reservation.getId(), qrError.getMessage());
+                }
+                
+                // 결제 완료 알림 발송 (회원만)
+                if (reservation.getUserType() == UserType.MEMBER) {
+                    try {
+                        String expoTitle = reservation.getExpo().getTitle();
+                        String paymentAmount = String.format("%,d원", paidAmount);
+                        notificationService.sendPaymentCompleteNotification(
+                            reservation.getUserId(),
+                            reservation.getId(),
+                            expoTitle,
+                            paymentAmount
+                        );
+                        log.info("가상계좌 결제 완료 알림 발송 - 예약 ID: {}, 회원 ID: {}, 금액: {}", 
+                                reservation.getId(), reservation.getUserId(), paymentAmount);
+                    } catch (Exception e) {
+                        log.error("가상계좌 결제 완료 알림 발송 실패 - 예약 ID: {}, 오류: {}", 
+                                reservation.getId(), e.getMessage());
+                    }
+                }
                 
                 reservationPaymentInfoRepository.save(rpi);
                 break;

--- a/src/main/java/com/myce/qrcode/service/impl/QrCodeServiceImpl.java
+++ b/src/main/java/com/myce/qrcode/service/impl/QrCodeServiceImpl.java
@@ -13,6 +13,7 @@ import com.myce.expo.entity.Expo;
 import com.myce.expo.repository.AdminCodeRepository;
 import com.myce.notification.service.NotificationService;
 import com.myce.notification.service.SseService;
+import com.myce.notification.service.SupportEmailService;
 import com.myce.qrcode.dto.QrUseResponse;
 import com.myce.qrcode.dto.QrVerifyResponse;
 import com.myce.qrcode.entity.QrCode;
@@ -47,6 +48,7 @@ public class QrCodeServiceImpl implements QrCodeService {
     private final QrResponseMapper qrResponseMapper;
     private final SseService sseService;
     private final NotificationService notificationService;
+    private final SupportEmailService supportEmailService;
 
     @Override
     @Transactional
@@ -280,21 +282,39 @@ public class QrCodeServiceImpl implements QrCodeService {
         try {
             Reservation reservation = reserver.getReservation();
             
-            // MEMBER 타입인 경우에만 알림 전송
-            if (reservation.getUserType() != UserType.MEMBER) {
-                log.debug("알림 건너뜀 - 회원이 아닌 예약자 (UserType: {}, 예약자 ID: {})", 
-                        reservation.getUserType(), reserver.getId());
-                return;
-            }
-            
-            Long memberId = reservation.getUserId();
             String expoTitle = reservation.getExpo().getTitle();
             
-            // NotificationService에서 MongoDB 저장 + SSE 전송 통합 처리
-            notificationService.sendQrIssuedNotification(memberId, reservation.getId(), expoTitle, isReissue);
-            
-            log.info("QR {} 알림 처리 완료 - 예약자 ID: {}, 회원 ID: {}", 
-                    isReissue ? "재발급" : "발급", reserver.getId(), memberId);
+            if (reservation.getUserType() == UserType.MEMBER) {
+                // 회원: 사이트 내 알림 + SSE 전송
+                Long memberId = reservation.getUserId();
+                notificationService.sendQrIssuedNotification(memberId, reservation.getId(), expoTitle, isReissue);
+                log.info("회원 QR {} 알림 처리 완료 - 예약자 ID: {}, 회원 ID: {}", 
+                        isReissue ? "재발급" : "발급", reserver.getId(), memberId);
+            } else {
+                // 비회원: 이메일 알림
+                String subject = String.format("[박람회 QR 코드 %s] %s", 
+                        isReissue ? "재발급" : "발급", expoTitle);
+                String body = String.format(
+                    "안녕하세요 %s님,\n\n" +
+                    "박람회 '%s'의 QR 코드가 %s되었습니다.\n\n" +
+                    "[예매 정보]\n" +
+                    "- 예약자: %s\n" +
+                    "- 예약번호: %s\n" +
+                    "QR 코드는 박람회 당일 입장 시 필요합니다.\n" +
+                    "예매 상세 조회: https://myce.live/guest-reservation\n\n" +
+                    "감사합니다.",
+                    reserver.getName(),
+                    expoTitle,
+                    isReissue ? "재발급" : "발급",
+                    reserver.getName(),
+                    reservation.getReservationCode(),
+                    expoTitle
+                );
+                
+                supportEmailService.sendSupportMail(reserver.getEmail(), subject, body);
+                log.info("비회원 QR {} 이메일 알림 전송 완료 - 예약자 ID: {}, 이메일: {}", 
+                        isReissue ? "재발급" : "발급", reserver.getId(), reserver.getEmail());
+            }
         } catch (Exception e) {
             log.error("QR 발급 알림 처리 실패 - 예약자 ID: {}, 오류: {}", 
                     reserver.getId(), e.getMessage(), e);

--- a/src/main/java/com/myce/qrcode/service/impl/QrCodeServiceImpl.java
+++ b/src/main/java/com/myce/qrcode/service/impl/QrCodeServiceImpl.java
@@ -295,20 +295,19 @@ public class QrCodeServiceImpl implements QrCodeService {
                 String subject = String.format("[박람회 QR 코드 %s] %s", 
                         isReissue ? "재발급" : "발급", expoTitle);
                 String body = String.format(
-                    "안녕하세요 %s님,\n\n" +
-                    "박람회 '%s'의 QR 코드가 %s되었습니다.\n\n" +
-                    "[예매 정보]\n" +
-                    "- 예약자: %s\n" +
-                    "- 예약번호: %s\n" +
-                    "QR 코드는 박람회 당일 입장 시 필요합니다.\n" +
-                    "예매 상세 조회: https://myce.live/guest-reservation\n\n" +
-                    "감사합니다.",
+                    "안녕하세요 %s님,<br><br>" +
+                        "박람회 '%s'의 QR 코드가 %s되었습니다.<br><br>" +
+                        "[예매 정보]<br>" +
+                        "- 예약자: %s<br>" +
+                        "- 예약번호: %s<br>" +
+                        "QR 코드는 박람회 당일 입장 시 필요합니다.<br>" +
+                        "예매 상세 조회: <a href=\"https://myce.live/guest-reservation\">바로가기</a><br><br>" +
+                        "감사합니다.",
                     reserver.getName(),
                     expoTitle,
                     isReissue ? "재발급" : "발급",
                     reserver.getName(),
-                    reservation.getReservationCode(),
-                    expoTitle
+                    reservation.getReservationCode()
                 );
                 
                 supportEmailService.sendSupportMail(reserver.getEmail(), subject, body);

--- a/src/main/java/com/myce/reservation/controller/ReservationController.java
+++ b/src/main/java/com/myce/reservation/controller/ReservationController.java
@@ -96,7 +96,7 @@ public class ReservationController {
     }
 
     // 비회원 예매 조회 (이메일 + 예매번호)
-    @GetMapping("/non-member")
+    @GetMapping("/guest")
     public ResponseEntity<ReservationDetailResponse> getNonMemberReservation(
             @RequestParam String email,
             @RequestParam String reservationCode) {


### PR DESCRIPTION
## 주요 개선사항

  1. 박람회 결제 로직 통합

  - 기존: 결제 성공 후 개별 API 호출 (트랜잭션 미보장)
  - 개선: 하나의 통합 API로 모든 후처리 작업을 트랜잭션으로 관리
  - 엔드포인트: /payment/reservation/verify, /payment/reservation/verify-vbank
  - 처리 항목: 결제검증 → 예약상태 업데이트 → 예약자정보 저장 → 티켓수량 차감 → 마일리지 처리 → 등급 업데이트 → QR
  발급 → 알림 전송

  2. 비회원 QR 알림 연결 

  - 문제: 비회원은 QR 발급시 알림을 받지 못함
  - 해결: 이메일 알림 연동으로 회원과 동일한 서비스 제공
  - 적용: QR 발급/재발급시 비회원에게 자동 이메일 발송

  3. URL 표준화

  - 변경: /non-member → /guest-reservation
  - 적용: 프론트엔드/백엔드 전반에 걸친 일관성 있는 URL 체계