### PR TITLE
feat: 박람회 상세 정렬 수정

### DIFF
--- a/src/main/java/com/myce/expo/repository/BoothRepository.java
+++ b/src/main/java/com/myce/expo/repository/BoothRepository.java
@@ -2,6 +2,7 @@ package com.myce.expo.repository;
 
 import com.myce.expo.entity.Booth;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -13,4 +14,8 @@ public interface BoothRepository extends JpaRepository<Booth, Long> {
     boolean existsByExpoIdAndIsPremiumTrueAndDisplayRank(Long expoId, Integer displayRank);
 
     List<Booth> findAllByExpoId(Long expoId);
+
+    // 프리미엄 부스가 displayRank 순서에 따라 먼저 표시
+    @Query("SELECT b FROM Booth b WHERE b.expo.id = :expoId ORDER BY b.isPremium DESC, b.displayRank ASC")
+    List<Booth> findByExpoIdSorted(Long expoId);
 }

--- a/src/main/java/com/myce/expo/repository/EventRepository.java
+++ b/src/main/java/com/myce/expo/repository/EventRepository.java
@@ -10,5 +10,7 @@ import java.util.List;
 public interface EventRepository extends JpaRepository<Event, Long> {
     List<Event> findAllByExpoId(Long expoId);
 
+    List<Event> findAllByExpoIdOrderByEventDateAscStartTimeAsc(Long expoId);
+
     List<Event> findByEventDateAndStartTimeBetween(LocalDate eventDate, LocalTime startTime, LocalTime endTime);
 }

--- a/src/main/java/com/myce/expo/repository/TicketRepository.java
+++ b/src/main/java/com/myce/expo/repository/TicketRepository.java
@@ -9,5 +9,6 @@ import java.util.List;
 @Repository
 public interface TicketRepository extends JpaRepository<Ticket,Long> {
     List<Ticket> findByExpoId(Long id);
+        List<Ticket> findByExpoIdOrderByTypeAscSaleStartDateAsc(Long expoId);
     List<Ticket> findByExpoIdOrderByCreatedAtAsc(Long expoId);
 }

--- a/src/main/java/com/myce/expo/service/impl/EventServiceImpl.java
+++ b/src/main/java/com/myce/expo/service/impl/EventServiceImpl.java
@@ -78,7 +78,7 @@ public class EventServiceImpl implements EventService {
     @Transactional(readOnly = true)
     public List<EventResponse> getPublicEvents(Long expoId) {
         // 행사 엔티티 목록 조회 (권한 검증 없음)
-        List<Event> events = eventRepository.findAllByExpoId(expoId);
+        List<Event> events = eventRepository.findAllByExpoIdOrderByEventDateAscStartTimeAsc(expoId);
 
         // 행사 엔티티를 응답 dto로 매핑하여 리스트로 반환
         return events.stream()

--- a/src/main/java/com/myce/expo/service/impl/ExpoServiceImpl.java
+++ b/src/main/java/com/myce/expo/service/impl/ExpoServiceImpl.java
@@ -227,10 +227,10 @@ public class ExpoServiceImpl implements ExpoService {
                 .map(expoCategory -> expoCategory.getCategory().getName())
                 .collect(Collectors.toList());
 
-        // 현재 예약자 수 계산
+        // 현재 예약자 수 계산 (총 발행 수량 - 남은 티켓 수)
         List<Ticket> tickets = ticketRepository.findByExpoIdOrderByCreatedAtAsc(expoId);
         int currentReservationCount = tickets.stream()
-                .mapToInt(Ticket::getRemainingQuantity)
+                .mapToInt(ticket -> ticket.getTotalQuantity() - ticket.getRemainingQuantity())
                 .sum();
 
         // 주최자 상세 정보 빌드

--- a/src/main/java/com/myce/expo/service/impl/ExpoServiceImpl.java
+++ b/src/main/java/com/myce/expo/service/impl/ExpoServiceImpl.java
@@ -402,7 +402,7 @@ public class ExpoServiceImpl implements ExpoService {
             throw new CustomException(CustomErrorCode.EXPO_NOT_PUBLISHED);
         }
 
-        List<Booth> booths = boothRepository.findAllByExpoId(expoId);
+                List<Booth> booths = boothRepository.findByExpoIdSorted(expoId);
 
         return booths.stream()
                 .map(boothMapper::toResponse)

--- a/src/main/java/com/myce/expo/service/impl/TicketServiceImpl.java
+++ b/src/main/java/com/myce/expo/service/impl/TicketServiceImpl.java
@@ -19,7 +19,7 @@ public class TicketServiceImpl implements TicketService {
 
   @Override
   public List<TicketSummaryResponse> getTickets(Long expoId) {
-    List<Ticket> tickets = ticketRepository.findByExpoId(expoId);
+            List<Ticket> tickets = ticketRepository.findByExpoIdOrderByTypeAscSaleStartDateAsc(expoId);
 
     return tickets.stream()
         .map(t -> TicketSummaryResponse.builder()


### PR DESCRIPTION
### 박람회 상세
* 예약 현황 수 수정
* 부스 정보 불러오기 프리미엄 여부에 따라 정렬
* 이벤트 정보 eventDate, startTime 기준으로 정렬
* 티켓 정보 얼리버드, 판매기간 정렬