### PR TITLE
[CRM-298] fix: cancelDeny 상태값 수정

### DIFF
--- a/src/main/java/com/myce/advertisement/entity/Advertisement.java
+++ b/src/main/java/com/myce/advertisement/entity/Advertisement.java
@@ -120,9 +120,9 @@ public class Advertisement {
         if (this.status != AdvertisementStatus.PENDING_CANCEL) {
             throw new CustomException(CustomErrorCode.INVALID_ADVERTISEMENT_STATUS);
         }
-        if (this.displayEndDate.isBefore(LocalDate.now())) {
+        if (!this.displayEndDate.isAfter(LocalDate.now())) {
             this.status = AdvertisementStatus.COMPLETED;
-        }else if(this.displayStartDate.isBefore(LocalDate.now())){
+        }else if(!this.displayStartDate.isAfter(LocalDate.now())){
             this.status = AdvertisementStatus.PUBLISHED;
         }else{
             this.status = AdvertisementStatus.PENDING_PUBLISH;

--- a/src/main/java/com/myce/advertisement/service/impl/PlatformCurrentAdServiceImpl.java
+++ b/src/main/java/com/myce/advertisement/service/impl/PlatformCurrentAdServiceImpl.java
@@ -76,8 +76,6 @@ public class PlatformCurrentAdServiceImpl implements PlatformCurrentAdService {
         Refund refund = refundRepository.findByPayment(payment)
                 .orElseThrow(() -> new CustomException(CustomErrorCode.REFUND_NOT_FOUND));
 
-        refund.updateToRefund();
-
         if(refund.getIsPartial()){
             adPayment.setStatus(PaymentStatus.PARTIAL_REFUNDED);
         }else{
@@ -86,7 +84,9 @@ public class PlatformCurrentAdServiceImpl implements PlatformCurrentAdService {
         adPayment.setUpdatedAt(LocalDateTime.now());
 
         log.info("cancelCurrent - Advertisement : {}, Payment : {}", ad, payment);
+        log.info("refund.isPartial = {}", refund.getIsPartial());
 
+        refund.updateToRefund();
         ad.cancel();
     }
 }


### PR DESCRIPTION
### 구현 기능
* Advertisement의 cancelDeny 상태값을 당일도 포함하도록 수정