### PR TITLE
[CRM-299] fix: 예매 및 QR 플로우 보완 

### DIFF
--- a/src/main/java/com/myce/expo/service/impl/PlatformExpoManageServiceImpl.java
+++ b/src/main/java/com/myce/expo/service/impl/PlatformExpoManageServiceImpl.java
@@ -104,12 +104,10 @@ public class PlatformExpoManageServiceImpl implements PlatformExpoManageService 
                     return new CustomException(CustomErrorCode.EXPO_NOT_FOUND);
                 });
         
-        // 3. 수수료 설정 조회
-        ExpoFeeSetting feeSetting = expoFeeSettingRepository.findAll()
-                .stream()
-                .findFirst()
+        // 3. 활성화된 수수료 설정 조회
+        ExpoFeeSetting feeSetting = expoFeeSettingRepository.findByIsActiveTrue()
                 .orElseThrow(() -> {
-                    log.error("박람회 수수료 설정이 존재하지 않음");
+                    log.error("활성화된 박람회 수수료 설정이 존재하지 않음");
                     return new CustomException(CustomErrorCode.FEE_SETTING_NOT_FOUND);
                 });
         
@@ -409,12 +407,10 @@ public class PlatformExpoManageServiceImpl implements PlatformExpoManageService 
             throw new CustomException(CustomErrorCode.INVALID_EXPO_STATUS);
         }
         
-        // 4. 수수료 설정 조회
-        ExpoFeeSetting feeSetting = expoFeeSettingRepository.findAll()
-                .stream()
-                .findFirst()
+        // 4. 활성화된 수수료 설정 조회
+        ExpoFeeSetting feeSetting = expoFeeSettingRepository.findByIsActiveTrue()
                 .orElseThrow(() -> {
-                    log.error("박람회 수수료 설정이 존재하지 않음");
+                    log.error("활성화된 박람회 수수료 설정이 존재하지 않음");
                     return new CustomException(CustomErrorCode.FEE_SETTING_NOT_FOUND);
                 });
         

--- a/src/main/java/com/myce/member/service/impl/MemberExpoServiceImpl.java
+++ b/src/main/java/com/myce/member/service/impl/MemberExpoServiceImpl.java
@@ -380,7 +380,7 @@ public class MemberExpoServiceImpl implements MemberExpoService {
                     .isReserverListView(true)
                     .isPaymentView(true)
                     .isEmailLogView(true)
-                    .isOperationsConfigUpdate(true)
+                    .isOperationsConfigUpdate(false)
                     .isInquiryView(true)
                     .build();
             adminPermissions.add(permission);

--- a/src/main/java/com/myce/reservation/dto/ReservationDetailResponse.java
+++ b/src/main/java/com/myce/reservation/dto/ReservationDetailResponse.java
@@ -48,6 +48,7 @@ public class ReservationDetailResponse {
     public static class ReservationInfo {
         private Long reservationId;
         private String reservationCode;
+        private String status;
         private Integer quantity;
         private LocalDateTime createdAt;
         private Integer ticketPrice;
@@ -68,6 +69,8 @@ public class ReservationDetailResponse {
         private String phone;
         private String email;
         private String qrCodeUrl;
+        private String qrStatus;
+        private LocalDateTime qrUsedAt;
     }
     
     @Getter

--- a/src/main/java/com/myce/reservation/service/mapper/ReservationDetailMapper.java
+++ b/src/main/java/com/myce/reservation/service/mapper/ReservationDetailMapper.java
@@ -60,6 +60,7 @@ public class ReservationDetailMapper {
         return ReservationDetailResponse.ReservationInfo.builder()
                 .reservationId(reservation.getId())
                 .reservationCode(reservation.getReservationCode())
+                .status(reservation.getStatus().name())
                 .quantity(reservation.getQuantity())
                 .createdAt(reservation.getCreatedAt())
                 .ticketPrice(reservation.getTicket().getPrice())
@@ -83,6 +84,9 @@ public class ReservationDetailMapper {
                     String qrCodeUrl = qrCodeOpt
                             .map(QrCode::getQrImageUrl)
                             .orElse(null);
+                    String qrStatus = qrCodeOpt
+                            .map(qrCode -> qrCode.getStatus().name())
+                            .orElse("NOT_ISSUED");
                     
                     return ReservationDetailResponse.ReserverInfo.builder()
                             .reserverId(reserver.getId())
@@ -91,6 +95,8 @@ public class ReservationDetailMapper {
                             .phone(reserver.getPhone())
                             .email(reserver.getEmail())
                             .qrCodeUrl(qrCodeUrl)
+                            .qrStatus(qrStatus)
+                            .qrUsedAt(qrCodeOpt.map(QrCode::getUsedAt).orElse(null))
                             .build();
                 })
                 .collect(Collectors.toList());


### PR DESCRIPTION
admin_code 발급시 운영설정 false

엑스포 신청할떄 결제 영수증 생성 로직 수정 ( 실제 is_active fee setting 가져오게)

승인대기/결제대기에서 취소시 결제영수증/환불영수증 비활성화

QR코드  입장권 티켓 안에 STATUS표시할수있도록 수정

CONFIRM_PENDING 주황

COMFIRMED 초록

APPROVE 주황색

ACTIVE 초록색

USED 회색

EXPIRED  빨간색

예약 정보 입력시 에러 표시 수정 올바른 전화번호를 입력 해주세요.