### PR TITLE
[CRM-119] fix: 가상계좌 웹훅 수정하면서 예매 오류들 수정

### DIFF
--- a/src/main/java/com/myce/expo/service/TicketService.java
+++ b/src/main/java/com/myce/expo/service/TicketService.java
@@ -10,4 +10,7 @@ public interface TicketService {
 
   // 티켓 수량 빼기
   void updateRemainingQuantity(TicketQuantityRequest request);
+  
+  // 티켓 수량 복구 (가상계좌 만료 시)
+  void restoreTicketQuantity(Long ticketId, Integer quantity);
 }

--- a/src/main/java/com/myce/expo/service/impl/TicketServiceImpl.java
+++ b/src/main/java/com/myce/expo/service/impl/TicketServiceImpl.java
@@ -44,4 +44,13 @@ public class TicketServiceImpl implements TicketService {
 
     ticket.updateRemainingQuantity(ticket.getRemainingQuantity() - request.getQuantity());
   }
+  
+  @Transactional
+  @Override
+  public void restoreTicketQuantity(Long ticketId, Integer quantity) {
+    Ticket ticket = ticketRepository.findById(ticketId)
+        .orElseThrow(() -> new CustomException(CustomErrorCode.TICKET_NOT_EXIST));
+
+    ticket.updateRemainingQuantity(ticket.getRemainingQuantity() + quantity);
+  }
 }

--- a/src/main/java/com/myce/payment/dto/ReservationPaymentVerifyRequest.java
+++ b/src/main/java/com/myce/payment/dto/ReservationPaymentVerifyRequest.java
@@ -24,4 +24,5 @@ public class ReservationPaymentVerifyRequest {
     private List<ReserverBulkSaveRequest.ReserverSaveInfo> reserverInfos;
     private Long ticketId;
     private Integer quantity;
+    private String sessionId; // Redis 세션 ID 추가
 }

--- a/src/main/java/com/myce/payment/service/impl/ReservationPaymentServiceImpl.java
+++ b/src/main/java/com/myce/payment/service/impl/ReservationPaymentServiceImpl.java
@@ -74,12 +74,22 @@ public class ReservationPaymentServiceImpl implements ReservationPaymentService 
         
         // 2. Redis에서 결제 세션 검증 및 DB 저장
         
-        // Redis에서 결제 세션 검증 (임시 ID 0으로 확인)
-        PreReservationCacheDto cachedDto = preReservationRepository.findById(0L);
-        if (cachedDto == null) {
-            log.error("결제 세션 만료 또는 유효하지 않음");
+        // Redis에서 결제 세션 검증 (세션 ID 필수)
+        if (request.getSessionId() == null) {
+            log.error("세션 ID가 제공되지 않음");
             throw new CustomException(CustomErrorCode.PAYMENT_SESSION_EXPIRED);
         }
+        
+        com.myce.reservation.repository.impl.PreReservationRepositoryImpl repoImpl = 
+            (com.myce.reservation.repository.impl.PreReservationRepositoryImpl) preReservationRepository;
+        PreReservationCacheDto cachedDto = repoImpl.findBySessionId(request.getSessionId());
+        
+        if (cachedDto == null) {
+            log.error("결제 세션 만료 또는 유효하지 않음 - 세션 ID: {}", request.getSessionId());
+            throw new CustomException(CustomErrorCode.PAYMENT_SESSION_EXPIRED);
+        }
+        
+        log.info("세션 ID로 Redis 조회 성공: {} - userType: {}", request.getSessionId(), cachedDto.getUserType());
         
         // Redis DTO에서 엔티티 재조회하여 DB에 저장
         Expo expo = expoRepository.findById(cachedDto.getExpoId())
@@ -207,10 +217,12 @@ public class ReservationPaymentServiceImpl implements ReservationPaymentService 
             
             // 13. Redis에서 결제 세션 정리
             try {
-                preReservationRepository.delete(0L);
-                log.info("결제 완료 후 Redis 세션 정리 완료 - reservationId: {}", reservation.getId());
+                repoImpl.deleteBySessionId(request.getSessionId());
+                log.info("결제 완료 후 Redis 세션 정리 완료 - 세션 ID: {}, reservationId: {}", 
+                        request.getSessionId(), reservation.getId());
             } catch (Exception e) {
-                log.warn("Redis 세션 정리 실패 - reservationId: {}, 오류: {}", reservation.getId(), e.getMessage());
+                log.warn("Redis 세션 정리 실패 - reservationId: {}, 세션 ID: {}, 오류: {}", 
+                        reservation.getId(), request.getSessionId(), e.getMessage());
             }
             
             log.info("박람회 결제 통합 처리 완료 - reservationId: {}", reservation.getId());
@@ -234,12 +246,22 @@ public class ReservationPaymentServiceImpl implements ReservationPaymentService 
         
         // 2. Redis에서 결제 세션 검증 및 DB 저장
         
-        // Redis에서 결제 세션 검증 (임시 ID 0으로 확인)
-        PreReservationCacheDto cachedDto = preReservationRepository.findById(0L);
-        if (cachedDto == null) {
-            log.error("결제 세션 만료 또는 유효하지 않음");
+        // Redis에서 결제 세션 검증 (세션 ID 필수)
+        if (request.getSessionId() == null) {
+            log.error("가상계좌 - 세션 ID가 제공되지 않음");
             throw new CustomException(CustomErrorCode.PAYMENT_SESSION_EXPIRED);
         }
+        
+        com.myce.reservation.repository.impl.PreReservationRepositoryImpl repoImpl = 
+            (com.myce.reservation.repository.impl.PreReservationRepositoryImpl) preReservationRepository;
+        PreReservationCacheDto cachedDto = repoImpl.findBySessionId(request.getSessionId());
+        
+        if (cachedDto == null) {
+            log.error("가상계좌 결제 세션 만료 또는 유효하지 않음 - 세션 ID: {}", request.getSessionId());
+            throw new CustomException(CustomErrorCode.PAYMENT_SESSION_EXPIRED);
+        }
+        
+        log.info("가상계좌 - 세션 ID로 Redis 조회 성공: {} - userType: {}", request.getSessionId(), cachedDto.getUserType());
         
         // Redis DTO에서 엔티티 재조회하여 DB에 저장
         Expo expo = expoRepository.findById(cachedDto.getExpoId())
@@ -314,10 +336,12 @@ public class ReservationPaymentServiceImpl implements ReservationPaymentService 
             
             // 8. Redis에서 결제 세션 정리
             try {
-                preReservationRepository.delete(0L);
-                log.info("가상계좌 결제 완료 후 Redis 세션 정리 완료 - reservationId: {}", reservation.getId());
+                repoImpl.deleteBySessionId(request.getSessionId());
+                log.info("가상계좌 결제 완료 후 Redis 세션 정리 완료 - 세션 ID: {}, reservationId: {}", 
+                        request.getSessionId(), reservation.getId());
             } catch (Exception e) {
-                log.warn("Redis 세션 정리 실패 - reservationId: {}, 오류: {}", reservation.getId(), e.getMessage());
+                log.warn("가상계좌 Redis 세션 정리 실패 - reservationId: {}, 세션 ID: {}, 오류: {}", 
+                        reservation.getId(), request.getSessionId(), e.getMessage());
             }
             
             // 가상계좌는 입금 완료 시 웹훅에서 나머지 처리 (마일리지, 등급, QR 등)

--- a/src/main/java/com/myce/payment/service/impl/ReservationPaymentServiceImpl.java
+++ b/src/main/java/com/myce/payment/service/impl/ReservationPaymentServiceImpl.java
@@ -32,6 +32,7 @@ import com.myce.reservation.repository.PreReservationRepository;
 import com.myce.reservation.repository.ReservationRepository;
 import com.myce.reservation.service.ReservationService;
 import com.myce.reservation.service.ReserverService;
+import com.myce.reservation.service.GuestReservationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -59,6 +60,7 @@ public class ReservationPaymentServiceImpl implements ReservationPaymentService 
     private final MemberGradeService memberGradeService;
     private final QrCodeService qrCodeService;
     private final NotificationService notificationService;
+    private final GuestReservationService guestReservationService;
 
     @Override
     @Transactional
@@ -124,9 +126,30 @@ public class ReservationPaymentServiceImpl implements ReservationPaymentService 
             // 6. 예약 상태를 CONFIRMED로 변경
             reservationService.updateStatusToConfirm(reservation.getId());
             
-            // 7. 예약자 정보 저장
+            // 7. 예약자 정보 저장 및 비회원 Guest ID 생성
             if (request.getReserverInfos() != null && !request.getReserverInfos().isEmpty()) {
                 reserverService.saveReservers(reservation.getId(), request.getReserverInfos());
+                
+                // 비회원인 경우 Guest 엔티티 생성 및 reservation의 userId 업데이트
+                if (reservation.getUserType() == UserType.GUEST) {
+                    com.myce.reservation.dto.GuestReservationRequest guestRequest = 
+                        new com.myce.reservation.dto.GuestReservationRequest();
+                    guestRequest.setReservationId(reservation.getId());
+                    guestRequest.setReserverInfos(request.getReserverInfos().stream()
+                        .map(info -> {
+                            com.myce.reservation.dto.ReserverInfo reserverInfo = 
+                                new com.myce.reservation.dto.ReserverInfo();
+                            reserverInfo.setName(info.getName());
+                            reserverInfo.setEmail(info.getEmail());
+                            reserverInfo.setPhone(info.getPhone());
+                            reserverInfo.setBirth(info.getBirth());
+                            reserverInfo.setGender(info.getGender());
+                            return reserverInfo;
+                        }).collect(java.util.stream.Collectors.toList()));
+                    
+                    guestReservationService.updateGuestId(guestRequest);
+                    log.info("비회원 Guest ID 생성 및 업데이트 완료 - reservationId: {}", reservation.getId());
+                }
             }
             
             // 8. 티켓 수량 감소
@@ -254,9 +277,30 @@ public class ReservationPaymentServiceImpl implements ReservationPaymentService 
                     paymentRequest, reservation, paidAmount, PaymentStatus.PENDING);
             reservationPaymentInfoRepository.save(paymentInfo);
             
-            // 6. 예약자 정보 저장
+            // 6. 예약자 정보 저장 및 비회원 Guest ID 생성
             if (request.getReserverInfos() != null && !request.getReserverInfos().isEmpty()) {
                 reserverService.saveReservers(reservation.getId(), request.getReserverInfos());
+                
+                // 비회원인 경우 Guest 엔티티 생성 및 reservation의 userId 업데이트
+                if (reservation.getUserType() == UserType.GUEST) {
+                    com.myce.reservation.dto.GuestReservationRequest guestRequest = 
+                        new com.myce.reservation.dto.GuestReservationRequest();
+                    guestRequest.setReservationId(reservation.getId());
+                    guestRequest.setReserverInfos(request.getReserverInfos().stream()
+                        .map(info -> {
+                            com.myce.reservation.dto.ReserverInfo reserverInfo = 
+                                new com.myce.reservation.dto.ReserverInfo();
+                            reserverInfo.setName(info.getName());
+                            reserverInfo.setEmail(info.getEmail());
+                            reserverInfo.setPhone(info.getPhone());
+                            reserverInfo.setBirth(info.getBirth());
+                            reserverInfo.setGender(info.getGender());
+                            return reserverInfo;
+                        }).collect(java.util.stream.Collectors.toList()));
+                    
+                    guestReservationService.updateGuestId(guestRequest);
+                    log.info("비회원 Guest ID 생성 및 업데이트 완료 (가상계좌) - reservationId: {}", reservation.getId());
+                }
             }
             
             // 7. 티켓 수량 감소

--- a/src/main/java/com/myce/payment/service/impl/ReservationPaymentServiceImpl.java
+++ b/src/main/java/com/myce/payment/service/impl/ReservationPaymentServiceImpl.java
@@ -209,9 +209,33 @@ public class ReservationPaymentServiceImpl implements ReservationPaymentService 
         Map<String, Object> portOnePayment = portOneApiService.getPaymentInfo(request.getImpUid(), accessToken);
         Integer paidAmount = verifyVbankDetails(request, portOnePayment);
         
-        // 2. 예약 정보 조회
-        Reservation reservation = reservationRepository.findById(request.getTargetId())
-                .orElseThrow(() -> new CustomException(CustomErrorCode.RESERVATION_NOT_FOUND));
+        // 2. Redis에서 결제 세션 검증 및 DB 저장
+        
+        // Redis에서 결제 세션 검증 (임시 ID 0으로 확인)
+        PreReservationCacheDto cachedDto = preReservationRepository.findById(0L);
+        if (cachedDto == null) {
+            log.error("결제 세션 만료 또는 유효하지 않음");
+            throw new CustomException(CustomErrorCode.PAYMENT_SESSION_EXPIRED);
+        }
+        
+        // Redis DTO에서 엔티티 재조회하여 DB에 저장
+        Expo expo = expoRepository.findById(cachedDto.getExpoId())
+                .orElseThrow(() -> new CustomException(CustomErrorCode.EXPO_NOT_EXIST));
+        Ticket ticket = ticketRepository.findById(cachedDto.getTicketId())
+                .orElseThrow(() -> new CustomException(CustomErrorCode.TICKET_NOT_EXIST));
+        
+        Reservation newReservation = Reservation.builder()
+                .expo(expo)
+                .ticket(ticket)
+                .reservationCode(cachedDto.getReservationCode())
+                .userType(cachedDto.getUserType())
+                .userId(cachedDto.getUserId())
+                .quantity(cachedDto.getQuantity())
+                .status(ReservationStatus.CONFIRMED_PENDING)
+                .build();
+        
+        Reservation reservation = reservationRepository.save(newReservation);
+        log.info("Redis 세션에서 DB 저장 완료 - reservationId: {}", reservation.getId());
         
         // 3. 비회원 적립금 지급 방지
         if (reservation.getUserType() == UserType.GUEST) {
@@ -221,17 +245,18 @@ public class ReservationPaymentServiceImpl implements ReservationPaymentService 
         
         try {
             // 4. Payment 엔티티 저장 (PENDING 상태)
-            Payment payment = paymentMapper.toEntity(convertToPaymentVerifyRequest(request), portOnePayment);
+            PaymentVerifyRequest paymentRequest = convertToPaymentVerifyRequest(request, reservation.getId());
+            Payment payment = paymentMapper.toEntity(paymentRequest, portOnePayment);
             paymentRepository.save(payment);
             
             // 5. ReservationPaymentInfo 저장 (PENDING 상태)
             ReservationPaymentInfo paymentInfo = paymentMapper.toReservationPaymentInfo(
-                    convertToPaymentVerifyRequest(request), reservation, paidAmount, PaymentStatus.PENDING);
+                    paymentRequest, reservation, paidAmount, PaymentStatus.PENDING);
             reservationPaymentInfoRepository.save(paymentInfo);
             
             // 6. 예약자 정보 저장
             if (request.getReserverInfos() != null && !request.getReserverInfos().isEmpty()) {
-                reserverService.saveReservers(request.getTargetId(), request.getReserverInfos());
+                reserverService.saveReservers(reservation.getId(), request.getReserverInfos());
             }
             
             // 7. 티켓 수량 감소
@@ -243,13 +268,21 @@ public class ReservationPaymentServiceImpl implements ReservationPaymentService 
                 ticketService.updateRemainingQuantity(ticketRequest);
             }
             
+            // 8. Redis에서 결제 세션 정리
+            try {
+                preReservationRepository.delete(0L);
+                log.info("가상계좌 결제 완료 후 Redis 세션 정리 완료 - reservationId: {}", reservation.getId());
+            } catch (Exception e) {
+                log.warn("Redis 세션 정리 실패 - reservationId: {}, 오류: {}", reservation.getId(), e.getMessage());
+            }
+            
             // 가상계좌는 입금 완료 시 웹훅에서 나머지 처리 (마일리지, 등급, QR 등)
             
-            log.info("박람회 가상계좌 결제 처리 완료 - reservationId: {}", request.getTargetId());
+            log.info("박람회 가상계좌 결제 처리 완료 - reservationId: {}", reservation.getId());
             return paymentMapper.toPaymentVerifyResponse(payment, paymentInfo);
             
         } catch (Exception e) {
-            log.error("박람회 가상계좌 결제 처리 실패 - reservationId: {}, 오류: {}", request.getTargetId(), e.getMessage(), e);
+            log.error("박람회 가상계좌 결제 처리 실패 - reservationId: {}, 오류: {}", reservation.getId(), e.getMessage(), e);
             throw new CustomException(CustomErrorCode.PAYMENT_NOT_READY_OR_PAID);
         }
     }

--- a/src/main/java/com/myce/reservation/controller/ReservationController.java
+++ b/src/main/java/com/myce/reservation/controller/ReservationController.java
@@ -83,8 +83,19 @@ public class ReservationController {
     }
 
     @GetMapping("/payment-summary")
-    public ResponseEntity<ReservationPaymentSummaryResponse> getPaymentSummary(@RequestParam Long preReservationId){
-        ReservationPaymentSummaryResponse response = reservationService.getPaymentSummary(preReservationId);
+    public ResponseEntity<ReservationPaymentSummaryResponse> getPaymentSummary(
+            @RequestParam Long preReservationId,
+            @RequestParam(required = false) String sessionId){
+        
+        ReservationPaymentSummaryResponse response;
+        
+        // 세션 ID가 제공되면 세션 기반 조회, 아니면 기존 방식
+        if (sessionId != null && !sessionId.trim().isEmpty()) {
+            response = reservationService.getPaymentSummaryBySessionId(sessionId);
+        } else {
+            response = reservationService.getPaymentSummary(preReservationId);
+        }
+        
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/myce/reservation/dto/PreReservationResponse.java
+++ b/src/main/java/com/myce/reservation/dto/PreReservationResponse.java
@@ -9,4 +9,10 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class PreReservationResponse {
   private Long reservationId;
+  private String sessionId; // Redis 세션 ID 추가
+  
+  // 기존 생성자 유지
+  public PreReservationResponse(Long reservationId) {
+    this.reservationId = reservationId;
+  }
 }

--- a/src/main/java/com/myce/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/myce/reservation/repository/ReservationRepository.java
@@ -233,4 +233,7 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
             """)
     Optional<Reservation> findByReservationCodeAndEmail(@Param("reservationCode") String reservationCode, 
                                                         @Param("email") String email);
+    
+    // 가상계좌 만료 처리용
+    List<Reservation> findByStatusAndCreatedAtBefore(ReservationStatus status, LocalDateTime createdAt);
 }

--- a/src/main/java/com/myce/reservation/repository/impl/PreReservationRepositoryImpl.java
+++ b/src/main/java/com/myce/reservation/repository/impl/PreReservationRepositoryImpl.java
@@ -4,10 +4,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.myce.reservation.dto.PreReservationCacheDto;
 import com.myce.reservation.repository.PreReservationRepository;
 import java.util.concurrent.TimeUnit;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
 
+@Slf4j
 @Repository
 @RequiredArgsConstructor
 public class PreReservationRepositoryImpl implements PreReservationRepository {
@@ -18,10 +21,36 @@ public class PreReservationRepositoryImpl implements PreReservationRepository {
     private final ObjectMapper objectMapper;
 
     @Override
+    @Deprecated
     public void save(PreReservationCacheDto cacheDto, int limitTime) {
-        // 임시 ID 0으로 Redis 저장
-        String key = String.format(KEY_FORMAT, 0L);
+        // 더 이상 사용하지 않음 - saveWithUniqueKey 사용
+        log.warn("Deprecated save method called - use saveWithUniqueKey instead");
+        String sessionId = saveWithUniqueKey(cacheDto, limitTime);
+        log.info("Fallback to saveWithUniqueKey - sessionId: {}", sessionId);
+    }
+    
+    // 고유한 세션 ID로 저장하는 새로운 메서드
+    public String saveWithUniqueKey(PreReservationCacheDto cacheDto, int limitTime) {
+        String sessionId = UUID.randomUUID().toString();
+        String key = "reservation:session:" + sessionId;
         redisTemplate.opsForValue().set(key, cacheDto, limitTime, TimeUnit.MINUTES);
+        return sessionId;
+    }
+    
+    // 세션 ID로 조회하는 메서드
+    public PreReservationCacheDto findBySessionId(String sessionId) {
+        String key = "reservation:session:" + sessionId;
+        Object result = redisTemplate.opsForValue().get(key);
+        if (result == null) {
+            return null;
+        }
+        return objectMapper.convertValue(result, PreReservationCacheDto.class);
+    }
+    
+    // 세션 ID로 삭제하는 메서드
+    public void deleteBySessionId(String sessionId) {
+        String key = "reservation:session:" + sessionId;
+        redisTemplate.delete(key);
     }
 
     @Override

--- a/src/main/java/com/myce/reservation/service/Impl/ReservationServiceImpl.java
+++ b/src/main/java/com/myce/reservation/service/Impl/ReservationServiceImpl.java
@@ -201,34 +201,42 @@ public class ReservationServiceImpl implements ReservationService {
                 .status(ReservationStatus.CONFIRMED_PENDING)
                 .build();
 
-        // DB에는 저장하지 않고 Redis에만 10분 TTL로 저장 (임시 ID = 0)
+        // DB에는 저장하지 않고 Redis에만 10분 TTL로 저장 (모든 예매가 고유한 세션 ID 사용)
         try {
-            preReservationRepository.save(cacheDto, 10);
-            log.info("결제 세션 Redis 저장 완료 (DB 저장 안함) - reservationCode: {}", reservationCode);
+            // PreReservationRepositoryImpl을 직접 캐스팅하여 새로운 메서드 사용
+            com.myce.reservation.repository.impl.PreReservationRepositoryImpl repoImpl = 
+                (com.myce.reservation.repository.impl.PreReservationRepositoryImpl) preReservationRepository;
+            String sessionId = repoImpl.saveWithUniqueKey(cacheDto, 10);
+            
+            String userTypeInfo = request.getUserType() == UserType.MEMBER ? "회원" : "비회원";
+            log.info("결제 세션 Redis 저장 완료 ({}) - 세션 ID: {}, reservationCode: {}", 
+                    userTypeInfo, sessionId, reservationCode);
             
             // 저장 직후 바로 조회해서 검증
-            PreReservationCacheDto testRead = preReservationRepository.findById(0L);
+            PreReservationCacheDto testRead = repoImpl.findBySessionId(sessionId);
             if (testRead != null) {
-                log.info("Redis 저장 검증 성공 - 조회된 reservationCode: {}", testRead.getReservationCode());
+                log.info("Redis 저장 검증 성공 ({}) - 세션 ID: {}, reservationCode: {}", 
+                        userTypeInfo, sessionId, testRead.getReservationCode());
             } else {
-                log.error("Redis 저장 검증 실패 - 바로 조회했는데 null 반환");
+                log.error("Redis 저장 검증 실패 ({}) - 세션 ID: {}", userTypeInfo, sessionId);
             }
+            
+            // 세션 ID와 함께 반환 (reservationId는 0)
+            return new PreReservationResponse(0L, sessionId);
         } catch (Exception e) {
             log.error("결제 세션 Redis 저장 실패 - reservationCode: {}, 오류: {}", reservationCode, e.getMessage());
             throw new CustomException(CustomErrorCode.RESERVATION_CODE_GENERATION_FAILED);
         }
-
-        // 임시 ID 0 반환
-        return new PreReservationResponse(0L);
     }
 
     @Override
     public ReservationPaymentSummaryResponse getPaymentSummary(Long reservationId) {
         log.info("getPaymentSummary 호출 - reservationId: {}", reservationId);
         
-        // reservationId가 0이면 Redis에서 조회
+        // reservationId가 0이면 Redis에서 조회 (하지만 이제는 세션 ID가 필요)
         if (reservationId == 0L) {
-            log.info("Redis에서 캐시 데이터 조회 시도");
+            log.info("Redis에서 캐시 데이터 조회 시도 - reservationId: 0 (세션 ID 필요)");
+            // 세션 ID가 없으면 기존 방식으로 폴백
             PreReservationCacheDto cachedDto = preReservationRepository.findById(0L);
             
             if (cachedDto == null) {
@@ -261,6 +269,39 @@ public class ReservationServiceImpl implements ReservationService {
         String ticketName = "[" + ticketType + "] " + ticket.getName();
 
         return reservationMapper.toPaymentSummary(ticket, ticketName, reservation.getQuantity());
+    }
+
+    @Override
+    public ReservationPaymentSummaryResponse getPaymentSummaryBySessionId(String sessionId) {
+        log.info("getPaymentSummaryBySessionId 호출 - sessionId: {}", sessionId);
+        
+        if (sessionId == null) {
+            log.error("세션 ID가 제공되지 않음");
+            throw new CustomException(CustomErrorCode.RESERVATION_NOT_FOUND);
+        }
+        
+        // Redis에서 세션 ID로 조회
+        com.myce.reservation.repository.impl.PreReservationRepositoryImpl repoImpl = 
+            (com.myce.reservation.repository.impl.PreReservationRepositoryImpl) preReservationRepository;
+        PreReservationCacheDto cachedDto = repoImpl.findBySessionId(sessionId);
+        
+        if (cachedDto == null) {
+            log.error("Redis에서 캐시 데이터를 찾을 수 없음 - 세션 ID: {}, TTL 만료 가능성", sessionId);
+            throw new CustomException(CustomErrorCode.RESERVATION_NOT_FOUND);
+        }
+        
+        log.info("Redis에서 캐시 데이터 조회 성공 - 세션 ID: {}, reservationCode: {}", 
+                sessionId, cachedDto.getReservationCode());
+        
+        Ticket ticket = ticketRepository.findById(cachedDto.getTicketId())
+            .orElseThrow(() -> new CustomException(CustomErrorCode.TICKET_NOT_EXIST));
+        
+        // 티켓 타입
+        String ticketType = ticket.getType().toString();
+        // 티켓 이름
+        String ticketName = "[" + ticketType + "] " + ticket.getName();
+        
+        return reservationMapper.toPaymentSummary(ticket, ticketName, cachedDto.getQuantity());
     }
 
     @Transactional

--- a/src/main/java/com/myce/reservation/service/Impl/VirtualBankExpireServiceImpl.java
+++ b/src/main/java/com/myce/reservation/service/Impl/VirtualBankExpireServiceImpl.java
@@ -1,0 +1,94 @@
+package com.myce.reservation.service.impl;
+
+import com.myce.expo.service.TicketService;
+import com.myce.payment.entity.ReservationPaymentInfo;
+import com.myce.payment.entity.type.PaymentStatus;
+import com.myce.payment.repository.ReservationPaymentInfoRepository;
+import com.myce.reservation.entity.Reservation;
+import com.myce.reservation.entity.code.ReservationStatus;
+import com.myce.reservation.repository.ReservationRepository;
+import com.myce.reservation.service.VirtualBankExpireService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class VirtualBankExpireServiceImpl implements VirtualBankExpireService {
+    
+    private final ReservationRepository reservationRepository;
+    private final ReservationPaymentInfoRepository reservationPaymentInfoRepository;
+    private final TicketService ticketService;
+
+    @Override
+    @Transactional
+    public void processExpiredVirtualBankReservations() {
+        // 어제 자정 이전에 생성된 CONFIRMED_PENDING 상태의 예약들 조회
+        LocalDateTime yesterday = LocalDateTime.now().minusDays(1).withHour(0).withMinute(0).withSecond(0).withNano(0);
+        
+        List<Reservation> expiredReservations = reservationRepository.findByStatusAndCreatedAtBefore(
+                ReservationStatus.CONFIRMED_PENDING, yesterday);
+        
+        if (expiredReservations.isEmpty()) {
+            log.info("[VirtualBankExpire] 만료 처리할 가상계좌 예약이 없습니다");
+            return;
+        }
+        
+        int cancelledCount = 0;
+        int paymentFailedCount = 0;
+        int ticketRestoredCount = 0;
+        
+        for (Reservation reservation : expiredReservations) {
+            try {
+                processExpiredReservation(reservation);
+                cancelledCount++;
+                
+                // 결제 정보 처리
+                if (updatePaymentInfoToFailed(reservation.getId())) {
+                    paymentFailedCount++;
+                }
+                
+                // 티켓 수량 복구
+                restoreTicketQuantity(reservation);
+                ticketRestoredCount++;
+                
+                log.info("[VirtualBankExpire] 가상계좌 만료 처리 완료 - 예약ID: {}, 티켓ID: {}, 복구 수량: {}", 
+                        reservation.getId(), reservation.getTicket().getId(), reservation.getQuantity());
+                        
+            } catch (Exception e) {
+                log.error("[VirtualBankExpire] 가상계좌 만료 처리 실패 - 예약ID: {}, 오류: {}", 
+                        reservation.getId(), e.getMessage(), e);
+            }
+        }
+        
+        log.info("[VirtualBankExpire] 가상계좌 만료 처리 결과 - 취소된 예약: {}건, 실패 처리된 결제: {}건, 복구된 티켓: {}건", 
+                cancelledCount, paymentFailedCount, ticketRestoredCount);
+    }
+    
+    private void processExpiredReservation(Reservation reservation) {
+        reservation.updateStatus(ReservationStatus.CANCELLED);
+        reservationRepository.save(reservation);
+    }
+    
+    private boolean updatePaymentInfoToFailed(Long reservationId) {
+        ReservationPaymentInfo paymentInfo = reservationPaymentInfoRepository.findByReservationId(reservationId)
+                .orElse(null);
+        
+        if (paymentInfo != null && paymentInfo.getStatus() == PaymentStatus.PENDING) {
+            paymentInfo.setStatus(PaymentStatus.FAILED);
+            reservationPaymentInfoRepository.save(paymentInfo);
+            return true;
+        }
+        return false;
+    }
+    
+    private void restoreTicketQuantity(Reservation reservation) {
+        Integer quantityToRestore = reservation.getQuantity();
+        ticketService.restoreTicketQuantity(reservation.getTicket().getId(), quantityToRestore);
+    }
+}

--- a/src/main/java/com/myce/reservation/service/ReservationService.java
+++ b/src/main/java/com/myce/reservation/service/ReservationService.java
@@ -22,6 +22,8 @@ public interface ReservationService {
     PreReservationResponse savePreReservation(PreReservationRequest request);
 
     ReservationPaymentSummaryResponse getPaymentSummary(Long reservationId);
+    
+    ReservationPaymentSummaryResponse getPaymentSummaryBySessionId(String sessionId);
 
     void deletePendingReservation(Long reservationId);
 

--- a/src/main/java/com/myce/reservation/service/VirtualBankExpireService.java
+++ b/src/main/java/com/myce/reservation/service/VirtualBankExpireService.java
@@ -1,0 +1,12 @@
+package com.myce.reservation.service;
+
+public interface VirtualBankExpireService {
+    
+    /**
+     * 만료된 가상계좌 예약들을 처리
+     * - CONFIRMED_PENDING 상태의 예약을 CANCELLED로 변경
+     * - 관련 결제 정보를 FAILED로 변경  
+     * - 티켓 수량 복구
+     */
+    void processExpiredVirtualBankReservations();
+}

--- a/src/main/java/com/myce/schedule/jobs/VirtualBankExpireScheduler.java
+++ b/src/main/java/com/myce/schedule/jobs/VirtualBankExpireScheduler.java
@@ -1,0 +1,39 @@
+package com.myce.schedule.jobs;
+
+import com.myce.reservation.service.VirtualBankExpireService;
+import com.myce.schedule.TaskScheduler;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class VirtualBankExpireScheduler implements TaskScheduler {
+    
+    private final VirtualBankExpireService virtualBankExpireService;
+
+    @PostConstruct
+    public void init() {
+        log.info("[Scheduler] 가상계좌 만료 처리 스케줄러 등록 완료");
+    }
+
+    @Override
+    @Scheduled(cron = "0 0 0 * * *") // 매일 자정에 실행
+    public void run() {
+        try {
+            log.info("[VirtualBankExpireScheduler] 가상계좌 만료 처리 시작");
+            this.process();
+            log.info("[VirtualBankExpireScheduler] 가상계좌 만료 처리 완료");
+        } catch (Exception e) {
+            log.error("[VirtualBankExpireScheduler] 가상계좌 만료 처리 실패", e);
+        }
+    }
+
+    @Override
+    public void process() {
+        virtualBankExpireService.processExpiredVirtualBankReservations();
+    }
+}


### PR DESCRIPTION
## 해결한 문제들
### 1. 가상계좌 결제 처리 중 오류
* 어제 연결하면서 카드 결제, 계좌 이체만 redis 방식으로 연결해놔서 오류 발생 => 가상 계좌도 redis 연결해서 수행

### 2. 가상계좌 웹훅 405 에러
* 로컬에서 테스트할 때는 ngrok 사용해서 했었는데 myce 서버 도메인으로 바꿔서 해보니 오류 발생 -> 도메인을 `myce.live`가 아니라 `api.myce.live`로 해야 한다는 것을 깨닫고 해결

### 3. 가상계좌 스케줄러 설정
* 예매 당일 자정 전까지 가상계좌에 돈을 넣지 않은 사람들은 스케줄러를 통해 reservation CANCELED, reservation_payment_info FAILED로 변경.
* 그 사람들이 구매한 티켓 수만큼 티켓 회수

### 4. 비회원 결제 오류 및 동시성 문제 해결
* 기존의 잘못된 플로우
```
1. 예매 시작 -> Redis에 고정 키(0)로 저장 
2. 동시 접속 시 데이터 덮어쓰기 발생
3. 비회원 예매 시 Guest ID 생성 실패
4. 결제 실패 및 데이터 손실
```

* 개선한 플로우
```
1. 예매 시작 -> UUID 세션 ID 생성 -> Redis 저장
2. 결제 페이지 -> 세션 ID로 결제 요약 조회
3. 결제 완료 -> 세션 ID로 Redis 조회 -> DB 저장
4. 비회원인 경우 자동으로 Guest ID 생성
5. Redis 세션 정리 완료
```

✅ 회원/비회원 카드 결제, 가상 계좌, 계좌 이체 모두 창 2개 띄워서 동시 테스트 완료