### PR TITLE
[CRM-307] fix: 행사 알림 중복 오류 수정

### DIFF
--- a/src/main/java/com/myce/notification/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/myce/notification/service/impl/NotificationServiceImpl.java
@@ -200,33 +200,31 @@ public class NotificationServiceImpl implements NotificationService {
                     .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_EXIST_MESSAGE_TEMPLATE));
 
             // 해당 박람회 예약자들 조회
-            List<Reservation> reservations = reservationRepository.findByExpoIdWithDistinctMemberId(expoId);
+            List<Long> userIds = reservationRepository.findDistinctUserIdsByExpoId(expoId);
             
-            if (reservations.isEmpty()) {
+            if (userIds.isEmpty()) {
                 log.info("알림 전송 대상이 없습니다 - 박람회 ID: {}", expoId);
                 return;
             }
 
-            // 박람회 제목 가져오기 (첫 번째 예약에서)
-            String expoTitle = reservations.get(0).getExpo().getTitle();
+            // 박람회 정보 조회
+            Expo expo = expoRepository.findById(expoId)
+                    .orElseThrow(() -> new CustomException(CustomErrorCode.EXPO_NOT_FOUND));
+            String expoTitle = expo.getTitle();
             String content = template.getContent().replace("{expoTitle}", expoTitle);
 
             // 각 예약자에게 알림 전송
-            int notificationCount = 0;
-            for (Reservation reservation : reservations) {
-                // 회원 예약만 알림 발송
-                if (reservation.getUserType() == UserType.MEMBER) {
-                    saveNotification(
-                        reservation.getUserId(), 
-                        expoId, 
-                        template.getSubject(), 
-                        content,
-                        NotificationType.EXPO_REMINDER,
-                        NotificationTargetType.EXPO
-                    );
-                    notificationCount++;
-                }
+            for (Long userId : userIds) {
+                saveNotification(
+                    userId, 
+                    expoId, 
+                    template.getSubject(), 
+                    content,
+                    NotificationType.EXPO_REMINDER,
+                    NotificationTargetType.EXPO
+                );
             }
+            int notificationCount = userIds.size();
             
             log.info("박람회 시작 알림 처리 완료 - 박람회 ID: {}, 알림 수: {} 개", 
                     expoId, notificationCount);
@@ -246,9 +244,9 @@ public class NotificationServiceImpl implements NotificationService {
                     .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_EXIST_MESSAGE_TEMPLATE));
 
             // 해당 박람회 예약자들 조회
-            List<Reservation> reservations = reservationRepository.findByExpoIdWithDistinctMemberId(expoId);
+            List<Long> userIds = reservationRepository.findDistinctUserIdsByExpoId(expoId);
             
-            if (reservations.isEmpty()) {
+            if (userIds.isEmpty()) {
                 log.info("1시간 전 알림 전송 대상이 없습니다 - 박람회 ID: {}", expoId);
                 return;
             }
@@ -262,21 +260,17 @@ public class NotificationServiceImpl implements NotificationService {
                     .replace("{startTime}", startTime);
 
             // 각 예약자에게 알림 전송
-            int notificationCount = 0;
-            for (Reservation reservation : reservations) {
-                // 회원 예약만 알림 발송
-                if (reservation.getUserType() == UserType.MEMBER) {
-                    saveNotification(
-                        reservation.getUserId(), 
-                        expoId, 
-                        template.getSubject(), 
-                        content,
-                        NotificationType.EVENT_REMINDER,
-                        NotificationTargetType.EXPO
-                    );
-                    notificationCount++;
-                }
+            for (Long userId : userIds) {
+                saveNotification(
+                    userId, 
+                    expoId, 
+                    template.getSubject(), 
+                    content,
+                    NotificationType.EVENT_REMINDER,
+                    NotificationTargetType.EXPO
+                );
             }
+            int notificationCount = userIds.size();
             
             log.info("행사 1시간 전 알림 처리 완료 - 박람회 ID: {}, 알림 수: {} 개", 
                     expoId, notificationCount);

--- a/src/main/java/com/myce/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/myce/reservation/repository/ReservationRepository.java
@@ -136,7 +136,11 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 
     @Query("SELECT r FROM Reservation r " +
             "WHERE r.expo.id = :expoId AND r.userType = 'MEMBER' " +
-            "GROUP BY r.userId")
+            "AND r.id IN (" +
+                "SELECT MIN(r2.id) FROM Reservation r2 " +
+                "WHERE r2.expo.id = :expoId AND r2.userType = 'MEMBER' " +
+                "GROUP BY r2.userId" +
+            ")")
     List<Reservation> findByExpoIdWithDistinctMemberId(Long expoId);
 
     // === 대시보드 통계용 쿼리 메서드들 ===

--- a/src/main/java/com/myce/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/myce/reservation/repository/ReservationRepository.java
@@ -134,14 +134,9 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 
     List<Reservation> findByExpoId(Long expoId);
 
-    @Query("SELECT r FROM Reservation r " +
-            "WHERE r.expo.id = :expoId AND r.userType = 'MEMBER' " +
-            "AND r.id IN (" +
-                "SELECT MIN(r2.id) FROM Reservation r2 " +
-                "WHERE r2.expo.id = :expoId AND r2.userType = 'MEMBER' " +
-                "GROUP BY r2.userId" +
-            ")")
-    List<Reservation> findByExpoIdWithDistinctMemberId(Long expoId);
+    @Query("SELECT DISTINCT r.userId FROM Reservation r " +
+            "WHERE r.expo.id = :expoId AND r.userType = 'MEMBER'")
+    List<Long> findDistinctUserIdsByExpoId(Long expoId);
 
     // === 대시보드 통계용 쿼리 메서드들 ===
 


### PR DESCRIPTION
# 🚨 알림 중복 발송 버그 수정

## 📋 개요
`NotificationServiceImpl`의 `sendEventHourReminderNotification` 메서드에서 발생하던 중복 알림 발송 문제를 해결했습니다.

### 🚨 알림 중복 발송 버그 수정

#### 문제점 분석
**기존 코드:**
```java
@Query("SELECT r FROM Reservation r " +
       "WHERE r.expo.id = :expoId AND r.userType = 'MEMBER' " +
       "GROUP BY r.userId")
List<Reservation> findByExpoIdWithDistinctMemberId(Long expoId);
```

**문제 상황:**
- 한 사용자가 동일 박람회에 대해 여러 예약을 생성한 경우
- JPQL에서 `GROUP BY r.userId` 구문이 제대로 동작하지 않아 중복 결과 반환
- 결과적으로 동일 사용자에게 이벤트 1시간 전 알림이 예약 개수만큼 중복 발송됨

**예시:**
- 사용자 A가 박람회 X에 대해 3개의 예약을 생성
- 이벤트 알림 시점에 사용자 A에게 동일한 알림이 3번 발송됨

#### 해결책
**수정된 코드:**
```java
  // After (DISTINCT 방식)
  @Query("SELECT DISTINCT r.userId FROM Reservation r WHERE
  r.expo.id = :expoId AND r.userType = 'MEMBER'")
  List<Long> findDistinctUserIdsByExpoId(Long expoId);
```


## 🔍 변경된 파일

### Backend
- `myce-server/src/main/java/com/myce/reservation/repository/ReservationRepository.java`
  - `findByExpoIdWithDistinctMemberId()` 메서드 쿼리 수정

## 스크린샷
<img width="467" height="506" alt="image" src="https://github.com/user-attachments/assets/146cc41c-79b6-410f-9476-0dc45d3abae2" />
