### PR TITLE
feat: 플랫폼 채팅 읽음 처리 및 상태 관리 최적화

### DIFF
--- a/src/main/java/com/myce/chat/controller/ChatWebSocketController.java
+++ b/src/main/java/com/myce/chat/controller/ChatWebSocketController.java
@@ -184,39 +184,61 @@ public class ChatWebSocketController {
                 broadcastMessage
             );
             
-            // 🆕 AI_ACTIVE 상태에서만 발송자 본인 메시지 즉시 읽음 처리
+            // 🆕 상태 기반 발송자 본인 메시지 즉시 읽음 처리
             // 데이터베이스에서 최신 채팅방 상태를 다시 조회하여 정확한 상태 확인
             ChatRoom currentRoom = chatRoomRepository.findByRoomCode(roomId).orElse(null);
-            if (currentRoom != null && currentRoom.getCurrentState() == ChatRoom.ChatRoomState.AI_ACTIVE) {
-                try {
-                    // AI 상담 중일 때만 발송자 본인 메시지 즉시 읽음 처리
-                    Member sender = memberRepository.findById(userId)
-                        .orElseThrow(() -> new CustomException(CustomErrorCode.MEMBER_NOT_EXIST));
-                    String senderRole = sender.getRole().name();
-                    
-                    chatRoomService.markAsRead(roomId, messageResponse.getMessageId(), userId, senderRole);
-                    log.debug("✅ AI 상담 중 발송자 본인 메시지 읽음 처리 완료 - userId: {}, roomId: {}, messageId: {}", 
-                              userId, roomId, messageResponse.getMessageId());
-                    
-                    // 🔔 읽음 상태 변경을 WebSocket으로 브로드캐스트
-                    Map<String, Object> readStatusUpdate = Map.of(
-                        "type", "read_status_update",
-                        "messageId", messageResponse.getMessageId(),
-                        "readBy", userId,
-                        "readerType", "USER",
-                        "timestamp", System.currentTimeMillis()
-                    );
-                    
-                    messagingTemplate.convertAndSend(
-                        "/topic/chat/" + roomId,
-                        readStatusUpdate
-                    );
-                    
-                    log.debug("🔔 읽음 상태 WebSocket 브로드캐스트 완료 - roomId: {}, messageId: {}", 
-                              roomId, messageResponse.getMessageId());
-                } catch (Exception e) {
-                    log.warn("⚠️ AI 상담 중 발송자 본인 메시지 읽음 처리 실패 - userId: {}, roomId: {}, error: {}", 
-                             userId, roomId, e.getMessage());
+            if (currentRoom != null) {
+                ChatRoom.ChatRoomState currentState = currentRoom.getCurrentState();
+                
+                // 플랫폼 채팅방에서 AI_ACTIVE 또는 ADMIN_ACTIVE 상태일 때 자동 읽음 처리
+                boolean shouldAutoRead = roomId.startsWith("platform-") && 
+                    (currentState == ChatRoom.ChatRoomState.AI_ACTIVE || 
+                     currentState == ChatRoom.ChatRoomState.ADMIN_ACTIVE);
+                
+                if (shouldAutoRead) {
+                    try {
+                        // 발송자 본인 메시지 즉시 읽음 처리
+                        Member sender = memberRepository.findById(userId)
+                            .orElseThrow(() -> new CustomException(CustomErrorCode.MEMBER_NOT_EXIST));
+                        String senderRole = sender.getRole().name();
+                        
+                        chatRoomService.markAsRead(roomId, messageResponse.getMessageId(), userId, senderRole);
+                        log.debug("✅ 플랫폼 상담 중 발송자 본인 메시지 읽음 처리 완료 - userId: {}, roomId: {}, state: {}, messageId: {}", 
+                                  userId, roomId, currentState, messageResponse.getMessageId());
+                        
+                        // 🆕 플랫폼 관리자가 메시지를 보낸 경우 → 해당 유저의 미읽음 메시지도 자동 읽음 처리
+                        if ("PLATFORM_ADMIN".equals(senderRole) && 
+                            currentState == ChatRoom.ChatRoomState.ADMIN_ACTIVE) {
+                            
+                            String[] roomParts = roomId.split("-");
+                            Long platformUserId = Long.parseLong(roomParts[1]);
+                            
+                            // 유저의 미읽은 메시지들을 모두 읽음 처리
+                            chatRoomService.markAsRead(roomId, messageResponse.getMessageId(), platformUserId, "USER");
+                            log.debug("✅ 플랫폼 관리자 답장으로 인한 유저 미읽음 자동 처리 완료 - platformUserId: {}, roomId: {}, messageId: {}", 
+                                      platformUserId, roomId, messageResponse.getMessageId());
+                        }
+                        
+                        // 🔔 읽음 상태 변경을 WebSocket으로 브로드캐스트
+                        Map<String, Object> readStatusUpdate = Map.of(
+                            "type", "read_status_update",
+                            "messageId", messageResponse.getMessageId(),
+                            "readBy", userId,
+                            "readerType", "USER",
+                            "timestamp", System.currentTimeMillis()
+                        );
+                        
+                        messagingTemplate.convertAndSend(
+                            "/topic/chat/" + roomId,
+                            readStatusUpdate
+                        );
+                        
+                        log.debug("🔔 읽음 상태 WebSocket 브로드캐스트 완료 - roomId: {}, messageId: {}", 
+                                  roomId, messageResponse.getMessageId());
+                    } catch (Exception e) {
+                        log.warn("⚠️ 플랫폼 상담 중 발송자 본인 메시지 읽음 처리 실패 - userId: {}, roomId: {}, state: {}, error: {}", 
+                                 userId, roomId, currentState, e.getMessage());
+                    }
                 }
             }
             
@@ -752,51 +774,19 @@ public class ChatWebSocketController {
                 adminCode = chatWebSocketService.determineAdminCode(userId, ADMIN_CODE_TYPE);
             }
             
-            // Assign admin directly (no handoff process needed)
-            chatWebSocketService.assignAdminIfNeeded(currentRoom, adminCode);
-            ChatRoom savedRoom = chatRoomRepository.save(currentRoom);
+            // Use consistent handoff process like acceptHandoff for consistency
+            chatRoomService.handoffAIToAdmin(roomId, adminCode);
+            // Refresh the chatRoom from DB to get the updated state
+            ChatRoom savedRoom = chatRoomRepository.findByRoomCode(roomId)
+                .orElseThrow(() -> new IllegalStateException("채팅방을 찾을 수 없습니다"));
             log.info("🔧 Room saved after intervention - roomId: {}, state: {}, hasAssignedAdmin: {}", 
                     savedRoom.getRoomCode(), savedRoom.getCurrentState(), savedRoom.hasAssignedAdmin());
             
-            // Save intervention system message to database for persistence
-            ChatMessage interventionSystemMessage = ChatMessage.createSystemMessage(
-                roomId, 
-                "ADMIN_INTERVENTION_START:관리자가 상담에 참여했습니다.\n더 자세하고 전문적인 도움을 드리겠습니다."
-            );
-            ChatMessage savedSystemMessage = chatMessageRepository.save(interventionSystemMessage);
-            
-            // Send intervention system message (not a regular chat message)
-            Map<String, Object> systemMessagePayload = Map.of(
-                "type", "ADMIN_INTERVENTION_START",
-                "roomCode", roomId,
-                "adminName", currentRoom.getAdminDisplayName(),
-                "timestamp", java.time.LocalDateTime.now().toString(),
-                "message", "관리자가 상담에 참여했습니다.\n더 자세하고 전문적인 도움을 드리겠습니다.",
-                "messageId", savedSystemMessage.getId()
-            );
-            
-            // Refresh room state after admin assignment
-            ChatRoom updatedRoom = chatRoomRepository.findByRoomCode(roomId)
-                .orElseThrow(() -> new IllegalStateException("채팅방을 찾을 수 없습니다"));
-            Map<String, Object> interventionRoomState = createRoomStateInfo(updatedRoom, "proactive_intervention");
-            
-            // Broadcast system message (not a regular chat message)
-            Map<String, Object> broadcastMessage = Map.of(
-                "type", "SYSTEM_MESSAGE",
-                "payload", systemMessagePayload,
-                "roomState", interventionRoomState
-            );
-            
-            messagingTemplate.convertAndSend(
-                "/topic/chat/" + roomId,
-                broadcastMessage
-            );
-            
-            // Update button state to ADMIN_ACTIVE
-            sendButtonStateUpdate(roomId, "ADMIN_ACTIVE");
+            // handoffAIToAdmin already handles system message and WebSocket broadcasts
+            // No additional messages needed to avoid duplication
             
             log.info("관리자 사전 개입 완료 - roomId: {}, userId: {}, newState: {}", 
-                roomId, userId, updatedRoom.getCurrentState());
+                roomId, userId, savedRoom.getCurrentState());
             
         } catch (Exception e) {
             log.error("관리자 사전 개입 실패 - roomId: {}", message.get("roomId"), e);
@@ -844,6 +834,41 @@ public class ChatWebSocketController {
             // Refresh the chatRoom from DB to get the updated state
             chatRoom = chatRoomRepository.findByRoomCode(roomId)
                 .orElseThrow(() -> new IllegalStateException("채팅방을 찾을 수 없습니다"));
+            
+            // Save handoff acceptance system message to database for persistence
+            ChatMessage acceptSystemMessage = ChatMessage.createSystemMessage(
+                roomId, 
+                "ADMIN_HANDOFF_ACCEPTED:관리자가 상담에 참여했습니다.\n더 자세하고 전문적인 도움을 드리겠습니다."
+            );
+            ChatMessage savedSystemMessage = chatMessageRepository.save(acceptSystemMessage);
+            
+            // Send handoff acceptance system message (not a regular chat message)
+            Map<String, Object> systemMessagePayload = Map.of(
+                "type", "ADMIN_HANDOFF_ACCEPTED",
+                "roomCode", roomId,
+                "adminName", chatRoom.getAdminDisplayName(),
+                "timestamp", java.time.LocalDateTime.now().toString(),
+                "message", "관리자가 상담에 참여했습니다.\n더 자세하고 전문적인 도움을 드리겠습니다.",
+                "messageId", savedSystemMessage.getId()
+            );
+            
+            // Create room state info for handoff acceptance
+            Map<String, Object> acceptRoomState = createRoomStateInfo(chatRoom, "handoff_accepted");
+            
+            // Broadcast system message (not a regular chat message)
+            Map<String, Object> broadcastMessage = Map.of(
+                "type", "SYSTEM_MESSAGE",
+                "payload", systemMessagePayload,
+                "roomState", acceptRoomState
+            );
+            
+            messagingTemplate.convertAndSend(
+                "/topic/chat/" + roomId,
+                broadcastMessage
+            );
+            
+            // Update button state to ADMIN_ACTIVE
+            sendButtonStateUpdate(roomId, "ADMIN_ACTIVE");
             
             log.info("관리자 인계 수락 완료 - roomCode: {}, adminCode: {}, newState: {}", 
                 roomId, adminCode, chatRoom.getCurrentState());

--- a/src/main/java/com/myce/chat/document/ChatRoom.java
+++ b/src/main/java/com/myce/chat/document/ChatRoom.java
@@ -156,7 +156,11 @@ public class ChatRoom {
         
         // roomCode 기반 초기 상태 분기 처리
         if (roomCode != null && roomCode.startsWith("platform-")) {
-            this.currentState = ChatRoomState.AI_ACTIVE;  // 플랫폼: AI로 시작
+            // 플랫폼 채팅방: 기존 상태 유지 (신규 채팅만 AI로 시작)
+            if (this.currentState == null) {
+                this.currentState = ChatRoomState.AI_ACTIVE;  // 신규 채팅: AI로 시작
+            }
+            // 기존에 ADMIN_ACTIVE였다면 그대로 유지하여 상담 연속성 보장
         } else {
             this.currentState = null;  // 박람회: legacy fallback 사용 (담당자 배정 로직)
         }

--- a/src/main/java/com/myce/chat/dto/ChatRoomListResponse.java
+++ b/src/main/java/com/myce/chat/dto/ChatRoomListResponse.java
@@ -108,13 +108,18 @@ public class ChatRoomListResponse {
          * 담당 관리자 표시명 (관리자용)
          */
         private String adminDisplayName;
+        
+        /**
+         * 현재 채팅방 상태 (AI_ACTIVE, WAITING_FOR_ADMIN, ADMIN_ACTIVE)
+         */
+        private String currentState;
 
         @Builder
         public ChatRoomInfo(String id, String roomCode, Long expoId, String expoTitle,
                            Long otherMemberId, String otherMemberName, String otherMemberRole,
                            String lastMessage, LocalDateTime lastMessageAt,
                            Integer unreadCount, Boolean isActive,
-                           String currentAdminCode, String adminDisplayName) {
+                           String currentAdminCode, String adminDisplayName, String currentState) {
             this.id = id;
             this.roomCode = roomCode;
             this.expoId = expoId;
@@ -128,6 +133,7 @@ public class ChatRoomListResponse {
             this.isActive = isActive != null ? isActive : true;
             this.currentAdminCode = currentAdminCode;
             this.adminDisplayName = adminDisplayName;
+            this.currentState = currentState;
         }
     }
 }

--- a/src/main/java/com/myce/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/myce/chat/repository/ChatMessageRepository.java
@@ -38,4 +38,9 @@ public interface ChatMessageRepository extends MongoRepository<ChatMessage, Stri
      * 채팅방에서 특정 메시지 ID 이후의 특정 발송자 타입 메시지 개수
      */
     long countByRoomCodeAndSenderTypeAndIdGreaterThan(String roomCode, String senderType, String messageId);
+    
+    /**
+     * 채팅방에서 여러 발송자 타입 중 하나라도 해당하는 메시지 개수 (플랫폼 상태 결정용)
+     */
+    long countByRoomCodeAndSenderTypeIn(String roomCode, List<String> senderTypes);
 }

--- a/src/main/java/com/myce/chat/service/impl/ChatRoomServiceImpl.java
+++ b/src/main/java/com/myce/chat/service/impl/ChatRoomServiceImpl.java
@@ -20,6 +20,7 @@ import com.myce.member.repository.MemberRepository;
 import com.myce.ai.service.AIChatService;
 import com.myce.chat.service.ChatCacheService;
 import com.myce.chat.service.ChatUnreadService;
+import com.myce.chat.service.util.ChatReadStatusUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -89,6 +90,9 @@ public class ChatRoomServiceImpl implements ChatRoomService {
         if (Role.PLATFORM_ADMIN.name().equals(memberRole)) {
             // 플랫폼 관리자인 경우: 모든 플랫폼 채팅방 조회 (platform-* rooms)
             chatRooms = chatRoomRepository.findByExpoIdIsNullAndIsActiveTrueOrderByLastMessageAtDesc();
+            
+            // 🆕 플랫폼 채팅방들 상태 동기화 (관리자가 목록을 볼 때 올바른 상태 표시)
+            chatRooms.forEach(this::syncPlatformChatState);
         } else {
             // 일반 사용자와 EXPO_ADMIN 모두 동일하게 처리: 본인이 참여한 채팅방만 조회
             // EXPO_ADMIN의 관리자 채팅은 /admin/inquiry 페이지에서 별도 처리
@@ -99,6 +103,11 @@ public class ChatRoomServiceImpl implements ChatRoomService {
             
             // 플랫폼 방 포함하여 다시 조회
             chatRooms = chatRoomRepository.findByMemberIdAndIsActiveTrueOrderByLastMessageAtDesc(memberId);
+            
+            // 🆕 사용자의 플랫폼 채팅방 상태 동기화
+            chatRooms.stream()
+                .filter(room -> room.getRoomCode() != null && room.getRoomCode().startsWith("platform-"))
+                .forEach(this::syncPlatformChatState);
         }
 
         // 4. MongoDB Document를 DTO로 변환 (복수형 네이밍 적용)
@@ -302,6 +311,9 @@ public class ChatRoomServiceImpl implements ChatRoomService {
                     return new CustomException(CustomErrorCode.CHAT_ROOM_NOT_FOUND);
                 });
         
+        // 🆕 1-1. 플랫폼 채팅방 상태 동기화 (메시지 이력 기반)
+        syncPlatformChatState(chatRoom);
+        
         // 2. 사용자 권한 검증 (새로운 통합 권한 검증 로직 사용)
         validateChatRoomAccess(roomCode, memberId, memberRole);
         
@@ -326,10 +338,10 @@ public class ChatRoomServiceImpl implements ChatRoomService {
             // 실제 역할에 따라 적절한 읽음 상태 업데이트
             if (Role.USER.name().equals(actualRole)) {
                 // 일반 사용자 → USER 읽음 상태 업데이트
-                updatedReadStatus = updateReadStatusForUser(currentReadStatus, latestMessageId);
+                updatedReadStatus = ChatReadStatusUtil.updateReadStatusForUser(currentReadStatus, latestMessageId);
             } else {
                 // 관리자 (박람회 소유자, AdminCode, 플랫폼 관리자) → ADMIN 읽음 상태 업데이트
-                updatedReadStatus = updateReadStatusForAdmin(currentReadStatus, latestMessageId);
+                updatedReadStatus = ChatReadStatusUtil.updateReadStatusForAdmin(currentReadStatus, latestMessageId);
             }
             
             chatRoom.updateReadStatus(updatedReadStatus);
@@ -599,39 +611,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
             .build();
     }
     
-    /**
-     * 사용자 읽음 상태 업데이트
-     */
-    private String updateReadStatusForUser(String currentReadStatus, String lastReadMessageId) {
-        if (currentReadStatus == null || currentReadStatus.isEmpty() || currentReadStatus.equals("{}")) {
-            return "{\"USER\":\"" + lastReadMessageId + "\"}";
-        }
-        
-        // 기존 USER 정보가 있으면 업데이트, 없으면 추가
-        if (currentReadStatus.contains("\"USER\"")) {
-            return currentReadStatus.replaceAll("\"USER\":\"[^\"]*\"", "\"USER\":\"" + lastReadMessageId + "\"");
-        } else {
-            return currentReadStatus.substring(0, currentReadStatus.length() - 1) + 
-                   ",\"USER\":\"" + lastReadMessageId + "\"}";
-        }
-    }
-    
-    /**
-     * 관리자 읽음 상태 업데이트
-     */
-    private String updateReadStatusForAdmin(String currentReadStatus, String lastReadMessageId) {
-        if (currentReadStatus == null || currentReadStatus.isEmpty() || currentReadStatus.equals("{}")) {
-            return "{\"ADMIN\":\"" + lastReadMessageId + "\"}";
-        }
-        
-        // 기존 ADMIN 정보가 있으면 업데이트, 없으면 추가
-        if (currentReadStatus.contains("\"ADMIN\"")) {
-            return currentReadStatus.replaceAll("\"ADMIN\":\"[^\"]*\"", "\"ADMIN\":\"" + lastReadMessageId + "\"");
-        } else {
-            return currentReadStatus.substring(0, currentReadStatus.length() - 1) + 
-                   ",\"ADMIN\":\"" + lastReadMessageId + "\"}";
-        }
-    }
+    // 중복 메서드 제거됨 - ChatReadStatusUtil로 통합
     
     /**
      * 플랫폼 채팅방 자동 생성
@@ -713,6 +693,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
     /**
      * 채팅방에서의 실제 역할 판단
      * EXPO_ADMIN이면서 USER일 수 있는 경우를 처리
+     * AdminCode 관리자와 박람회 소유자를 정확히 구분
      * 
      * @param roomCode 채팅방 코드
      * @param memberId 사용자 ID
@@ -731,15 +712,46 @@ public class ChatRoomServiceImpl implements ChatRoomService {
             try {
                 String[] parts = roomCode.split("-");
                 if (parts.length >= 3) {
+                    Long expoId = Long.parseLong(parts[1]);
                     Long roomUserId = Long.parseLong(parts[2]);
                     
                     // 채팅방의 사용자 ID와 현재 사용자 ID가 같으면 USER 역할
                     if (memberId.equals(roomUserId)) {
                         return Role.USER.name();
-                    } else {
-                        // 다르면 관리자 역할
-                        return "ADMIN";
                     }
+                    
+                    // EXPO_ADMIN인 경우 세부 권한 검증
+                    if (Role.EXPO_ADMIN.name().equals(memberRole)) {
+                        // 1. AdminCode 권한 확인
+                        try {
+                            Optional<AdminCode> adminCodeOpt = adminCodeRepository.findById(memberId);
+                            if (adminCodeOpt.isPresent()) {
+                                AdminCode adminCode = adminCodeOpt.get();
+                                if (adminCode.getExpoId().equals(expoId)) {
+                                    log.debug("✅ AdminCode 관리자 역할 확인 - memberId: {}, expoId: {}", memberId, expoId);
+                                    return "ADMIN";
+                                }
+                            }
+                        } catch (Exception e) {
+                            log.debug("AdminCode 권한 확인 실패, 박람회 소유자 권한 확인으로 이동 - memberId: {}", memberId);
+                        }
+                        
+                        // 2. 박람회 소유자 권한 확인
+                        try {
+                            Optional<Expo> expoOpt = expoRepository.findById(expoId);
+                            if (expoOpt.isPresent() && expoOpt.get().getMember().getId().equals(memberId)) {
+                                log.debug("✅ 박람회 소유자 역할 확인 - memberId: {}, expoId: {}", memberId, expoId);
+                                return "ADMIN";
+                            }
+                        } catch (Exception e) {
+                            log.warn("박람회 소유자 권한 확인 실패 - memberId: {}, expoId: {}", memberId, expoId, e);
+                        }
+                    }
+                    
+                    // 위의 모든 검증을 통과하지 못하면 USER로 간주
+                    log.debug("❌ 관리자 권한 없음 - USER로 처리 - memberId: {}, expoId: {}, memberRole: {}", 
+                             memberId, expoId, memberRole);
+                    return Role.USER.name();
                 }
             } catch (NumberFormatException e) {
                 log.warn("Invalid room code format for role determination: {}", roomCode);
@@ -748,5 +760,52 @@ public class ChatRoomServiceImpl implements ChatRoomService {
         
         // 기본값: 시스템 역할 그대로 사용
         return memberRole;
+    }
+    
+    /**
+     * 플랫폼 채팅방의 실제 상태 결정 (메시지 이력 기반)
+     * @param roomCode 플랫폼 채팅방 코드 (platform-{userId})
+     * @return 실제 채팅방 상태
+     */
+    private ChatRoom.ChatRoomState determinePlatformChatState(String roomCode) {
+        try {
+            // 관리자/시스템 메시지 존재 여부 확인
+            List<String> adminSenderTypes = List.of("ADMIN", "PLATFORM_ADMIN", "SYSTEM");
+            long adminMessageCount = chatMessageRepository.countByRoomCodeAndSenderTypeIn(roomCode, adminSenderTypes);
+            
+            log.debug("🔍 플랫폼 채팅방 상태 결정 - roomCode: {}, adminMessageCount: {}", roomCode, adminMessageCount);
+            
+            // 관리자/시스템 메시지가 하나라도 있으면 ADMIN_ACTIVE
+            return adminMessageCount > 0 ? 
+                ChatRoom.ChatRoomState.ADMIN_ACTIVE : 
+                ChatRoom.ChatRoomState.AI_ACTIVE;
+                
+        } catch (Exception e) {
+            log.warn("플랫폼 채팅방 상태 결정 실패 - roomCode: {}, error: {}", roomCode, e.getMessage());
+            // 에러 시 안전한 기본값 반환
+            return ChatRoom.ChatRoomState.AI_ACTIVE;
+        }
+    }
+    
+    /**
+     * 플랫폼 채팅방 상태 동기화 (필요 시 DB 업데이트)
+     * @param chatRoom 동기화할 채팅방
+     */
+    private void syncPlatformChatState(ChatRoom chatRoom) {
+        if (chatRoom.getRoomCode() != null && chatRoom.getRoomCode().startsWith("platform-")) {
+            ChatRoom.ChatRoomState actualState = determinePlatformChatState(chatRoom.getRoomCode());
+            ChatRoom.ChatRoomState currentState = chatRoom.getCurrentState();
+            
+            if (actualState != currentState) {
+                log.info("🔄 플랫폼 채팅방 상태 동기화 - roomCode: {}, {} → {}", 
+                        chatRoom.getRoomCode(), currentState, actualState);
+                
+                chatRoom.setCurrentState(actualState);
+                chatRoomRepository.save(chatRoom);
+                
+                log.debug("✅ 플랫폼 채팅방 상태 업데이트 완료 - roomCode: {}, newState: {}", 
+                         chatRoom.getRoomCode(), actualState);
+            }
+        }
     }
 }

--- a/src/main/java/com/myce/chat/service/impl/ChatUnreadServiceImpl.java
+++ b/src/main/java/com/myce/chat/service/impl/ChatUnreadServiceImpl.java
@@ -79,19 +79,21 @@ public class ChatUnreadServiceImpl implements ChatUnreadService {
         try {
             log.debug("🔍 개별 메시지 unread count 계산 - messageId: {}, senderType: {}", messageId, messageSenderType);
             
-            // 🆕 플랫폼 AI 채팅에서 USER 메시지는 항상 읽음으로 처리 (AI가 즉시 읽었다고 간주)
-            if (roomCode != null && roomCode.startsWith("platform-") && "USER".equals(messageSenderType)) {
-                ChatRoom chatRoom = chatRoomRepository.findByRoomCode(roomCode).orElse(null);
-                if (chatRoom != null && chatRoom.getCurrentState() == ChatRoom.ChatRoomState.AI_ACTIVE) {
-                    log.debug("✅ AI 상담 중 USER 메시지 - unreadCount 강제 0 설정 - messageId: {}", messageId);
-                    return 0;
-                }
-            }
-            
-            // 1. 채팅방 조회
+            // 1. 채팅방 조회 (한 번만 조회하여 성능 최적화)
             ChatRoom chatRoom = chatRoomRepository.findByRoomCode(roomCode).orElse(null);
             if (chatRoom == null || messageId == null) {
                 return 1; // 안전한 기본값
+            }
+            
+            // 🆕 플랫폼 AI 채팅에서 USER 메시지는 항상 읽음으로 처리 (AI/관리자가 즉시 읽었다고 간주)
+            if (roomCode != null && roomCode.startsWith("platform-") && "USER".equals(messageSenderType)) {
+                ChatRoom.ChatRoomState currentState = chatRoom.getCurrentState();
+                if (currentState == ChatRoom.ChatRoomState.AI_ACTIVE || 
+                    currentState == ChatRoom.ChatRoomState.ADMIN_ACTIVE) {
+                    log.debug("✅ 플랫폼 상담 중 USER 메시지 - unreadCount 강제 0 설정 - messageId: {}, state: {}", 
+                              messageId, currentState);
+                    return 0;
+                }
             }
             
             // 2. 메시지 발송자에 따라 읽음 상태 확인할 상대방 타입 결정

--- a/src/main/java/com/myce/chat/service/impl/ChatWebSocketServiceImpl.java
+++ b/src/main/java/com/myce/chat/service/impl/ChatWebSocketServiceImpl.java
@@ -261,8 +261,22 @@ public class ChatWebSocketServiceImpl implements ChatWebSocketService {
                     // 플랫폼 관리자가 보낸 경우 → 사용자가 수신자
                     return roomUserId;
                 } else {
-                    // 사용자가 보낸 경우 → 플랫폼 관리자가 수신자 (특정 플랫폼 관리자 ID 없으므로 null)
-                    return null;
+                    // 사용자가 보낸 경우 → 현재 활성 플랫폼 관리자가 수신자
+                    try {
+                        ChatRoom chatRoom = chatRoomRepository.findByRoomCode(roomId).orElse(null);
+                        if (chatRoom != null && chatRoom.getCurrentState() == ChatRoom.ChatRoomState.ADMIN_ACTIVE) {
+                            // ADMIN_ACTIVE 상태일 때 현재 담당 관리자의 ID 반환
+                            String currentAdminCode = chatRoom.getCurrentAdminCode();
+                            if ("PLATFORM_ADMIN".equals(currentAdminCode)) {
+                                // 플랫폼 관리자 중 첫 번째 활성 관리자 찾기 (임시로 null 반환)
+                                // TODO: 실제 활성 플랫폼 관리자 ID를 찾는 로직 구현 필요
+                                return null;
+                            }
+                        }
+                    } catch (Exception e) {
+                        log.warn("Failed to find active platform admin for room: {}", roomId, e);
+                    }
+                    return null; // AI 상태이거나 관리자를 찾을 수 없는 경우
                 }
             } else if (roomId.startsWith(ADMIN_ROOM_PREFIX)) {
                 // 박람회 채팅: admin-{expoId}-{userId}

--- a/src/main/java/com/myce/chat/service/impl/ExpoChatServiceImpl.java
+++ b/src/main/java/com/myce/chat/service/impl/ExpoChatServiceImpl.java
@@ -11,6 +11,7 @@ import com.myce.chat.repository.ChatMessageRepository;
 import com.myce.chat.service.ChatCacheService;
 import com.myce.chat.service.ChatUnreadService;
 import com.myce.chat.service.ExpoChatService;
+import com.myce.chat.service.util.ChatReadStatusUtil;
 import com.myce.chat.service.mapper.ChatMessageMapper;
 import com.myce.common.dto.PageResponse;
 import com.myce.common.exception.CustomErrorCode;
@@ -142,7 +143,7 @@ public class ExpoChatServiceImpl implements ExpoChatService {
             
             // readStatusJson 업데이트 (MongoDB)
             String currentReadStatus = chatRoom.getReadStatusJson();
-            String updatedReadStatus = updateReadStatusForAdmin(currentReadStatus, latestMessageId);
+            String updatedReadStatus = ChatReadStatusUtil.updateReadStatusForAdmin(currentReadStatus, latestMessageId);
             
             log.info("EXPO 관리자 읽음 처리 - roomCode: {}, latestMessageId: {}, 이전 readStatus: {}, 업데이트된 readStatus: {}", 
                 roomCode, latestMessageId, currentReadStatus, updatedReadStatus);
@@ -207,19 +208,7 @@ public class ExpoChatServiceImpl implements ExpoChatService {
     /**
      * 관리자 읽음 상태 업데이트
      */
-    private String updateReadStatusForAdmin(String currentReadStatus, String lastReadMessageId) {
-        if (currentReadStatus == null || currentReadStatus.isEmpty() || currentReadStatus.equals("{}")) {
-            return "{\"ADMIN\":\"" + lastReadMessageId + "\"}";
-        }
-        
-        // 기존 ADMIN 정보가 있으면 업데이트, 없으면 추가
-        if (currentReadStatus.contains("\"ADMIN\"")) {
-            return currentReadStatus.replaceAll("\"ADMIN\":\"[^\"]*\"", "\"ADMIN\":\"" + lastReadMessageId + "\"");
-        } else {
-            return currentReadStatus.substring(0, currentReadStatus.length() - 1) + 
-                   ",\"ADMIN\":\"" + lastReadMessageId + "\"}";
-        }
-    }
+    // 중복 메서드 제거됨 - ChatReadStatusUtil로 통합
 
     @Override
     public Long getUnreadCount(Long expoId, String roomCode, CustomUserDetails userDetails) {
@@ -338,6 +327,7 @@ public class ExpoChatServiceImpl implements ExpoChatService {
                 .isActive(chatRoom.getIsActive())
                 .currentAdminCode(chatRoom.getCurrentAdminCode())
                 .adminDisplayName(chatRoom.getAdminDisplayName())
+                .currentState(chatRoom.getCurrentState() != null ? chatRoom.getCurrentState().name() : null)
                 .build();
     }
 

--- a/src/main/java/com/myce/chat/service/mapper/ChatRoomMapper.java
+++ b/src/main/java/com/myce/chat/service/mapper/ChatRoomMapper.java
@@ -25,6 +25,9 @@ public class ChatRoomMapper {
                 .lastMessageAt(chatRoom.getLastMessageAt())
                 .unreadCount(unreadCount)
                 .isActive(chatRoom.getIsActive())
+                .currentAdminCode(chatRoom.getCurrentAdminCode())
+                .adminDisplayName(chatRoom.getAdminDisplayName())
+                .currentState(chatRoom.getCurrentState() != null ? chatRoom.getCurrentState().name() : null)
                 .build();
     }
 }

--- a/src/main/java/com/myce/chat/service/util/ChatReadStatusUtil.java
+++ b/src/main/java/com/myce/chat/service/util/ChatReadStatusUtil.java
@@ -1,0 +1,154 @@
+package com.myce.chat.service.util;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 채팅 읽음 상태 처리 유틸리티 클래스
+ * 
+ * 기존 ChatRoomServiceImpl과 ExpoChatServiceImpl에서 중복으로 구현된
+ * 읽음 상태 JSON 업데이트 로직을 통합하여 일관성과 유지보수성 향상
+ */
+@Slf4j
+public final class ChatReadStatusUtil {
+
+    private ChatReadStatusUtil() {
+        // 유틸리티 클래스는 인스턴스화 방지
+    }
+
+    /**
+     * 사용자(USER) 읽음 상태 업데이트
+     * 
+     * @param currentReadStatus 현재 읽음 상태 JSON
+     * @param lastReadMessageId 마지막으로 읽은 메시지 ID
+     * @return 업데이트된 읽음 상태 JSON
+     */
+    public static String updateReadStatusForUser(String currentReadStatus, String lastReadMessageId) {
+        if (currentReadStatus == null || currentReadStatus.isEmpty() || currentReadStatus.equals("{}")) {
+            return "{\"USER\":\"" + lastReadMessageId + "\"}";
+        }
+        
+        // 기존 USER 정보가 있으면 업데이트, 없으면 추가
+        if (currentReadStatus.contains("\"USER\"")) {
+            return currentReadStatus.replaceAll("\"USER\":\"[^\"]*\"", "\"USER\":\"" + lastReadMessageId + "\"");
+        } else {
+            return currentReadStatus.substring(0, currentReadStatus.length() - 1) + 
+                   ",\"USER\":\"" + lastReadMessageId + "\"}";
+        }
+    }
+
+    /**
+     * 관리자(ADMIN) 읽음 상태 업데이트
+     * 
+     * @param currentReadStatus 현재 읽음 상태 JSON
+     * @param lastReadMessageId 마지막으로 읽은 메시지 ID
+     * @return 업데이트된 읽음 상태 JSON
+     */
+    public static String updateReadStatusForAdmin(String currentReadStatus, String lastReadMessageId) {
+        if (currentReadStatus == null || currentReadStatus.isEmpty() || currentReadStatus.equals("{}")) {
+            return "{\"ADMIN\":\"" + lastReadMessageId + "\"}";
+        }
+        
+        // 기존 ADMIN 정보가 있으면 업데이트, 없으면 추가
+        if (currentReadStatus.contains("\"ADMIN\"")) {
+            return currentReadStatus.replaceAll("\"ADMIN\":\"[^\"]*\"", "\"ADMIN\":\"" + lastReadMessageId + "\"");
+        } else {
+            return currentReadStatus.substring(0, currentReadStatus.length() - 1) + 
+                   ",\"ADMIN\":\"" + lastReadMessageId + "\"}";
+        }
+    }
+
+    /**
+     * 읽음 상태 JSON에서 특정 사용자 타입의 마지막 읽은 메시지 ID 추출
+     * 
+     * @param readStatusJson 읽음 상태 JSON
+     * @param userType 사용자 타입 ("USER" 또는 "ADMIN")
+     * @return 마지막으로 읽은 메시지 ID, 없으면 null
+     */
+    public static String extractLastReadMessageId(String readStatusJson, String userType) {
+        try {
+            if (readStatusJson == null || readStatusJson.isEmpty() || readStatusJson.equals("{}")) {
+                return null;
+            }
+            
+            // 간단한 JSON 파싱 (Jackson 라이브러리 사용하지 않고)
+            String searchKey = "\"" + userType + "\":\"";
+            int startIndex = readStatusJson.indexOf(searchKey);
+            if (startIndex == -1) {
+                return null;
+            }
+            
+            startIndex += searchKey.length();
+            int endIndex = readStatusJson.indexOf("\"", startIndex);
+            if (endIndex == -1) {
+                return null;
+            }
+            
+            return readStatusJson.substring(startIndex, endIndex);
+            
+        } catch (Exception e) {
+            log.warn("readStatusJson 파싱 실패: {}", readStatusJson, e);
+            return null;
+        }
+    }
+
+    /**
+     * 읽음 상태 JSON 유효성 검증
+     * 
+     * @param readStatusJson 검증할 JSON 문자열
+     * @return 유효한 JSON이면 true
+     */
+    public static boolean isValidReadStatusJson(String readStatusJson) {
+        if (readStatusJson == null || readStatusJson.isEmpty()) {
+            return true; // 빈 값은 유효함 (초기 상태)
+        }
+        
+        try {
+            // 기본적인 JSON 형식 확인
+            return readStatusJson.startsWith("{") && 
+                   readStatusJson.endsWith("}") && 
+                   (readStatusJson.contains("\"USER\"") || readStatusJson.contains("\"ADMIN\"") || 
+                    readStatusJson.equals("{}"));
+        } catch (Exception e) {
+            log.warn("읽음 상태 JSON 유효성 검증 실패: {}", readStatusJson, e);
+            return false;
+        }
+    }
+
+    /**
+     * 빈 읽음 상태 JSON 생성
+     * 
+     * @return 초기 상태의 빈 JSON 문자열
+     */
+    public static String createEmptyReadStatus() {
+        return "{}";
+    }
+
+    /**
+     * 전체 읽음 상태 JSON 생성 (USER, ADMIN 모두 동일한 메시지 ID로 설정)
+     * 
+     * @param messageId 설정할 메시지 ID
+     * @return 전체 읽음 처리된 JSON 문자열
+     */
+    public static String createFullReadStatus(String messageId) {
+        return String.format("{\"USER\":\"%s\",\"ADMIN\":\"%s\"}", messageId, messageId);
+    }
+
+    /**
+     * 읽음 상태 JSON에서 특정 사용자 타입이 읽지 않은 메시지인지 확인
+     * 
+     * @param readStatusJson 읽음 상태 JSON
+     * @param userType 확인할 사용자 타입 ("USER" 또는 "ADMIN")
+     * @param messageId 확인할 메시지 ID
+     * @return 읽지 않은 메시지면 true
+     */
+    public static boolean isUnreadMessage(String readStatusJson, String userType, String messageId) {
+        String lastReadId = extractLastReadMessageId(readStatusJson, userType);
+        
+        if (lastReadId == null || lastReadId.isEmpty()) {
+            return true; // 아무것도 읽지 않았으면 읽지 않은 메시지
+        }
+        
+        // MongoDB ObjectId는 시간순 정렬이 가능하므로 문자열 비교로 판단
+        return messageId.compareTo(lastReadId) > 0;
+    }
+}


### PR DESCRIPTION
🎯 주요 개선사항:
- 플랫폼 상담 ADMIN_ACTIVE 상태에서 유저 메시지 즉시 읽음 처리
- 관리자 답장 시 유저 미읽음 메시지 자동 클리어
- 기존 플랫폼 채팅방 상태 동적 결정 (메시지 이력 기반)
- 새로고침 후 올바른 상담 상태 유지

🔧 수정된 파일:
- ChatUnreadServiceImpl: ADMIN_ACTIVE 상태 자동 읽음 처리 추가
- ChatWebSocketController: 관리자 메시지 시 유저 읽음 자동 처리
- ChatWebSocketServiceImpl: 플랫폼 관리자 receiverId 처리 개선
- ChatRoomServiceImpl: 메시지 이력 기반 상태 동기화 시스템
- ChatRoomListResponse: currentState 필드 추가로 상태 영속성 보장
- ChatRoom: 플랫폼 채팅방 상태 리셋 방지 로직

✅ 해결된 문제:
- 플랫폼 상담에서 읽음 배지가 몇 초 후에 사라지는 문제
- 새로고침 시 관리자 상담 상태가 AI로 리셋되는 문제
- 기존 관리자 상담 이력이 있는 방이 AI 상담으로 표시되는 문제
