### PR TITLE
[CRM-302] fix: 박람회 및 광고 결제 관련 api permitall 제거

### DIFF
--- a/src/main/java/com/myce/auth/security/config/SecurityConfig.java
+++ b/src/main/java/com/myce/auth/security/config/SecurityConfig.java
@@ -46,7 +46,7 @@ public class SecurityConfig {
             "/api/ads", "/api/auth/**",
             "/api/categories", "/api/expos/**", "/api/reservations/**",
             "/api/reservations/guest", "/api/expo/fees/active", "/api/ad/fees/active",
-            "/api/members/expos/*/payment", "/api/members/ads/*/payment",
+//            "/api/members/expos/*/payment", "/api/members/ads/*/payment",
             "/api/reviews/expo/*", "/api/reviews/*/", "/api/reviews/best",
             "/api/settings/refund-fee/public", "/api/ad-position/dropdown",
             "/api/settings/ad-fee/active", "/api/settings/expo-fee/active"


### PR DESCRIPTION
## 수정 내용
- permitAll 리스트 필터 대상 제외로 인한 오류 수정 
  - 마이페이지 내 박람회 결제 api
  - 마이페이지 내 광고 결제 api
  
 > 필터가 필요한 api일 경우 security permitAll에 포함되면 안되니 확인 후 또 제거될 것 있으면 전달 부탁드립니다!