### PR TITLE
[CRM-302] fix : permitall 상세 수정

### DIFF
--- a/src/main/java/com/myce/auth/security/config/SecurityConfig.java
+++ b/src/main/java/com/myce/auth/security/config/SecurityConfig.java
@@ -43,7 +43,16 @@ public class SecurityConfig {
 
     public static final String[] GET_PERMIT_ALL = {
             "/api/ads", "/api/auth/**",
-            "/api/categories", "/api/expos/**", "/api/reservations/**",
+            "/api/categories",
+            "/api/expos",                           // 박람회 카드 리스트 조회 (검색, 필터링)
+            "/api/expos/*/congestion",              // 박람회 실시간 혼잡도 조회
+            "/api/expos/*/tickets/reservations",    // 박람회 티켓 조회(예매용)
+            "/api/expos/*/basic",                   // 박람회 기본 정보 조회
+            "/api/expos/*/bookmark",                // 박람회 찜하기 상태 조회 (비회원도 접근)
+            "/api/expos/*/reviews",                 // 박람회 리뷰 정보 조회 (비회원 접근 가능)
+            "/api/expos/*/location",                // 박람회 위치 정보 조회
+            "/api/expos/*/booths/public",           // 박람회 부스 정보 조회 (공개용)
+            "/api/reservations/**",
             "/api/reservations/guest", "/api/expo/fees/active", "/api/ad/fees/active",
             "/api/reviews/expo/*", "/api/reviews/*/", "/api/reviews/best",
             "/api/settings/refund-fee/public", "/api/ad-position/dropdown",

--- a/src/main/java/com/myce/expo/controller/ExpoController.java
+++ b/src/main/java/com/myce/expo/controller/ExpoController.java
@@ -55,7 +55,7 @@ public class ExpoController {
     }
 
     // 박람회 카드 리스트 조회
-    @GetMapping()
+    @GetMapping
     public ResponseEntity<Page<ExpoCardResponse>> getExpoCards(
         @RequestParam(required=false) String keyword,   // 검색
         @RequestParam(required=false) String category,  // 카테고리


### PR DESCRIPTION
  ## Summary
  기존에 와일드카드(`/api/expos/**`)로 뭉뚱그려져 있던 expo API 권한 설정을
  구체적인 경로별로 세분화하여 보안성과 명확성을 개선했습니다.

  ## Changes
  - **Before**: `/api/expos/**` (모든 expo API 허용)
  - **After**: 비회원 접근이 필요한 특정 API만 명시적으로 허용

  ### 추가된 구체적인 permitAll 경로들:
  - `/api/expos/*/congestion` - 박람회 실시간 혼잡도 조회
  - `/api/expos/*/tickets/reservations` - 박람회 티켓 조회(예매용)
  - `/api/expos/*/basic` - 박람회 기본 정보 조회
  - `/api/expos/*/bookmark` - 박람회 찜하기 상태 조회
  - `/api/expos/*/reviews` - 박람회 리뷰 정보 조회
  - `/api/expos/*/location` - 박람회 위치 정보 조회
  - `/api/expos/*/booths/public` - 박람회 부스 정보 조회