### PR TITLE
[CRM-302] fix: DELETE permitAll 제거

### DIFF
--- a/src/main/java/com/myce/auth/security/config/SecurityConfig.java
+++ b/src/main/java/com/myce/auth/security/config/SecurityConfig.java
@@ -72,7 +72,7 @@ public class SecurityConfig {
     };
 
     public static final String[] DELETE_PERMIT_ALL = {
-            "/api/**", "/api/reservations/**",
+            "/api/reservations/**",
             "/api/reservations/*",                   // 예매 삭제 (결제 실패/취소 시)
     };
 


### PR DESCRIPTION
## 수정 내용
- DELETE 요청에 대한 전역 api 제거