### PR TITLE
[CRM-312] fix: 배너 기간 검사 API에 등록 배너 중 만료 상태 제외

### DIFF
--- a/src/main/java/com/myce/advertisement/service/impl/SystemAdServiceImpl.java
+++ b/src/main/java/com/myce/advertisement/service/impl/SystemAdServiceImpl.java
@@ -49,7 +49,8 @@ public class SystemAdServiceImpl implements SystemAdService {
             LocalDate finalDate = date;
             long overlappingCount = activeAds.stream()
                     .filter(ad -> !finalDate.isBefore(ad.getDisplayStartDate()) &&
-                            !finalDate.isAfter(ad.getDisplayEndDate()))
+                            !finalDate.isAfter(ad.getDisplayEndDate()) &&
+                            !AdvertisementStatus.EXPIRED_STATUSES.contains(ad.getStatus()))
                     .count();
             //해당 날짜의 배너 수가 최댓값일때
             if (overlappingCount >= requestedAdPosition.getMaxCount()) {


### PR DESCRIPTION
### 구현 기능
* 배너 기간 검사 API에 등록 배너 중 만료 상태 제외