### PR TITLE
[CRM-302] fix: 신청자 정보에 성별 제거

### DIFF
--- a/src/main/java/com/myce/expo/service/mapper/ExpoApplicationMapper.java
+++ b/src/main/java/com/myce/expo/service/mapper/ExpoApplicationMapper.java
@@ -65,7 +65,6 @@ public class ExpoApplicationMapper {
                         .name(member.getName())
                         .email(member.getEmail())
                         .phone(member.getPhone())
-                        .gender(member.getGender().name())
                         .birth(member.getBirth())
                         .build())
                 .business(businessProfile != null ? ExpoApplicationDetailResponse.BusinessInfo.builder()


### PR DESCRIPTION
## 수정내용
- 박람회 신청 조회 시 신청자 정보에 성별 정보 제거
- 소셜로그인 대상자는 성별정보가 없음
   -> 성별이 Enum으로 설정되어있어 nullPoint발생
- 신청자 정보에서는 성별 정보가 필요없다 판단하여 제거