### PR TITLE
fix: 행사 알림 중복 오류 수정

### DIFF
--- a/src/main/java/com/myce/schedule/jobs/EventNotificationScheduler.java
+++ b/src/main/java/com/myce/schedule/jobs/EventNotificationScheduler.java
@@ -16,6 +16,8 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Component
@@ -64,15 +66,32 @@ public class EventNotificationScheduler implements TaskScheduler {
             return;
         }
 
-        // 각 이벤트의 박람회에 대해 1시간 전 알림 전송
-        for (Event event : upcomingEvents) {
-            notificationService.sendEventHourReminderNotification(
-                event.getExpo().getId(), 
-                event.getName(), 
-                event.getStartTime().toString()
-            );
-            log.info("[Scheduler] 행사 1시간 전 알림 전송 완료 - 박람회: {}, 이벤트: {}",
-                    event.getExpo().getTitle(), event.getName());
+        // 박람회별로 그룹핑하여 중복 알림 방지
+        Set<Long> processedExpoIds = upcomingEvents.stream()
+                .map(event -> event.getExpo().getId())
+                .collect(Collectors.toSet());
+
+        // 각 박람회에 대해 한 번씩만 알림 전송
+        for (Long expoId : processedExpoIds) {
+            // 해당 박람회의 이벤트 정보 수집
+            List<Event> expoEvents = upcomingEvents.stream()
+                    .filter(event -> event.getExpo().getId().equals(expoId))
+                    .collect(Collectors.toList());
+            
+            if (!expoEvents.isEmpty()) {
+                Event firstEvent = expoEvents.get(0);
+                String eventNames = expoEvents.stream()
+                        .map(Event::getName)
+                        .collect(Collectors.joining(", "));
+                
+                notificationService.sendEventHourReminderNotification(
+                    expoId,
+                    eventNames,
+                    firstEvent.getStartTime().toString()
+                );
+                log.info("[Scheduler] 행사 1시간 전 알림 전송 완료 - 박람회: {}, 이벤트: {}",
+                        firstEvent.getExpo().getTitle(), eventNames);
+            }
         }
     }
 }


### PR DESCRIPTION
# EventNotificationScheduler 중복 알림 방지 수정사항

## 문제점
- 동일한 박람회에 여러 이벤트가 1시간 후 시작할 때, 각 이벤트마다 알림을 전송하여 예약자들에게 중복 알림 발생

## 수정 내용

### Import 추가 (15-20라인)

**수정 전:**
```java
import java.time.LocalDate;
import java.time.LocalDateTime;
import java.time.LocalTime;
import java.util.List;
```

**수정 후:**
```java
import java.time.LocalDate;
import java.time.LocalDateTime;
import java.time.LocalTime;
import java.util.List;
import java.util.Set;
import java.util.stream.Collectors;
```

### 알림 전송 로직 수정 (67-76라인 → 69-95라인)

**수정 전:**
```java
        // 각 이벤트의 박람회에 대해 1시간 전 알림 전송
        for (Event event : upcomingEvents) {
            notificationService.sendEventHourReminderNotification(
                event.getExpo().getId(), 
                event.getName(), 
                event.getStartTime().toString()
            );
            log.info("[Scheduler] 행사 1시간 전 알림 전송 완료 - 박람회: {}, 이벤트: {}",
                    event.getExpo().getTitle(), event.getName());
        }
```

**수정 후:**
```java
        // 박람회별로 그룹핑하여 중복 알림 방지
        Set<Long> processedExpoIds = upcomingEvents.stream()
                .map(event -> event.getExpo().getId())
                .collect(Collectors.toSet());

        // 각 박람회에 대해 한 번씩만 알림 전송
        for (Long expoId : processedExpoIds) {
            // 해당 박람회의 이벤트 정보 수집
            List<Event> expoEvents = upcomingEvents.stream()
                    .filter(event -> event.getExpo().getId().equals(expoId))
                    .collect(Collectors.toList());
            
            if (!expoEvents.isEmpty()) {
                Event firstEvent = expoEvents.get(0);
                String eventNames = expoEvents.stream()
                        .map(Event::getName)
                        .collect(Collectors.joining(", "));
                
                notificationService.sendEventHourReminderNotification(
                    expoId,
                    eventNames,
                    firstEvent.getStartTime().toString()
                );
                log.info("[Scheduler] 행사 1시간 전 알림 전송 완료 - 박람회: {}, 이벤트: {}",
                        firstEvent.getExpo().getTitle(), eventNames);
            }
        }
```

## 수정 로직 설명

1. **박람회 ID 수집 (70-72라인)**
   - `upcomingEvents`에서 박람회 ID들을 추출하여 `Set`으로 중복 제거
   - 동일한 박람회는 한 번만 처리되도록 보장

2. **박람회별 이벤트 그룹핑 (77-79라인)**
   - 각 박람회 ID에 대해 해당하는 모든 이벤트들을 필터링하여 수집

3. **이벤트명 결합 (83-85라인)**
   - 동일한 박람회의 여러 이벤트명들을 콤마(`,`)로 구분하여 하나의 문자열로 결합
   - 예: "세미나 A, 워크샵 B, 전시회 C"

4. **단일 알림 전송 (87-91라인)**
   - 박람회당 한 번의 알림만 전송
   - 첫 번째 이벤트의 시작 시간을 기준으로 사용

## 결과
- 동일한 박람회에 8개의 이벤트가 1시간 후 시작되어도 예약자들에게는 **1번의 알림**만 전송
- 알림 내용에는 모든 이벤트명이 포함되어 정보 손실 없음