### PR TITLE
[Refactor] Spring Security 리팩토링

### DIFF
--- a/src/main/java/com/myce/auth/security/config/SecurityConfig.java
+++ b/src/main/java/com/myce/auth/security/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.myce.auth.security.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.myce.auth.repository.RefreshTokenRepository;
 import com.myce.auth.repository.TokenBlackListRepository;
 import com.myce.auth.security.filter.CustomLogoutFilter;
@@ -14,6 +15,7 @@ import com.myce.auth.security.repository.RedisOAuth2AuthorizationRequestReposito
 import com.myce.auth.security.util.JwtUtil;
 import com.myce.auth.service.AdminCodeDetailService;
 import com.myce.auth.service.impl.UserDetailsServiceImpl;
+import com.myce.common.exception.ErrorResponse;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -78,8 +80,14 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable) // HTTP Basic 인증
                 .exceptionHandling(ex -> ex
                         .authenticationEntryPoint((request, response, authException) -> {
+                            //  HTTP 상태 코드 설정
                             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-                            response.getWriter().write("Unauthorized");
+                            // Content-Type을 JSON으로 설정
+                            response.setContentType("application/json;charset=UTF-8");
+                            // ErrorResponse 객체 생성
+                            ErrorResponse errorResponse = new ErrorResponse("U002", "유효하지 않은 토큰입니다.");
+                            // 객체를 JSON으로 직렬화하여 응답 본문에 작성
+                            new ObjectMapper().writeValue(response.getWriter(), errorResponse);
                         }))
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));

--- a/src/main/java/com/myce/auth/security/config/SecurityConfig.java
+++ b/src/main/java/com/myce/auth/security/config/SecurityConfig.java
@@ -37,59 +37,6 @@ import org.springframework.web.cors.CorsConfigurationSource;
 @EnableMethodSecurity(prePostEnabled = true)
 public class SecurityConfig {
 
-    public static final String[] POST_PERMIT_ALL = {
-            "/api/auth/**", "/api/payment/**", "/api/reservations/**",
-            "/api/reservers", "/api/payment/imp-uid",
-            "/api/reservations/pre-reservation",     // 사전 예매 생성
-    };
-
-    public static final String[] GET_PERMIT_ALL = {
-            "/api/ads", "/api/auth/**",
-            "/api/categories",
-            "/api/expos",                           // 박람회 카드 리스트 조회 (검색, 필터링)
-            "/api/expos/*/congestion",              // 박람회 실시간 혼잡도 조회
-            "/api/expos/*/tickets/reservations",    // 박람회 티켓 조회(예매용)
-            "/api/expos/*/basic",                   // 박람회 기본 정보 조회
-            "/api/expos/*/bookmark",                // 박람회 찜하기 상태 조회 (비회원도 접근)
-            "/api/expos/*/reviews",                 // 박람회 리뷰 정보 조회 (비회원 접근 가능)
-            "/api/expos/*/location",                // 박람회 위치 정보 조회
-            "/api/expos/*/booths/public",           // 박람회 부스 정보 조회 (공개용)
-            "/api/reservations/*/success",           // 예매 성공 정보 조회
-            "/api/reservations/*/pending",           // 예매 대기 정보 조회 (가상계좌)
-            "/api/reservations/payment-summary",     // 결제 요약 정보 조회
-            "/api/reservations/guest",               // 비회원 예매 조회 (이메일 + 예매번호)
-            "/api/reservations/guest", "/api/expo/fees/active", "/api/ad/fees/active",
-            "/api/reviews/expo/*", "/api/reviews/*/", "/api/reviews/best",
-            "/api/settings/refund-fee/public", "/api/ad-position/dropdown",
-            "/api/settings/ad-fee/active", "/api/settings/expo-fee/active"
-    };
-
-    public static final String[] PATCH_PERMIT_ALL = {
-            "/api/tickets/quantity",
-            "/api/reservations/**", "/api/platform/ads/*/status",
-            "/api/payment/*/status",
-            "/api/reservations/guestId",             // 비회원 ID 업데이트
-            "/api/reservations/*/confirm",           // 예매 상태 확인으로 변경
-    };
-
-    public static final String[] DELETE_PERMIT_ALL = {
-            "/api/reservations/**",
-            "/api/reservations/*",                   // 예매 삭제 (결제 실패/취소 시)
-    };
-
-    public static final String[] ECT_PERMIT_ALL = {
-            "/swagger-ui/**",
-            "/v3/api-docs/**",
-            "/swagger-resources/**",
-            "/webjars/**",
-            "/auth-docs/login",
-            "/actuator/**",               // All actuator endpoints for monitoring
-            "/ws/**", // WebSocket 엔드포인트 허용
-            "/images/**", // Static 이미지 리소스 허용
-            "/api/login/oauth2/code/**",      // OAuth2 callback endpoints
-            "/api/oauth2/**"              // Custom OAuth2 endpoints
-    };
-
     private final JwtUtil jwtUtil;
     private final TokenCookieProvider tokenCookieProvider;
     private final UserDetailsServiceImpl userDetailsService;
@@ -152,15 +99,15 @@ public class SecurityConfig {
                 .failureHandler(oAuth2LoginFailureHandler));
 
         http.authorizeHttpRequests(auth ->
-                auth.requestMatchers(HttpMethod.POST, POST_PERMIT_ALL)
+                auth.requestMatchers(HttpMethod.POST, SecurityEndpoints.POST_PERMIT_ALL)
                         .permitAll()
-                        .requestMatchers(HttpMethod.GET, GET_PERMIT_ALL)
+                        .requestMatchers(HttpMethod.GET, SecurityEndpoints.GET_PERMIT_ALL)
                         .permitAll()
-                        .requestMatchers(HttpMethod.PATCH, PATCH_PERMIT_ALL)
+                        .requestMatchers(HttpMethod.PATCH, SecurityEndpoints.PATCH_PERMIT_ALL)
                         .permitAll()
-                        .requestMatchers(HttpMethod.DELETE, DELETE_PERMIT_ALL)
+                        .requestMatchers(HttpMethod.DELETE, SecurityEndpoints.DELETE_PERMIT_ALL)
                         .permitAll()
-                        .requestMatchers(ECT_PERMIT_ALL).permitAll()
+                        .requestMatchers(SecurityEndpoints.ETC_PERMIT_ALL).permitAll()
                         .anyRequest()
                         .authenticated());
         return http.build();

--- a/src/main/java/com/myce/auth/security/config/SecurityEndPoints.java
+++ b/src/main/java/com/myce/auth/security/config/SecurityEndPoints.java
@@ -1,0 +1,77 @@
+package com.myce.auth.security.config;
+
+// Spring Security에서 인증 없이 접근 가능한 엔드포인트를 정의하는 설정 클래스
+public final class SecurityEndpoints {
+
+    private SecurityEndpoints() {
+        throw new UnsupportedOperationException("Utility class");
+    }
+
+    // ===== POST 요청 허용 엔드포인트 =====
+    public static final String[] POST_PERMIT_ALL = {
+            "/api/auth/**",
+            "/api/reservations/**",
+            "/api/reservers",
+            "/api/reservations/pre-reservation",
+            "/api/payment/**",
+            "/api/payment/imp-uid",
+    };
+
+    // ===== GET 요청 허용 엔드포인트 =====
+    public static final String[] GET_PERMIT_ALL = {
+            "/api/ads",
+            "/api/auth/**",
+            "/api/categories",
+            "/api/expos",
+            "/api/expos/*/congestion",
+            "/api/expos/*/tickets/reservations",
+            "/api/expos/*/basic",
+            "/api/expos/*/bookmark",
+            "/api/expos/*/reviews",
+            "/api/expos/*/location",
+            "/api/expos/*/booths/public",
+            "/api/reservations/*/success",
+            "/api/reservations/*/pending",
+            "/api/reservations/payment-summary",
+            "/api/reservations/guest",
+            "/api/reviews/expo/*",
+            "/api/reviews/*/",
+            "/api/reviews/best",
+            "/api/expo/fees/active",
+            "/api/ad/fees/active",
+            "/api/settings/refund-fee/public",
+            "/api/settings/ad-fee/active",
+            "/api/settings/expo-fee/active",
+            "/api/ad-position/dropdown",
+    };
+
+    // ===== PATCH 요청 허용 엔드포인트 =====
+    public static final String[] PATCH_PERMIT_ALL = {
+            "/api/tickets/quantity",
+            "/api/reservations/**",
+            "/api/reservations/guestId",
+            "/api/reservations/*/confirm",
+            "/api/payment/*/status",
+            "/api/platform/ads/*/status",
+    };
+
+    // ===== DELETE 요청 허용 엔드포인트 =====
+    public static final String[] DELETE_PERMIT_ALL = {
+            "/api/reservations/**",
+            "/api/reservations/*",
+    };
+
+    // ===== 기타 요청 허용 엔드포인트 (Swagger, Actuator, WebSocket 등) =====
+    public static final String[] ETC_PERMIT_ALL = {
+            "/swagger-ui/**",
+            "/v3/api-docs/**",
+            "/swagger-resources/**",
+            "/webjars/**",
+            "/auth-docs/login",
+            "/actuator/**",
+            "/ws/**",
+            "/images/**",
+            "/api/login/oauth2/code/**",
+            "/api/oauth2/**",
+    };
+}

--- a/src/main/java/com/myce/auth/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/myce/auth/security/filter/JwtAuthenticationFilter.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.myce.auth.dto.CustomUserDetails;
 import com.myce.auth.dto.type.LoginType;
 import com.myce.auth.repository.TokenBlackListRepository;
-import com.myce.auth.security.config.SecurityConfig;
+import com.myce.auth.security.config.SecurityEndpoints;
 import com.myce.auth.security.util.JwtUtil;
 import com.myce.auth.service.AdminCodeDetailService;
 import com.myce.auth.service.impl.UserDetailsServiceImpl;
@@ -135,19 +135,19 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             return false;
         }
 
-        if(isExist(SecurityConfig.ECT_PERMIT_ALL, path)) return true;
+        if(isExist(SecurityEndpoints.ETC_PERMIT_ALL, path)) return true;
 
         if(HttpMethod.GET.name().equals(method)) {
-            return isExist(SecurityConfig.GET_PERMIT_ALL, path);
+            return isExist(SecurityEndpoints.GET_PERMIT_ALL, path);
         }
         if(HttpMethod.POST.name().equals(method)) {
-            return isExist(SecurityConfig.POST_PERMIT_ALL, path);
+            return isExist(SecurityEndpoints.POST_PERMIT_ALL, path);
         }
         if(HttpMethod.PATCH.name().equals(method)) {
-            return isExist(SecurityConfig.PATCH_PERMIT_ALL, path);
+            return isExist(SecurityEndpoints.PATCH_PERMIT_ALL, path);
         }
         if(HttpMethod.DELETE.name().equals(method)) {
-            return isExist(SecurityConfig.DELETE_PERMIT_ALL, path);
+            return isExist(SecurityEndpoints.DELETE_PERMIT_ALL, path);
         }
 
         return false;


### PR DESCRIPTION
* PERMIT_ALL 이 부분을 따로 SecurityEndpoints.java로 나눠서 분리
* configure()이 너무 많은 책임을 지고 있어서 Filter들을 따로 처리 시도
  * FilterConfig로 분리 시도 -> 하면 순환 참조라는 에러 발생
  * SpringSecurity 내부 안에서 Bean을 따로 만들어서 시도 -> 서블릿 필터 체인에 자동으로 등록되면서 에러 발생
  => 기존 그대로 유지
* SpringSecurity 부분에서 문자열로 에러 처리를 하는 부분이 있어서 기존에 있는 CustomErrorCode 사용해서 동일하게 시도 
  * Spring Security 필터는 Dispatcher Servlet 전이기 때문에 GlobalExceptionHandler가 예외를 잡지 못하기에 따로 처리